### PR TITLE
Fix export_yaml schema export bug and update docs

### DIFF
--- a/docs/reference/export.md
+++ b/docs/reference/export.md
@@ -394,7 +394,7 @@ Export ontology schemas to YAML format.
 
 | Method | Description | Algorithm |
 |--------|-------------|-----------|
-| `export(schema, filename)` | Export schema | YAML schema serialization |
+| `export_ontology_schema(ontology, filename)` | Export ontology schema | YAML schema serialization |
 
 **Example:**
 
@@ -402,7 +402,7 @@ Export ontology schemas to YAML format.
 from semantica.export import YAMLSchemaExporter
 
 exporter = YAMLSchemaExporter()
-exporter.export(schema, "schema.yaml")
+exporter.export_ontology_schema(schema, "schema.yaml")
 ```
 
 ---

--- a/semantica/export/export_usage.md
+++ b/semantica/export/export_usage.md
@@ -280,7 +280,7 @@ from semantica.export import YAMLSchemaExporter
 exporter = YAMLSchemaExporter()
 
 # Export schema
-exporter.export(schema, "schema.yaml")
+exporter.export_ontology_schema(schema, "schema.yaml")
 ```
 
 ### Using YAML Export Methods

--- a/semantica/export/methods.py
+++ b/semantica/export/methods.py
@@ -201,7 +201,7 @@ def export_rdf(
     """
     # Check for custom method in registry
     custom_method = method_registry.get("rdf", method)
-    if custom_method:
+    if custom_method and custom_method is not export_rdf:
         try:
             return custom_method(data, file_path, format=format, **kwargs)
         except Exception as e:
@@ -250,7 +250,7 @@ def export_json(
     """
     # Check for custom method in registry
     custom_method = method_registry.get("json", method)
-    if custom_method:
+    if custom_method and custom_method is not export_json:
         try:
             return custom_method(data, file_path, format=format, **kwargs)
         except Exception as e:
@@ -296,7 +296,7 @@ def export_csv(
     """
     # Check for custom method in registry
     custom_method = method_registry.get("csv", method)
-    if custom_method:
+    if custom_method and custom_method is not export_csv:
         try:
             return custom_method(data, file_path, **kwargs)
         except Exception as e:
@@ -347,7 +347,7 @@ def export_graph(
     """
     # Check for custom method in registry
     custom_method = method_registry.get("graph", method)
-    if custom_method:
+    if custom_method and custom_method is not export_graph:
         try:
             return custom_method(graph_data, file_path, format=format, **kwargs)
         except Exception as e:
@@ -395,7 +395,7 @@ def export_yaml(
     """
     # Check for custom method in registry
     custom_method = method_registry.get("yaml", method)
-    if custom_method:
+    if custom_method and custom_method is not export_yaml:
         try:
             return custom_method(data, file_path, **kwargs)
         except Exception as e:
@@ -413,7 +413,9 @@ def export_yaml(
             exporter.export(data, file_path, **kwargs)
         elif method == "schema":
             exporter = YAMLSchemaExporter(**config)
-            exporter.export(data, file_path, **kwargs)
+            yaml_content = exporter.export_ontology_schema(data, **kwargs)
+            with open(file_path, "w", encoding="utf-8") as f:
+                f.write(yaml_content)
         else:
             raise ProcessingError(f"Unknown YAML export method: {method}")
 
@@ -450,7 +452,7 @@ def export_owl(
     """
     # Check for custom method in registry
     custom_method = method_registry.get("owl", method)
-    if custom_method:
+    if custom_method and custom_method is not export_owl:
         try:
             return custom_method(ontology, file_path, format=format, **kwargs)
         except Exception as e:
@@ -502,7 +504,7 @@ def export_vector(
     """
     # Check for custom method in registry
     custom_method = method_registry.get("vector", method)
-    if custom_method:
+    if custom_method and custom_method is not export_vector:
         try:
             return custom_method(vectors, file_path, format=format, **kwargs)
         except Exception as e:
@@ -550,7 +552,7 @@ def export_lpg(
     """
     # Check for custom method in registry
     custom_method = method_registry.get("lpg", method)
-    if custom_method:
+    if custom_method and custom_method is not export_lpg:
         try:
             return custom_method(knowledge_graph, file_path, **kwargs)
         except Exception as e:
@@ -601,7 +603,7 @@ def generate_report(
     """
     # Check for custom method in registry
     custom_method = method_registry.get("report", method)
-    if custom_method:
+    if custom_method and custom_method is not generate_report:
         try:
             return custom_method(data, file_path, format=format, **kwargs)
         except Exception as e:

--- a/tests/test_export_methods_wrapper.py
+++ b/tests/test_export_methods_wrapper.py
@@ -1,0 +1,37 @@
+import sys
+import os
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+import unittest
+import tempfile
+import shutil
+import yaml
+from pathlib import Path
+from semantica.export.methods import export_yaml
+
+class TestExportMethodsWrapper(unittest.TestCase):
+    def setUp(self):
+        self.test_dir = tempfile.mkdtemp()
+        self.schema = {
+            "uri": "http://example.org/schema",
+            "classes": [{"id": "Person", "label": "Person"}],
+            "properties": [{"id": "knows", "label": "Knows"}]
+        }
+
+    def tearDown(self):
+        shutil.rmtree(self.test_dir)
+
+    def test_export_yaml_schema(self):
+        output_path = Path(self.test_dir) / "schema.yaml"
+        
+        # This should call export_ontology_schema internally
+        export_yaml(self.schema, str(output_path), method="schema")
+        
+        self.assertTrue(output_path.exists())
+        with open(output_path, 'r') as f:
+            data = yaml.safe_load(f)
+            self.assertEqual(data['ontology']['uri'], "http://example.org/schema")
+            self.assertEqual(len(data['classes']), 1)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
This PR significantly hardens the `semantica.export` module by adding comprehensive unit tests, fixing critical bugs in export wrappers and logic, and updating documentation and cookbooks to match current API signatures.

## Key Changes

### 1. Bug Fixes & Logic Improvements
- **`semantica/export/methods.py`**: 
  - Fixed `export_yaml(method="schema")` to correctly call `export_ontology_schema` and handle file writing (previously failed as the underlying method returns a string).
  - Added safeguards to all convenience functions (`export_rdf`, `export_json`, etc.) to prevent infinite recursion if the registry returns the wrapper function itself.
- **`semantica/kg/graph_builder.py`**: Fixed a critical bug where `ConflictDetector` was receiving the entire graph dictionary instead of the entity list.
- **`semantica/export/rdf_exporter.py`**: Fixed `export_to_rdf` to correctly return serialized data for all formats.

### 2. Comprehensive Testing (`tests/`)
- **`tests/test_export_module.py`**: A full suite of unit tests covering all 11 export classes (`JSON`, `CSV`, `RDF`, `GraphML`, `YAML`, `OWL`, `Vector`, `LPG`, etc.).
- **`tests/test_export_methods_wrapper.py`**: Added specific tests for convenience wrapper functions in `methods.py`, verifying the fix for schema export.
- **`tests/test_notebook_15_export.py`** & **`tests/test_notebooks_simulation.py`**: Simulation tests that replicate cookbook logic to ensure end-to-end functionality.

### 3. Documentation & Notebook Updates
- **`docs/reference/export.md`** & **`semantica/export/export_usage.md`**: Updated to correctly document `YAMLSchemaExporter.export_ontology_schema` instead of the deprecated `export` method.
- **Cookbooks** (`15_Export.ipynb`, `05_Multi_Format_Export.ipynb`):
  - Updated `GraphBuilder.build()` calls to pass combined lists (fixing API mismatch).
  - Corrected `YAMLSchemaExporter` usage.
  - Fixed `VectorExporter` data preparation.
  - Adjusted `CSVExporter` paths.

## Verification
All tests passed successfully:
```bash
$ pytest tests/test_export_module.py tests/test_notebooks_simulation.py tests/test_notebook_15_export.py tests/test_export_methods_wrapper.py
...
13 passed in 3.82s
```
