### PR TITLE
Refactor: Remove QA Components & Enforce Submodule Imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ print(f" Ingested {len(sources)} sources")
 > **Entity & Relation Extraction** • NER, Relationships, Events, Triplets with LLM Enhancement
 
 ```python
-from semantica import Semantica
+from semantica.core import Semantica
 
 text = "Apple Inc., founded by Steve Jobs in 1976, acquired Beats Electronics for $3 billion."
 
@@ -304,7 +304,7 @@ print(f"Entities: {len(results.entities)}, Relationships: {len(results.relations
 > **Production-Ready KGs** • Entity Resolution • Temporal Support • Graph Analytics
 
 ```python
-from semantica import Semantica
+from semantica.core import Semantica
 from semantica.kg import GraphAnalyzer
 
 documents = ["doc1.txt", "doc2.txt", "doc3.txt"]
@@ -328,15 +328,12 @@ print(f"Nodes: {kg.node_count}, Answer: {result.answer}")
 > **6-Stage LLM Pipeline** • Automatic OWL Generation • HermiT/Pellet Validation
 
 ```python
-from semantica.ontology import OntologyGenerator, OntologyValidator
+from semantica.ontology import OntologyGenerator
 
 generator = OntologyGenerator(llm_provider="openai", model="gpt-4")
 ontology = generator.generate_from_documents(sources=["domain_docs/"])
 
-validator = OntologyValidator(reasoner="hermit")
-validation = validator.validate(ontology)
-
-print(f"Classes: {len(ontology.classes)}, Valid: {validation.is_consistent}")
+print(f"Classes: {len(ontology.classes)}")
 ```
 
 [**Cookbook: Ontology**](https://github.com/Hawksight-AI/semantica/tree/main/cookbook/introduction/14_Ontology.ipynb)
@@ -429,7 +426,7 @@ exporter.export("graph.ttl", format="turtle")
 > **For comprehensive examples, see the [**Cookbook**](https://github.com/Hawksight-AI/semantica/tree/main/cookbook) with 50+ interactive notebooks!**
 
 ```python
-from semantica import Semantica
+from semantica.core import Semantica
 
 # Initialize and build knowledge graph
 core = Semantica(ner_model="transformer", relation_strategy="hybrid")

--- a/docs/CodeExamples.md
+++ b/docs/CodeExamples.md
@@ -26,7 +26,7 @@ pip install -e ".[dev]"
 ### ⚡ 30-Second Demo: From Any Format to Knowledge
 
 ```python
-from semantica import Semantica
+from semantica.core import Semantica
 
 # Initialize with preferred providers
 core = Semantica(

--- a/docs/LIBS_README.md
+++ b/docs/LIBS_README.md
@@ -84,7 +84,7 @@ pip install -e ".[dev]"
 
 **Pattern 1: Using Semantica class (Recommended)**
 ```python
-from semantica import Semantica
+from semantica.core import Semantica
 
 # Initialize and build knowledge base
 semantica = Semantica()
@@ -105,7 +105,7 @@ ingestor = FileIngestor()
 
 ### 1. Basic Document Processing
 ```python
-from semantica import Semantica
+from semantica.core import Semantica
 
 # Build knowledge base from documents (auto-initializes)
 semantica = Semantica()
@@ -138,7 +138,7 @@ kg_viz.visualize_network(knowledge_graph, output="html", file_path="knowledge_gr
 
 ### 2. Web Content Processing
 ```python
-import semantica
+from semantica.core import Semantica
 from semantica.ingest import WebIngestor
 
 # Ingest web content
@@ -166,7 +166,7 @@ result = semantica_instance.build_knowledge_base(sources)
 
 ### 3. Knowledge Graph Analytics
 ```python
-from semantica import Semantica
+from semantica.core import Semantica
 from semantica.kg import GraphBuilder, GraphAnalyzer, CentralityCalculator, CommunityDetector
 
 # Build knowledge graph using Semantica class
@@ -565,7 +565,6 @@ for event in events:
 
 **Option 1: Using module-level build function (Recommended)**
 ```python
-import semantica
 import numpy as np
 
 # Generate embeddings using EmbeddingGenerator
@@ -770,7 +769,7 @@ for pattern in patterns:
 
 #### Custom Pipeline
 ```python
-from semantica import PipelineBuilder
+from semantica.pipeline import PipelineBuilder
 from semantica.pipeline import ExecutionEngine
 
 # Build custom pipeline
@@ -861,7 +860,6 @@ csv_exporter.export_knowledge_graph(graph, "knowledge_graph.csv")
 ### 8. Complete End-to-End Example
 
 ```python
-import semantica
 from semantica.ingest import FileIngestor
 from semantica.semantic_extract import NERExtractor, RelationExtractor
 from semantica.embeddings import EmbeddingGenerator
@@ -1199,7 +1197,7 @@ temporal_viz.visualize_metrics_evolution(metrics_history, timestamps,
 #### Quick Visualization Example
 
 ```python
-from semantica import Semantica
+from semantica.core import Semantica
 from semantica.visualization import KGVisualizer, EmbeddingVisualizer
 import numpy as np
 
@@ -1231,8 +1229,7 @@ if "embeddings" in result:
 
 ### Basic Configuration
 ```python
-import semantica
-from semantica import Config
+from semantica.core import Semantica, Config
 
 # Create configuration
 config = Config({
@@ -1257,7 +1254,7 @@ result = semantica_instance.build_knowledge_base(["document.pdf"])
 
 ### Advanced Configuration
 ```python
-from semantica import Semantica, Config
+from semantica.core import Semantica, Config
 
 # Advanced configuration
 config = Config({

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -65,7 +65,7 @@ graph LR
     Build a knowledge graph from a document with just a few lines:
     
     ```python
-    from semantica import Semantica
+    from semantica.core import Semantica
 
     # Initialize Semantica with default settings
     semantica = Semantica()
@@ -127,7 +127,7 @@ graph LR
     Merge knowledge from multiple data sources:
     
     ```python
-    from semantica import Semantica
+    from semantica.core import Semantica
 
     semantica = Semantica()
 
@@ -1220,7 +1220,7 @@ flowchart TD
     Build a knowledge base and query with GraphRAG:
     
     ```python
-    from semantica import Semantica
+    from semantica.core import Semantica
     from semantica.vector_store import VectorStore, store_vectors, search_vectors
     from semantica.semantic_extract import NamedEntityRecognizer
     from semantica.embeddings import embed_text
@@ -1433,7 +1433,7 @@ flowchart TD
     Integrate with LLM providers for answer generation:
     
     ```python
-    from semantica import Semantica
+    from semantica.core import Semantica
     from semantica.semantic_extract import create_provider, OpenAIProvider
     from semantica.context import ContextRetriever
     from semantica.vector_store import VectorStore
@@ -2680,7 +2680,7 @@ import os
 api_key = os.getenv("OPENAI_API_KEY")
 
 # Good: Use config files
-from semantica import Config
+from semantica.core import Config
 config = Config.from_file("config.yaml")
 semantica = Semantica(config=config)
 ```
@@ -2705,7 +2705,7 @@ semantica = Semantica(config=config)
 - Gracefully handle API failures
 
 ```python
-from semantica import Semantica
+from semantica.core import Semantica
 import logging
 
 logging.basicConfig(level=logging.INFO)

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -48,7 +48,7 @@ Real-world examples and use cases for Semantica.
 Build a knowledge graph from a single document.
 
 ```python
-from semantica import Semantica
+from semantica.core import Semantica
 
 semantica = Semantica()
 
@@ -71,7 +71,7 @@ print(f"Relationships: {len(kg['relationships'])}")
 Extract entities from text using Named Entity Recognition.
 
 ```python
-from semantica import Semantica
+from semantica.core import Semantica
 
 semantica = Semantica()
 text = "Apple Inc. is a technology company founded by Steve Jobs."
@@ -88,7 +88,7 @@ for entity in entities["entities"]:
 Combine data from multiple sources into a unified knowledge graph.
 
 ```python
-from semantica import Semantica
+from semantica.core import Semantica
 
 semantica = Semantica()
 sources = [
@@ -111,7 +111,7 @@ print(f"Unified graph: {len(result['knowledge_graph']['entities'])} entities")
 Resolve conflicts in data from multiple sources.
 
 ```python
-from semantica import Semantica
+from semantica.core import Semantica
 from semantica.conflicts import ConflictResolver
 
 semantica = Semantica()
@@ -130,7 +130,7 @@ resolved = resolver.resolve_conflicts(conflicts)
 Use custom configuration for specific use cases.
 
 ```python
-from semantica import Semantica, Config
+from semantica.core import Semantica, Config
 
 config = Config(
     embeddings=True,
@@ -150,7 +150,7 @@ result = semantica.build_knowledge_base(["document.pdf"])
 Build knowledge graph incrementally.
 
 ```python
-from semantica import Semantica
+from semantica.core import Semantica
 
 semantica = Semantica()
 
@@ -236,7 +236,7 @@ Process data streams in real-time.
 
 ```python
 from semantica.ingest import StreamIngestor
-from semantica import Semantica
+from semantica.core import Semantica
 
 semantica = Semantica()
 stream_ingestor = StreamIngestor(stream_uri="kafka://localhost:9092/topic")
@@ -257,7 +257,7 @@ for batch in stream_ingestor.stream(batch_size=100):
 Process large datasets efficiently with batching.
 
 ```python
-from semantica import Semantica
+from semantica.core import Semantica
 
 semantica = Semantica()
 sources = [f"data/doc_{i}.pdf" for i in range(1000)]

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -70,7 +70,7 @@ A structured representation where entities (nodes) are connected by relationship
 ### How do I build a knowledge graph?
 
 ```python
-from semantica import Semantica
+from semantica.core import Semantica
 
 semantica = Semantica()
 result = semantica.build_knowledge_base(["document.pdf"])
@@ -102,7 +102,7 @@ Yes! Semantica supports PDF, DOCX, HTML, JSON, CSV, and many other formats.
 ### How do I extract entities from text?
 
 ```python
-from semantica import Semantica
+from semantica.core import Semantica
 
 semantica = Semantica()
 result = semantica.semantic_extract.extract_entities("Your text")

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -72,7 +72,7 @@ Before installing Semantica, ensure you have:
 
 ```python
 import semantica
-print(semantica.version)
+print(semantica.__version__)
 ```
 
 ---

--- a/docs/index.md
+++ b/docs/index.md
@@ -417,7 +417,7 @@ Power GraphRAG applications with:
 ## 🚦 Quick Example
 
 ```python
-from semantica import Semantica
+from semantica.core import Semantica
 
 # Initialize
 core = Semantica()

--- a/docs/learning-more.md
+++ b/docs/learning-more.md
@@ -99,7 +99,7 @@ Additional resources, tutorials, and advanced learning materials for Semantica.
 ### Common Operations
 
 ```python
-from semantica import Semantica
+from semantica.core import Semantica
 semantica = Semantica()
 
 # Build Knowledge Graph

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -1007,7 +1007,7 @@ result = pipeline.execute(sources=["data/"], parallel=True)
 ### Pattern 1: Complete Knowledge Graph Pipeline
 
 ```python
-from semantica import Semantica
+from semantica.core import Semantica
 
 semantica = Semantica()
 result = semantica.build_knowledge_base(
@@ -1053,7 +1053,7 @@ deduplicated = [op.merged_entity for op in merge_operations]
 ### Pattern 3: GraphRAG with Hybrid Search
 
 ```python
-from semantica import Semantica
+from semantica.core import Semantica
 from semantica.vector_store import VectorStore, HybridSearch
 from semantica.context import AgentMemory
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -37,7 +37,7 @@ See the [Installation Guide](installation.md) for detailed instructions.
 Let's build a knowledge graph from a document:
 
 ```python
-from semantica import Semantica
+from semantica.core import Semantica
 
 # Initialize Semantica
 semantica = Semantica()
@@ -117,7 +117,7 @@ Extracted Relationships:
 Combine data from multiple sources:
 
 ```python
-from semantica import Semantica
+from semantica.core import Semantica
 
 semantica = Semantica()
 
@@ -149,7 +149,7 @@ print(f"Sources processed: {len(result['metadata']['sources'])}")
 Visualize the knowledge graph you created:
 
 ```python
-from semantica import Semantica
+from semantica.core import Semantica
 from semantica.visualization import KGVisualizer
 
 semantica = Semantica()
@@ -171,7 +171,7 @@ Open `graph.html` in your browser to see an interactive visualization.
 Export your knowledge graph in various formats:
 
 ```python
-from semantica import Semantica
+from semantica.core import Semantica
 from semantica.export import export_rdf, export_json, export_csv, export_owl
 
 semantica = Semantica()
@@ -194,7 +194,7 @@ print("Exported knowledge graph to multiple formats")
 ### Pattern 1: Process Text Directly
 
 ```python
-from semantica import Semantica
+from semantica.core import Semantica
 
 semantica = Semantica()
 
@@ -205,7 +205,7 @@ result = semantica.process_document(text)
 ### Pattern 2: Custom Configuration
 
 ```python
-from semantica import Semantica, Config
+from semantica.core import Semantica, Config
 
 # Create custom configuration
 config = Config(
@@ -222,7 +222,7 @@ result = semantica.build_knowledge_base(["document.pdf"])
 ### Pattern 3: Incremental Building
 
 ```python
-from semantica import Semantica
+from semantica.core import Semantica
 
 semantica = Semantica()
 

--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -63,7 +63,7 @@ Semantica is designed to solve complex data challenges across various domains. T
 **Code Example**:
 
 ```python
-from semantica import Semantica
+from semantica.core import Semantica
 from semantica.visualization import KGVisualizer
 
 # Initialize
@@ -95,7 +95,7 @@ visualizer.visualize(kg, output_path="citation_network.html")
 **Code Example**:
 
 ```python
-from semantica import Semantica
+from semantica.core import Semantica
 from semantica.ontology import OntologyGenerator
 
 semantica = Semantica()
@@ -285,7 +285,7 @@ ontology = ontology_gen.generate_from_graph(kg)
 **Code Example**:
 
 ```python
-from semantica import Semantica
+from semantica.core import Semantica
 
 semantica = Semantica()
 legal_entities = ["Party", "Clause", "Section", "Contract", "Term"]
@@ -317,7 +317,7 @@ print(f"Found {len(clause_rels)} clause relationships")
 **Code Example**:
 
 ```python
-from semantica import Semantica
+from semantica.core import Semantica
 from semantica.ingest import FileIngestor
 
 semantica = Semantica()
@@ -349,7 +349,7 @@ print(f"Hashtags: {len(hashtags)}")
 **Code Example**:
 
 ```python
-from semantica import Semantica
+from semantica.core import Semantica
 from semantica.vector_store import VectorStore, HybridSearch
 
 semantica = Semantica()

--- a/semantica/__init__.py
+++ b/semantica/__init__.py
@@ -20,28 +20,28 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 
 # Core imports
-from .core import Config, ConfigManager, LifecycleManager, PluginRegistry, Semantica
+# from .core import Config, ConfigManager, LifecycleManager, PluginRegistry, Semantica
 
 
 # Pipeline imports
-from .pipeline import (
-    ExecutionEngine,
-    FailureHandler,
-    ParallelismManager,
-    PipelineBuilder,
-    PipelineValidator,
-    ResourceScheduler,
-)
+# from .pipeline import (
+#     ExecutionEngine,
+#     FailureHandler,
+#     ParallelismManager,
+#     PipelineBuilder,
+#     PipelineValidator,
+#     ResourceScheduler,
+# )
 
 # Visualization
-from .visualization import (
-    AnalyticsVisualizer,
-    EmbeddingVisualizer,
-    KGVisualizer,
-    OntologyVisualizer,
-    SemanticNetworkVisualizer,
-    TemporalVisualizer,
-)
+# from .visualization import (
+#     AnalyticsVisualizer,
+#     EmbeddingVisualizer,
+#     KGVisualizer,
+#     OntologyVisualizer,
+#     SemanticNetworkVisualizer,
+#     TemporalVisualizer,
+# )
 
 
 # Module proxy class for submodule access
@@ -193,28 +193,7 @@ _modules = _SemanticaModules()
 
 
 
-__all__ = [
-    # Core
-    "Semantica",
-    "Config",
-    "ConfigManager",
-    "LifecycleManager",
-    "PluginRegistry",
-    # Pipeline
-    "PipelineBuilder",
-    "ExecutionEngine",
-    "FailureHandler",
-    "ParallelismManager",
-    "ResourceScheduler",
-    "PipelineValidator",
-    # Visualization
-    "KGVisualizer",
-    "OntologyVisualizer",
-    "EmbeddingVisualizer",
-    "SemanticNetworkVisualizer",
-    "AnalyticsVisualizer",
-    "TemporalVisualizer",
-]
+__all__ = []
 
 
 # Make submodules accessible via dot notation

--- a/semantica/core/orchestrator.py
+++ b/semantica/core/orchestrator.py
@@ -12,7 +12,7 @@ This module provides the main entry point for the Semantica framework, handling:
 - System health monitoring
 
 Example Usage:
-    >>> from semantica import Semantica
+    >>> from semantica.core import Semantica
     >>> framework = Semantica()
     >>> result = framework.build_knowledge_base(
     ...     sources=["doc1.pdf", "doc2.docx"],


### PR DESCRIPTION
##  Summary
This PR implements a major cleanup of the codebase by removing temporarily deferred Quality Assurance (QA) components and refactoring the import system to enforce submodule-specific usage. These changes ensure the codebase is modular, cleaner, and aligned with the architectural decision to defer complex QA logic while maintaining pipeline integrity in examples and cookbooks.

##  Key Changes

### 1. Removal of QA Components
The following components have been removed from active usage in all cookbook notebooks and examples to decouple dependencies on the deferred QA module:
- `OntologyValidator`
- `ConflictDetector`
- `KGQualityAssessor`
- `TripletValidator`
- `TripletQualityChecker`

**Strategy:**
- Replaced active component instantiations with **dummy variables** or **mock classes** (e.g., `ValidationResult`, `Conflict`) to preserve the logical flow of pipelines in tutorials without executing the removed code.
- Commented out or removed import statements for these components.
- Fixed undefined variable errors (e.g., `quality_score`, `provenance_tracker`) resulting from the removals.

### 2. Import System Refactoring
Moved away from generic top-level imports to explicit submodule imports to improve code clarity and avoid circular dependencies.

- **Removed Generic Exports:** Updated `semantica/__init__.py` to stop exporting core classes directly.
- **Updated Imports Globally:**
  - `from semantica import Semantica` → `from semantica.core import Semantica`
  - `from semantica import Config` → `from semantica.core import Config`
  - `from semantica import PipelineBuilder` → `from semantica.pipeline import PipelineBuilder`
  - Removed unused `import semantica` statements.

### 3. Documentation & Fixes
- Updated **all documentation files** (`README.md`, `docs/*.md`) to reflect the new import syntax.
- Updated **all Jupyter Notebooks** in the `cookbook/` directory to use correct imports and dummy QA variables.
- Fixed `print(semantica.version)` to `print(semantica.__version__)` in getting started guides.

##  Affected Areas
- **Cookbooks:** `introduction/*`, `use_cases/*`, `advanced/*`
- **Documentation:** `docs/`, `README.md`, `CONTRIBUTING.md`
- **Core Framework:** `semantica/__init__.py`

##  Verification
- **Static Analysis:** Ran `grep` searches to ensure no residual `from semantica import Semantica` or target QA component usages remain.
- **Pipeline Integrity:** Verified that notebooks (e.g., `GraphRAG_Complete.ipynb`, `Environmental_Impact.ipynb`) contain necessary mock objects to run without `NameError`.
- **Git Branch:** All changes pushed to `conflicts` branch.

##  Notes
- The QA components are removed from *active execution* in examples but the pipeline structures remain intact for educational purposes, using placeholders where necessary.
- Future re-implementation of QA modules will require updating these placeholders with real logic.