### PR TITLE
feat: Add missing RDF export and ontology generation methods

### DIFF
--- a/semantica/ontology/ontology_generator.py
+++ b/semantica/ontology/ontology_generator.py
@@ -217,6 +217,21 @@ class OntologyGenerator:
             )
             raise
 
+    def generate_from_graph(self, graph: Dict[str, Any], **options) -> Dict[str, Any]:
+        """
+        Generate ontology from a knowledge graph.
+
+        Alias for generate_ontology.
+
+        Args:
+            graph: Knowledge graph dictionary (output from GraphBuilder)
+            **options: Additional options
+
+        Returns:
+            Generated ontology dictionary
+        """
+        return self.generate_ontology(graph, **options)
+
     def _stage1_parse_semantic_network(
         self, data: Dict[str, Any], **options
     ) -> Dict[str, Any]:


### PR DESCRIPTION
## Summary
This PR addresses several `AttributeError` issues encountered when using the `OntologyGenerator` and `RDFExporter` classes, specifically ensuring compatibility with the project's example notebooks and documentation. It adds missing alias methods and implements N-Triples serialization support.

## Changes

### `semantica/ontology/ontology_generator.py`
- **Added `generate_from_graph` method**: This is an alias for the existing `generate_ontology` method. It ensures backward compatibility and supports calls made in the advanced cookbooks.

### `semantica/export/rdf_exporter.py`
- **Added `export_knowledge_graph` method**: Added to `RDFExporter` as an alias for the `export` method, resolving an `AttributeError` when running export workflows.
- **Implemented `convert_kg_to_rdf` in `RDFSerializer`**: Added a method to normalize `GraphBuilder` output (knowledge graphs) into a structure ready for RDF serialization. This handles field mapping (e.g., ensuring `label` exists by falling back to `name` or `id`).
- **Implemented `serialize_to_ntriples` in `RDFSerializer`**: Added support for the N-Triples format (line-based, plain text RDF).
- **Updated `RDFExporter.export_to_rdf`**: Enabled the "ntriples" format option by linking it to the new serializer method.

## Reasoning
Users following the `cookbook/advanced/05_Multi_Format_Export.ipynb` and other advanced examples were encountering runtime errors due to missing methods (`generate_from_graph`, `export_knowledge_graph`, `convert_kg_to_rdf`). These changes ensure the library's API matches the documented usage and provides robust RDF export capabilities.

## Verification
- **Ontology Generation**: Verified that `OntologyGenerator.generate_from_graph` correctly invokes the ontology generation logic.
- **RDF Export**: Verified that `RDFExporter.export_knowledge_graph` successfully exports files.
- **N-Triples Support**: Validated that `serialize_to_ntriples` produces valid `.nt` output.
- **KG Conversion**: Confirmed `convert_kg_to_rdf` correctly normalizes entity data for serialization.
