### PR TITLE
feat: Add pipeline_id support and fix parsing table display

### DIFF
--- a/semantica/embeddings/embedding_generator.py
+++ b/semantica/embeddings/embedding_generator.py
@@ -258,13 +258,14 @@ class EmbeddingGenerator:
         return max(0.0, min(1.0, similarity))
 
     def process_batch(
-        self, data_items: List[Union[str, Path]], **options
+        self, data_items: List[Union[str, Path]], pipeline_id: Optional[str] = None, **options
     ) -> Dict[str, Any]:
         """
         Process multiple data items for embedding generation.
 
         Args:
             data_items: List of data items
+            pipeline_id: Optional pipeline ID for progress tracking
             **options: Processing options
 
         Returns:
@@ -275,6 +276,7 @@ class EmbeddingGenerator:
             module="embeddings",
             submodule="EmbeddingGenerator",
             message=f"Batch of {len(data_items)} items",
+            pipeline_id=pipeline_id,
         )
 
         try:

--- a/semantica/kg/graph_builder.py
+++ b/semantica/kg/graph_builder.py
@@ -237,6 +237,7 @@ class GraphBuilder:
         self,
         sources: Union[List[Any], Any],
         second_arg: Optional[Any] = None,
+        pipeline_id: Optional[str] = None,
         **options,
     ) -> Dict[str, Any]:
         """
@@ -245,6 +246,7 @@ class GraphBuilder:
         Args:
             sources: Entities or sources list
             second_arg: Optional relationships list or entity_resolver (for backward compatibility)
+            pipeline_id: Optional pipeline ID for progress tracking
             **options: Additional build options
                 - extract: Whether to extract entities from text (default: True)
                 - extract_relations: Whether to extract relations from text (default: False)
@@ -307,6 +309,7 @@ class GraphBuilder:
             module="kg",
             submodule="GraphBuilder",
             message=f"Knowledge graph from {len(sources)} source(s)",
+            pipeline_id=pipeline_id,
         )
 
         try:
@@ -340,6 +343,7 @@ class GraphBuilder:
                         module="kg",
                         submodule="GraphBuilder",
                         message=f"Processing {len(entities_list)} entities",
+                        pipeline_id=pipeline_id,
                     )
                     
                     # Check if entities are already in dictionary format
@@ -409,6 +413,7 @@ class GraphBuilder:
                         module="kg",
                         submodule="GraphBuilder",
                         message=f"Processing {len(relationships_list)} relationships",
+                        pipeline_id=pipeline_id,
                     )
                     
                     # Check if relationships are already in dictionary format

--- a/semantica/parse/docx_parser.py
+++ b/semantica/parse/docx_parser.py
@@ -84,12 +84,13 @@ class DOCXParser:
         self.config = config
         self.progress_tracker = get_progress_tracker()
 
-    def parse(self, file_path: Union[str, Path], **options) -> Dict[str, Any]:
+    def parse(self, file_path: Union[str, Path], pipeline_id: Optional[str] = None, **options) -> Dict[str, Any]:
         """
         Parse DOCX document.
 
         Args:
             file_path: Path to DOCX file
+            pipeline_id: Optional pipeline ID for progress tracking
             **options: Parsing options:
                 - extract_formatting: Whether to extract formatting (default: False)
                 - extract_tables: Whether to extract tables (default: True)
@@ -106,6 +107,7 @@ class DOCXParser:
             module="parse",
             submodule="DOCXParser",
             message=f"DOCX: {file_path.name}",
+            pipeline_id=pipeline_id,
         )
 
         try:

--- a/semantica/parse/pdf_parser.py
+++ b/semantica/parse/pdf_parser.py
@@ -84,12 +84,13 @@ class PDFParser:
         if not self.progress_tracker.enabled:
             self.progress_tracker.enabled = True
 
-    def parse(self, file_path: Union[str, Path], **options) -> Dict[str, Any]:
+    def parse(self, file_path: Union[str, Path], pipeline_id: Optional[str] = None, **options) -> Dict[str, Any]:
         """
         Parse PDF document.
 
         Args:
             file_path: Path to PDF file
+            pipeline_id: Optional pipeline ID for progress tracking
             **options: Parsing options:
                 - extract_text: Whether to extract text (default: True)
                 - extract_tables: Whether to extract tables (default: True)
@@ -107,6 +108,7 @@ class PDFParser:
             module="parse",
             submodule="PDFParser",
             message=f"PDF: {file_path.name}",
+            pipeline_id=pipeline_id,
         )
 
         try:

--- a/semantica/pipeline/parallelism_manager.py
+++ b/semantica/pipeline/parallelism_manager.py
@@ -104,13 +104,14 @@ class ParallelismManager:
         self.lock = threading.Lock()
 
     def execute_parallel(
-        self, tasks: List[Task], **options
+        self, tasks: List[Task], pipeline_id: Optional[str] = None, **options
     ) -> List[ParallelExecutionResult]:
         """
         Execute tasks in parallel.
 
         Args:
             tasks: List of tasks to execute
+            pipeline_id: Optional pipeline ID for progress tracking
             **options: Additional options
 
         Returns:
@@ -120,6 +121,7 @@ class ParallelismManager:
             module="pipeline",
             submodule="ParallelismManager",
             message=f"Executing {len(tasks)} tasks in parallel",
+            pipeline_id=pipeline_id,
         )
 
         try:

--- a/semantica/semantic_extract/ner_extractor.py
+++ b/semantica/semantic_extract/ner_extractor.py
@@ -141,13 +141,14 @@ class NERExtractor:
                     f"spaCy model {self.model_name} not found. ML method will fallback."
                 )
 
-    def extract(self, text: Union[str, List[Dict[str, Any]], List[str]], **kwargs) -> Union[List[Entity], List[List[Entity]]]:
+    def extract(self, text: Union[str, List[Dict[str, Any]], List[str]], pipeline_id: Optional[str] = None, **kwargs) -> Union[List[Entity], List[List[Entity]]]:
         """
         Alias for extract_entities.
         Handles both single string and list of documents.
         
         Args:
             text: Input text or list of documents
+            pipeline_id: Optional pipeline ID for progress tracking
             **kwargs: Extraction options
             
         Returns:
@@ -159,6 +160,7 @@ class NERExtractor:
                 module="semantic_extract",
                 submodule="NERExtractor",
                 message=f"Batch extracting entities from {len(text)} documents",
+                pipeline_id=pipeline_id,
             )
             
             try:

--- a/semantica/semantic_extract/relation_extractor.py
+++ b/semantica/semantic_extract/relation_extractor.py
@@ -168,6 +168,7 @@ class RelationExtractor:
         self,
         text: Union[str, List[Dict[str, Any]], List[str]],
         entities: Union[List[Entity], List[List[Entity]]],
+        pipeline_id: Optional[str] = None,
         **kwargs
     ) -> Union[List[Relation], List[List[Relation]]]:
         """
@@ -177,6 +178,7 @@ class RelationExtractor:
         Args:
             text: Input text or list of documents
             entities: List of entities or list of list of entities
+            pipeline_id: Optional pipeline ID for progress tracking
             **kwargs: Extraction options
             
         Returns:
@@ -188,6 +190,7 @@ class RelationExtractor:
                 module="semantic_extract",
                 submodule="RelationExtractor",
                 message=f"Batch extracting relations from {len(text)} documents",
+                pipeline_id=pipeline_id,
             )
             
             try:


### PR DESCRIPTION
### Problem
- Trackers and batch processors don't support `pipeline_id`, so progress isn't visible in unified pipeline view
- Parsing extraction counts (tables, images, pages) not showing in progress display

### Changes
- Add `pipeline_id` parameter to all trackers, batch processors, parsers, and extractors
- Fix DoclingParser to show extraction counts in progress display
- Add "Extracted" column showing tables, images, pages
- Emphasize Docling as core dependency in messages

### Files Modified
- 11 core files with pipeline_id support
- DoclingParser extraction counts display
- Progress tracker "Extracted" column

### Backward Compatibility
✅ All `pipeline_id` parameters are optional (default: `None`)

Closes #136