### PR TITLE
Fix conflict resolution metadata and notebook output

### DIFF
--- a/cookbook/introduction/17_Conflict_Detection_and_Resolution.ipynb
+++ b/cookbook/introduction/17_Conflict_Detection_and_Resolution.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Conflict Detection and Resolution in Semantica\n",
+    "# Conflict Detection and Resolution\n",
     "\n",
     "## Overview\n",
     "\n",
@@ -261,7 +261,7 @@
     {
      "data": {
       "text/html": [
-       "<div style='font-family: monospace;'><h4>🧠 Semantica - 📊 Current Progress</h4><table style='width: 100%; border-collapse: collapse;'><tr><th>Status</th><th>Action</th><th>Module</th><th>Submodule</th><th>File</th><th>Time</th></tr><tr><td>✅</td><td>Semantica is resolving</td><td>⚠️ conflicts</td><td>ConflictDetector</td><td>-</td><td>0.00s</td></tr><tr><td>✅</td><td>Semantica is resolving</td><td>⚠️ conflicts</td><td>ConflictAnalyzer</td><td>-</td><td>0.00s</td></tr></table></div>"
+       "<div style='font-family: monospace;'><h4>🧠 Semantica - 📊 Current Progress</h4><table style='width: 100%; border-collapse: collapse;'><tr><th>Status</th><th>Action</th><th>Module</th><th>Submodule</th><th>File</th><th>Time</th></tr><tr><td>✅</td><td>Semantica is resolving</td><td>⚠️ conflicts</td><td>ConflictDetector</td><td>-</td><td>0.00s</td></tr><tr><td>✅</td><td>Semantica is resolving</td><td>⚠️ conflicts</td><td>ConflictAnalyzer</td><td>-</td><td>0.01s</td></tr><tr><td>✅</td><td>Semantica is resolving</td><td>⚠️ conflicts</td><td>ConflictResolver</td><td>-</td><td>0.00s</td></tr><tr><td>✅</td><td>Semantica is resolving</td><td>⚠️ conflicts</td><td>InvestigationGuideGenerator</td><td>-</td><td>0.00s</td></tr></table></div>"
       ],
       "text/plain": [
        "<IPython.core.display.HTML object>"
@@ -275,7 +275,7 @@
      "output_type": "stream",
      "text": [
       "Value conflict detected: emp_001.birth_date has conflicting values: ['1980-05-15', '1982-05-15']\n",
-      "Value conflict detected: emp_001.department has conflicting values: ['Engineering', 'Software Engineering']\n"
+      "Value conflict detected: emp_001.department has conflicting values: ['Software Engineering', 'Engineering']\n"
      ]
     },
     {
@@ -401,9 +401,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--- Resolution: Voting ---\n",
+      "Property: birth_date      | Resolved Value: 1980-05-15\n",
+      "Property: department      | Resolved Value: Engineering\n",
+      "\n",
+      "--- Resolution: Credibility Weighted ---\n",
+      "Property: birth_date      | Resolved Value: 1980-05-15 (Confidence: 0.79)\n",
+      "Property: department      | Resolved Value: Engineering (Confidence: 0.69)\n"
+     ]
+    }
+   ],
    "source": [
     "from semantica.conflicts import ConflictResolver\n",
     "\n",
@@ -448,9 +462,39 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=== Investigation: emp_001_birth_date_conflict ===\n",
+      "Summary: Conflict Type: value_conflict | Entity: emp_001 | Property: birth_date | Conflicting Values: 1980-05-15, 1982-05-15 | Severity: medium | Sources: public_dir, hr_db, linkedin_scrape\n",
+      "\n",
+      "Investigation Steps:\n",
+      "1. Review conflict details and context\n",
+      "   Action: Examine the conflict summary and identify the conflicting values\n",
+      "2. Identify all source documents\n",
+      "   Action: Locate and review the following source documents: public_dir, hr_db, linkedin_scrape\n",
+      "3. Compare conflicting information across sources\n",
+      "   Action: Review each source document and note the specific value and context for each\n",
+      "4. Assess source credibility and reliability\n",
+      "   Action: Review source credibility scores and document metadata\n",
+      "5. Determine resolution approach\n",
+      "   Action: Choose resolution strategy based on source credibility, recency, and business rules\n",
+      "6. Document resolution decision\n",
+      "   Action: Record the resolved value, resolution method, and rationale\n",
+      "\n",
+      "Recommended Actions:\n",
+      "[ ] Compare source documents side-by-side\n",
+      "[ ] Check for data entry errors or typos\n",
+      "[ ] Verify if values represent different time periods\n",
+      "[ ] Review 3 conflicting source documents\n",
+      "[ ] Identify most authoritative source\n"
+     ]
+    }
+   ],
    "source": [
     "from semantica.conflicts import InvestigationGuideGenerator\n",
     "\n",

--- a/semantica/conflicts/conflict_resolver.py
+++ b/semantica/conflicts/conflict_resolver.py
@@ -241,6 +241,17 @@ class ConflictResolver:
                 result = self._resolve_by_voting(conflict)
 
             result.resolution_strategy = strategy.value
+            conflict_type = (
+                conflict.conflict_type.value
+                if hasattr(conflict.conflict_type, "value")
+                else conflict.conflict_type
+            )
+            result.metadata.setdefault("conflict_type", conflict_type)
+            result.metadata.setdefault("entity_id", conflict.entity_id)
+            result.metadata.setdefault("property_name", conflict.property_name)
+            result.metadata.setdefault("relationship_id", conflict.relationship_id)
+            if conflict.metadata:
+                result.metadata.setdefault("conflict_metadata", conflict.metadata)
             self.resolution_history.append(result)
 
             self.progress_tracker.stop_tracking(


### PR DESCRIPTION
# Summary

Fixes cookbook printing crash when `property_name` is missing, and ensures `ResolutionResult.metadata` includes `property_name` (plus basic conflict context) from the originating `Conflict`.

# Changes

- Add conflict context to `ResolutionResult.metadata` in `ConflictResolver`
- Make cookbook output tolerate missing `property_name`

# Testing

```bash
pytest -q tests/conflicts/test_conflicts.py
```
