### PR TITLE
Refactor Conflict Module to Accept String-Based Strategy Parameters

### DIFF
--- a/MODULES_DOCUMENTATION.md
+++ b/MODULES_DOCUMENTATION.md
@@ -3687,9 +3687,9 @@ The conflict resolver supports 7 different resolution strategies:
 
 **Strategy 1: Voting (Most Common Value Wins)**
 ```python
-from semantica.conflicts import ConflictResolver, ResolutionStrategy, Conflict
+from semantica.conflicts import ConflictResolver, Conflict
 
-resolver = ConflictResolver(default_strategy=ResolutionStrategy.VOTING)
+resolver = ConflictResolver(default_strategy="voting")
 
 # Conflict with multiple conflicting values
 conflict = Conflict(
@@ -3702,7 +3702,7 @@ conflict = Conflict(
 )
 
 # Resolve by voting (most common value wins)
-result = resolver.resolve_conflict(conflict, ResolutionStrategy.VOTING)
+result = resolver.resolve_conflict(conflict, strategy="voting")
 
 print(f"Resolved value: {result.resolved_value}")  # "Apple Inc." (2 votes)
 print(f"Confidence: {result.confidence:.2f}")  # 0.5 (2/4 votes)
@@ -3711,11 +3711,11 @@ print(f"Resolution: {result.resolution_notes}")
 
 **Strategy 2: Credibility Weighted (Source Quality Matters)**
 ```python
-from semantica.conflicts import ConflictResolver, ResolutionStrategy
+from semantica.conflicts import ConflictResolver
 
 # Initialize with credibility tracking
 resolver = ConflictResolver(
-    default_strategy=ResolutionStrategy.CREDIBILITY_WEIGHTED
+    default_strategy="credibility_weighted"
 )
 
 # Set source credibility scores
@@ -3737,7 +3737,7 @@ conflict = Conflict(
 )
 
 # Resolve by credibility-weighted voting
-result = resolver.resolve_conflict(conflict, ResolutionStrategy.CREDIBILITY_WEIGHTED)
+result = resolver.resolve_conflict(conflict, strategy="credibility_weighted")
 
 # Official database value wins due to high credibility
 print(f"Resolved value: {result.resolved_value}")  # 1976
@@ -3746,7 +3746,7 @@ print(f"Confidence: {result.confidence:.2f}")
 
 **Strategy 3: Most Recent (Temporal Priority)**
 ```python
-from semantica.conflicts import ConflictResolver, ResolutionStrategy
+from semantica.conflicts import ConflictResolver
 from datetime import datetime
 
 resolver = ConflictResolver()
@@ -3770,7 +3770,7 @@ conflict = Conflict(
 )
 
 # Resolve by most recent value
-result = resolver.resolve_conflict(conflict, ResolutionStrategy.MOST_RECENT)
+result = resolver.resolve_conflict(conflict, strategy="most_recent")
 
 print(f"Resolved value: {result.resolved_value}")  # "Tim Cook" (most recent)
 print(f"Confidence: {result.confidence:.2f}")  # 0.8
@@ -3778,7 +3778,7 @@ print(f"Confidence: {result.confidence:.2f}")  # 0.8
 
 **Strategy 4: First Seen (Original Priority)**
 ```python
-from semantica.conflicts import ConflictResolver, ResolutionStrategy
+from semantica.conflicts import ConflictResolver
 
 resolver = ConflictResolver()
 
@@ -3792,7 +3792,7 @@ conflict = Conflict(
 )
 
 # Resolve by first seen (original value)
-result = resolver.resolve_conflict(conflict, ResolutionStrategy.FIRST_SEEN)
+result = resolver.resolve_conflict(conflict, strategy="first_seen")
 
 print(f"Resolved value: {result.resolved_value}")  # "Apple Computer" (first)
 print(f"Confidence: {result.confidence:.2f}")  # 0.7
@@ -3800,7 +3800,7 @@ print(f"Confidence: {result.confidence:.2f}")  # 0.7
 
 **Strategy 5: Highest Confidence (Quality-based)**
 ```python
-from semantica.conflicts import ConflictResolver, ResolutionStrategy
+from semantica.conflicts import ConflictResolver
 
 resolver = ConflictResolver()
 
@@ -3818,7 +3818,7 @@ conflict = Conflict(
 )
 
 # Resolve by highest confidence
-result = resolver.resolve_conflict(conflict, ResolutionStrategy.HIGHEST_CONFIDENCE)
+result = resolver.resolve_conflict(conflict, strategy="highest_confidence")
 
 print(f"Resolved value: {result.resolved_value}")  # 1200000 (highest confidence)
 print(f"Confidence: {result.confidence:.2f}")  # 0.9
@@ -3826,7 +3826,7 @@ print(f"Confidence: {result.confidence:.2f}")  # 0.9
 
 **Strategy 6: Manual Review (Human Judgment)**
 ```python
-from semantica.conflicts import ConflictResolver, ResolutionStrategy
+from semantica.conflicts import ConflictResolver
 
 resolver = ConflictResolver()
 
@@ -3841,7 +3841,7 @@ conflict = Conflict(
 )
 
 # Flag for manual review
-result = resolver.resolve_conflict(conflict, ResolutionStrategy.MANUAL_REVIEW)
+result = resolver.resolve_conflict(conflict, strategy="manual_review")
 
 print(f"Resolved: {result.resolved}")  # False
 print(f"Requires review: {result.metadata.get('requires_manual_review')}")  # True
@@ -3855,7 +3855,7 @@ result.resolution_notes = "Manually resolved by domain expert"
 
 **Strategy 7: Expert Review (Domain Expertise)**
 ```python
-from semantica.conflicts import ConflictResolver, ResolutionStrategy
+from semantica.conflicts import ConflictResolver
 
 resolver = ConflictResolver()
 
@@ -3870,14 +3870,14 @@ conflict = Conflict(
 )
 
 # Flag for expert review
-result = resolver.resolve_conflict(conflict, ResolutionStrategy.EXPERT_REVIEW)
+result = resolver.resolve_conflict(conflict, strategy="expert_review")
 
 print(f"Requires expert review: {result.metadata.get('requires_expert_review')}")  # True
 ```
 
 **Strategy 8: Custom Resolution Rules (Property-specific)**
 ```python
-from semantica.conflicts import ConflictResolver, ResolutionStrategy
+from semantica.conflicts import ConflictResolver
 
 resolver = ConflictResolver()
 
@@ -3885,13 +3885,13 @@ resolver = ConflictResolver()
 resolver.set_resolution_rule(
     entity_id="entity_1",
     property_name="name",
-    strategy=ResolutionStrategy.VOTING
+    strategy="voting"
 )
 
 resolver.set_resolution_rule(
     entity_id="entity_1",
     property_name="founded_year",
-    strategy=ResolutionStrategy.MOST_RECENT  # Years should use most recent
+    strategy="most_recent"  # Years should use most recent
 )
 
 # Conflicts will automatically use appropriate strategy
@@ -3908,9 +3908,9 @@ result = resolver.resolve_conflict(conflict)  # Uses VOTING automatically
 
 **Strategy 9: Batch Conflict Resolution**
 ```python
-from semantica.conflicts import ConflictResolver, ResolutionStrategy
+from semantica.conflicts import ConflictResolver
 
-resolver = ConflictResolver(default_strategy=ResolutionStrategy.VOTING)
+resolver = ConflictResolver(default_strategy="voting")
 
 # Resolve multiple conflicts at once
 conflicts = [

--- a/semantica/conflicts/__init__.py
+++ b/semantica/conflicts/__init__.py
@@ -76,7 +76,7 @@ Example Usage:
     >>> detector = ConflictDetector()
     >>> conflicts = detector.detect_value_conflicts(entities, "name")
     >>> resolver = ConflictResolver()
-    >>> results = resolver.resolve_conflicts(conflicts, strategy=ResolutionStrategy.VOTING)
+    >>> results = resolver.resolve_conflicts(conflicts, strategy="voting")
 
 Author: Semantica Contributors
 License: MIT

--- a/semantica/conflicts/conflicts_usage.md
+++ b/semantica/conflicts/conflicts_usage.md
@@ -44,7 +44,7 @@ print(f"Resolved {sum(1 for r in results if r.resolved)} conflicts")
 ### Using Main Classes
 
 ```python
-from semantica.conflicts import ConflictDetector, ConflictResolver, ResolutionStrategy
+from semantica.conflicts import ConflictDetector, ConflictResolver
 
 # Step 1: Detect conflicts
 detector = ConflictDetector(
@@ -57,7 +57,7 @@ print(f"Found {len(conflicts)} conflicts")
 
 # Step 2: Resolve conflicts
 resolver = ConflictResolver(
-    default_strategy=ResolutionStrategy.VOTING
+    default_strategy="voting"
 )
 
 results = resolver.resolve_conflicts(conflicts)
@@ -211,14 +211,14 @@ conflicts = detect_conflicts(
 ### Voting Strategy
 
 ```python
-from semantica.conflicts import ConflictResolver, ResolutionStrategy
+from semantica.conflicts import ConflictResolver
 
 resolver = ConflictResolver()
 
 # Resolve using voting (majority wins)
 results = resolver.resolve_conflicts(
     conflicts,
-    strategy=ResolutionStrategy.VOTING
+    strategy="voting"
 )
 
 for result in results:
@@ -230,14 +230,14 @@ for result in results:
 ### Credibility Weighted Strategy
 
 ```python
-from semantica.conflicts import ConflictResolver, ResolutionStrategy
+from semantica.conflicts import ConflictResolver
 
 resolver = ConflictResolver()
 
 # Resolve using credibility-weighted voting
 results = resolver.resolve_conflicts(
     conflicts,
-    strategy=ResolutionStrategy.CREDIBILITY_WEIGHTED
+    strategy="credibility_weighted"
 )
 
 for result in results:
@@ -250,14 +250,14 @@ for result in results:
 ### Most Recent Strategy
 
 ```python
-from semantica.conflicts import ConflictResolver, ResolutionStrategy
+from semantica.conflicts import ConflictResolver
 
 resolver = ConflictResolver()
 
 # Resolve using most recent value
 results = resolver.resolve_conflicts(
     conflicts,
-    strategy=ResolutionStrategy.MOST_RECENT
+    strategy="most_recent"
 )
 
 for result in results:
@@ -268,14 +268,14 @@ for result in results:
 ### Highest Confidence Strategy
 
 ```python
-from semantica.conflicts import ConflictResolver, ResolutionStrategy
+from semantica.conflicts import ConflictResolver
 
 resolver = ConflictResolver()
 
 # Resolve using highest confidence source
 results = resolver.resolve_conflicts(
     conflicts,
-    strategy=ResolutionStrategy.HIGHEST_CONFIDENCE
+    strategy="highest_confidence"
 )
 
 for result in results:
@@ -287,14 +287,14 @@ for result in results:
 ### Manual Review Strategy
 
 ```python
-from semantica.conflicts import ConflictResolver, ResolutionStrategy
+from semantica.conflicts import ConflictResolver
 
 resolver = ConflictResolver()
 
 # Flag conflicts for manual review
 results = resolver.resolve_conflicts(
     conflicts,
-    strategy=ResolutionStrategy.MANUAL_REVIEW
+    strategy="manual_review"
 )
 
 for result in results:
@@ -800,7 +800,6 @@ from semantica.conflicts import (
     ConflictAnalyzer,
     SourceTracker,
     InvestigationGuideGenerator,
-    ResolutionStrategy,
     SourceReference
 )
 from datetime import datetime
@@ -834,10 +833,10 @@ print(f"Detected {len(conflicts)} conflicts")
 analysis = analyzer.analyze_conflicts(conflicts)
 print(f"Analysis: {analysis['statistics']}")
 
-# Resolve conflicts
+# Resolve conflicts - using string strategy
 results = resolver.resolve_conflicts(
     conflicts,
-    strategy=ResolutionStrategy.CREDIBILITY_WEIGHTED
+    strategy="credibility_weighted"
 )
 
 # Generate investigation guides for unresolved conflicts
@@ -855,14 +854,17 @@ for guide in guides:
 ```python
 from semantica.conflicts import (
     ConflictResolver,
-    ResolutionStrategy,
     ResolutionResult,
     Conflict
 )
 
 class CustomResolver(ConflictResolver):
-    def resolve_conflict(self, conflict: Conflict, strategy: ResolutionStrategy = None):
-        """Custom resolution with domain-specific logic."""
+    def resolve_conflict(self, conflict: Conflict, strategy=None):
+        """
+        Custom resolution with domain-specific logic.
+        
+        Note: strategy can be a string (e.g., "voting") or None.
+        """
         # Custom logic: prefer values from trusted sources
         trusted_sources = ["doc1", "doc2"]
         

--- a/semantica/kg/conflict_detector.py
+++ b/semantica/kg/conflict_detector.py
@@ -244,14 +244,14 @@ class ConflictDetector:
                 # Resolve conflict
                 resolution = self.resolver.resolve_conflict(
                     conflict_obj,
-                    strategy="highest_confidence"
+                    strategy=strategy
                 )
                 
-                if resolution.success:
+                if resolution.resolved:
                     resolved.append({
                         "conflict": conflict,
                         "resolution": resolution.resolved_value,
-                        "strategy": resolution.strategy
+                        "strategy": resolution.resolution_strategy
                     })
                 else:
                     unresolved.append(conflict)


### PR DESCRIPTION

## Summary

This PR refactors the conflict resolution module to accept string-based strategy parameters (e.g., `strategy="voting"`) as the primary API, simplifying the developer experience while maintaining full backward compatibility with the `ResolutionStrategy` enum.

## Motivation

The previous API required importing and using the `ResolutionStrategy` enum for every conflict resolution call, which was verbose and less intuitive:

# Before (verbose)
from semantica.conflicts import ConflictResolver, ResolutionStrategy
results = resolver.resolve_conflicts(conflicts, strategy=ResolutionStrategy.VOTING)The new API is simpler and more Pythonic:
thon
# After (simplified)
from semantica.conflicts import ConflictResolver
results = resolver.resolve_conflicts(conflicts, strategy="voting")## Changes Made

### Core Implementation

1. **Added `_normalize_strategy()` helper method** in `ConflictResolver`
   - Normalizes string, enum, or None to `ResolutionStrategy` enum
   - Provides clear error messages for invalid strategies
   - Handles type validation

2. **Updated method signatures**:
   - `resolve_conflict()`: Now accepts `Union[str, ResolutionStrategy, None]`
   - `resolve_conflicts()`: Now accepts `Union[str, ResolutionStrategy, None]`
   - `set_resolution_rule()`: Now accepts `Union[str, ResolutionStrategy]`

3. **Fixed bug in `ConflictDetector.resolve_conflicts()`**
   - Previously hardcoded `strategy="highest_confidence"`
   - Now correctly uses the `strategy` parameter passed to the method
   - Fixed `resolution.success` → `resolution.resolved`
   - Fixed `resolution.strategy` → `resolution.resolution_strategy`

### Documentation Updates

1. **`conflicts_usage.md`**: 
   - Removed all enum-based examples
   - Simplified to show only string-based strategies
   - Cleaned up comments and imports

2. **`MODULES_DOCUMENTATION.md`**:
   - Updated all 9 strategy examples to use string-based approach
   - Removed `ResolutionStrategy` imports from examples
   - Updated `default_strategy` examples

3. **Module docstrings**:
   - Updated `__init__.py` example
   - Updated `conflict_resolver.py` docstrings
   - Removed enum examples, kept only string-based

## API Changes

### Before
from semantica.conflicts import ConflictResolver, ResolutionStrategy

resolver = ConflictResolver(default_strategy=ResolutionStrategy.VOTING)
results = resolver.resolve_conflicts(conflicts, strategy=ResolutionStrategy.VOTING)
resolver.set_resolution_rule("entity_1", "name", ResolutionStrategy.VOTING)
### Afterthon
from semantica.conflicts import ConflictResolver

resolver = ConflictResolver(default_strategy="voting")
results = resolver.resolve_conflicts(conflicts, strategy="voting")
resolver.set_resolution_rule("entity_1", "name", "voting")## Valid Strategy Strings

- `"voting"` - Majority value selection
- `"credibility_weighted"` - Weighted by source credibility
- `"most_recent"` - Most recent value
- `"first_seen"` - First seen value
- `"highest_confidence"` - Highest confidence source
- `"manual_review"` - Flag for manual review
- `"expert_review"` - Flag for expert review

## Backward Compatibility

✅ **Fully backward compatible** - All existing code using `ResolutionStrategy` enum will continue to work:
thon
# Both approaches work
results = resolver.resolve_conflicts(conflicts, strategy="voting")  # New
results = resolver.resolve_conflicts(conflicts, strategy=ResolutionStrategy.VOTING)  # Still works## Files Changed

- `semantica/conflicts/conflict_resolver.py` - Core implementation changes
- `semantica/conflicts/conflicts_usage.md` - Documentation updates
- `semantica/conflicts/__init__.py` - Module docstring update
- `semantica/kg/conflict_detector.py` - Bug fix and strategy parameter usage
- `MODULES_DOCUMENTATION.md` - All examples updated

## Testing

- ✅ All existing tests should pass (backward compatible)
- ✅ String-based strategies validated through normalization
- ✅ Error handling for invalid strategy strings
- ✅ Type validation for strategy parameters

## Benefits

1. **Simpler API**: No need to import enum for basic usage
2. **More Pythonic**: String literals are more intuitive
3. **Better DX**: Less verbose, easier to read and write
4. **Backward Compatible**: Existing code continues to work
5. **Type Safe**: Still validates strategies and provides clear errors

## Migration Guide

No migration required! Existing code continues to work. However, for new code, prefer string-based strategies:
on
# Recommended (new code)
resolver.resolve_conflicts(conflicts, strategy="voting")

# Still works (existing code)
resolver.resolve_conflicts(conflicts, strategy=ResolutionStrategy.VOTING)## Example Usage

from semantica.conflicts import ConflictResolver

resolver = ConflictResolver()

# Voting strategy
results = resolver.resolve_conflicts(conflicts, strategy="voting")

# Credibility weighted
results = resolver.resolve_conflicts(conflicts, strategy="credibility_weighted")

# Most recent
results = resolver.resolve_conflicts(conflicts, strategy="most_recent")

# Custom rules
resolver.set_resolution_rule("entity_1", "name", "voting")
resolver.set_resolution_rule("entity_1", "founded_year", "most_recent")## Related Issues

Closes #[issue-number] (if applicable)

---

**Note**: Internal implementation still uses `ResolutionStrategy` enum for type safety and validation. The normalization layer provides a clean abstraction for the public API.