### PR TITLE
Improve `semantic_extract` performance and add Groq LLM smoke tests

### DIFF
--- a/tests/semantic_extract/perf_real_use_cases.py
+++ b/tests/semantic_extract/perf_real_use_cases.py
@@ -1,0 +1,125 @@
+import statistics
+import time
+import os
+import sys
+from typing import Dict, List
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+
+from semantica.semantic_extract.event_detector import EventDetector
+from semantica.semantic_extract.ner_extractor import NERExtractor
+from semantica.semantic_extract.relation_extractor import RelationExtractor
+from semantica.semantic_extract.semantic_analyzer import SemanticAnalyzer
+from semantica.semantic_extract.semantic_network_extractor import SemanticNetworkExtractor
+from semantica.semantic_extract.triplet_extractor import TripletExtractor
+from semantica.utils.progress_tracker import get_progress_tracker
+
+
+def _make_documents(n: int) -> List[Dict[str, str]]:
+    base = (
+        "Apple Inc. was founded by Steve Jobs in 1976 and is headquartered in Cupertino, California. "
+        "Microsoft Corporation was founded by Bill Gates and Paul Allen in 1975. "
+        "In 2014, Apple acquired Beats Electronics for $3 billion. "
+        "In 2023, Google announced a partnership with OpenAI to improve search experiences."
+    )
+    return [{"id": f"doc_{i}", "content": f"{base} Document number {i}."} for i in range(n)]
+
+
+def _median_seconds(fn, repeats: int = 3) -> float:
+    times = []
+    for _ in range(repeats):
+        start = time.perf_counter()
+        fn()
+        times.append(time.perf_counter() - start)
+    return statistics.median(times)
+
+
+def _bench(label: str, fn, repeats: int = 3) -> dict:
+    fn()
+    seconds = _median_seconds(fn, repeats=repeats)
+    return {"label": label, "seconds": seconds}
+
+
+def main():
+    progress = get_progress_tracker()
+    progress.displays = []
+
+    docs = _make_documents(80)
+    texts = [d["content"] for d in docs]
+
+    ner = NERExtractor(method="pattern")
+    rel = RelationExtractor(method="pattern")
+    trip = TripletExtractor(method="pattern")
+    events = EventDetector(method="pattern")
+    analyzer = SemanticAnalyzer()
+    net = SemanticNetworkExtractor(ner_method="pattern", relation_method="pattern")
+
+    results = []
+
+    def ner_parallel():
+        ner.extract(texts)
+
+    def ner_seq():
+        ner.extract(texts, max_workers=1)
+
+    results.append(_bench("NER batch (default workers)", ner_parallel))
+    results.append(_bench("NER batch (max_workers=1)", ner_seq))
+
+    entities_batch = ner.extract(texts)
+
+    def rel_parallel():
+        rel.extract(texts, entities_batch)
+
+    def rel_seq():
+        rel.extract(texts, entities_batch, max_workers=1)
+
+    results.append(_bench("Relation batch (default workers)", rel_parallel))
+    results.append(_bench("Relation batch (max_workers=1)", rel_seq))
+
+    def trip_parallel():
+        trip.extract(texts)
+
+    def trip_seq():
+        trip.extract(texts, max_workers=1)
+
+    results.append(_bench("Triplet pipeline (default workers)", trip_parallel))
+    results.append(_bench("Triplet pipeline (max_workers=1)", trip_seq))
+
+    def ev_parallel():
+        events.detect_events(texts)
+
+    def ev_seq():
+        events.detect_events(texts, max_workers=1)
+
+    results.append(_bench("Event detection (default workers)", ev_parallel))
+    results.append(_bench("Event detection (max_workers=1)", ev_seq))
+
+    def analyzer_parallel():
+        analyzer.analyze(texts)
+
+    def analyzer_seq():
+        analyzer.analyze(texts, max_workers=1)
+
+    results.append(_bench("Semantic analysis (default workers)", analyzer_parallel))
+    results.append(_bench("Semantic analysis (max_workers=1)", analyzer_seq))
+
+    def net_parallel():
+        net.extract_network(texts)
+
+    def net_seq():
+        net.extract_network(texts, max_workers=1)
+
+    results.append(_bench("Semantic network (default workers)", net_parallel))
+    results.append(_bench("Semantic network (max_workers=1)", net_seq))
+
+    per_doc = []
+    for row in results:
+        per_doc.append({**row, "ms_per_doc": (row["seconds"] / len(texts)) * 1000.0})
+
+    print(f"Documents: {len(texts)}")
+    for row in per_doc:
+        print(f"{row['label']}: {row['seconds']:.3f}s  ({row['ms_per_doc']:.2f} ms/doc)")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/semantic_extract/test_extractors.py
+++ b/tests/semantic_extract/test_extractors.py
@@ -7,8 +7,12 @@ import os
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
 
 from semantica.semantic_extract.ner_extractor import NERExtractor
+from semantica.semantic_extract.ner_extractor import Entity as NEREntity
 from semantica.semantic_extract.relation_extractor import RelationExtractor
 from semantica.semantic_extract.triplet_extractor import TripletExtractor
+from semantica.semantic_extract.event_detector import EventDetector
+from semantica.semantic_extract.semantic_analyzer import SemanticAnalyzer
+from semantica.semantic_extract.semantic_network_extractor import SemanticNetworkExtractor
 from semantica.semantic_extract.named_entity_recognizer import Entity
 from semantica.semantic_extract.relation_extractor import Relation
 
@@ -51,6 +55,21 @@ class TestExtractors(unittest.TestCase):
         self.assertIsInstance(entities, list)
         mock_get_method.assert_called()
 
+    @patch("semantica.semantic_extract.methods.get_entity_method")
+    def test_ner_extraction_batch_via_extract_entities(self, mock_get_method):
+        mock_method = MagicMock()
+        mock_method.extract_entities.return_value = []
+        mock_get_method.return_value = mock_method
+
+        extractor = NERExtractor(method="pattern")
+        results = extractor.extract_entities(
+            ["Test text 1", "Test text 2"],
+        )
+
+        self.assertIsInstance(results, list)
+        self.assertEqual(len(results), 2)
+        self.assertTrue(all(isinstance(r, list) for r in results))
+
     @patch("semantica.semantic_extract.methods.get_relation_method")
     def test_relation_extraction(self, mock_get_method):
         """Test relation extraction call"""
@@ -64,6 +83,21 @@ class TestExtractors(unittest.TestCase):
         
         self.assertIsInstance(relations, list)
         mock_get_method.assert_called()
+
+    @patch("semantica.semantic_extract.methods.get_relation_method")
+    def test_relation_extraction_batch_via_extract_relations(self, mock_get_method):
+        mock_method = MagicMock()
+        mock_method.extract_relations.return_value = []
+        mock_get_method.return_value = mock_method
+
+        extractor = RelationExtractor(method="pattern")
+        texts = ["A knows B", "A knows B"]
+        entities = [NEREntity(text="A", label="PERSON", start_char=0, end_char=1, confidence=1.0)]
+
+        results = extractor.extract_relations(texts, entities)
+        self.assertIsInstance(results, list)
+        self.assertEqual(len(results), 2)
+        self.assertTrue(all(isinstance(r, list) for r in results))
 
     @patch("semantica.semantic_extract.methods.get_triplet_method")
     def test_triplet_extraction(self, mock_get_method):
@@ -80,6 +114,56 @@ class TestExtractors(unittest.TestCase):
         
         self.assertIsInstance(triplets, list)
         mock_get_method.assert_called()
+
+    @patch("semantica.semantic_extract.methods.get_triplet_method")
+    def test_triplet_extraction_batch_via_extract_triplets(self, mock_get_method):
+        mock_method = MagicMock()
+        mock_method.extract_triplets.return_value = []
+        mock_get_method.return_value = mock_method
+
+        extractor = TripletExtractor(method="pattern")
+        texts = ["A knows A", "A knows A"]
+        entities_batch = [[NEREntity(text="A", label="PERSON", start_char=0, end_char=1, confidence=1.0)] for _ in texts]
+        relations_batch = [[] for _ in texts]
+
+        results = extractor.extract_triplets(
+            texts,
+            entities=entities_batch,
+            relations=relations_batch,
+        )
+
+        self.assertIsInstance(results, list)
+        self.assertEqual(len(results), 2)
+        self.assertTrue(all(isinstance(r, list) for r in results))
+
+    def test_event_detector_batch_via_detect_events(self):
+        detector = EventDetector()
+        texts = ["Apple acquired Beats in 2014.", "Google announced a partnership in 2023."]
+        results = detector.detect_events(texts)
+        self.assertIsInstance(results, list)
+        self.assertEqual(len(results), 2)
+        self.assertTrue(all(isinstance(r, list) for r in results))
+
+    def test_semantic_analyzer_batch_parallel(self):
+        analyzer = SemanticAnalyzer()
+        texts = ["A short sentence.", "Another short sentence."]
+        results = analyzer.analyze(texts)
+        self.assertIsInstance(results, list)
+        self.assertEqual(len(results), 2)
+        self.assertTrue(all(isinstance(r, dict) for r in results))
+
+    def test_semantic_network_batch_via_extract_network(self):
+        extractor = SemanticNetworkExtractor()
+        texts = ["A knows B.", "C knows D."]
+        entities_batch = [[] for _ in texts]
+        relations_batch = [[] for _ in texts]
+        results = extractor.extract_network(
+            texts,
+            entities=entities_batch,
+            relations=relations_batch,
+        )
+        self.assertIsInstance(results, list)
+        self.assertEqual(len(results), 2)
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/semantic_extract/test_llm_smoke_groq.py
+++ b/tests/semantic_extract/test_llm_smoke_groq.py
@@ -1,0 +1,63 @@
+import os
+
+import pytest
+
+try:
+    from dotenv import load_dotenv
+
+    load_dotenv()
+except Exception:
+    pass
+
+pytest.importorskip("groq")
+
+from semantica.semantic_extract.ner_extractor import NERExtractor
+from semantica.semantic_extract.relation_extractor import RelationExtractor
+from semantica.semantic_extract.triplet_extractor import TripletExtractor
+
+
+def test_groq_llm_smoke_entities_relations_triplets():
+    if not os.getenv("GROQ_API_KEY"):
+        pytest.skip("GROQ_API_KEY is not set")
+
+    text = (
+        "Apple acquired Beats in 2014 for $3 billion. "
+        "Steve Jobs founded Apple. "
+        "Beats is based in California."
+    )
+    model = "llama-3.3-70b-versatile"
+
+    entities = NERExtractor(method="llm").extract(
+        text,
+        provider="groq",
+        model=model,
+        temperature=0.0,
+        max_tokens=250,
+    )
+    assert isinstance(entities, list)
+    assert len(entities) > 0
+    assert len(entities) <= 30
+
+    relations = RelationExtractor(method="llm").extract(
+        text,
+        entities=entities,
+        provider="groq",
+        model=model,
+        temperature=0.0,
+        max_tokens=350,
+        max_entities_prompt=12,
+    )
+    assert isinstance(relations, list)
+    assert len(relations) <= 30
+
+    triplets = TripletExtractor(method="llm").extract(
+        text,
+        entities=entities,
+        relations=relations,
+        provider="groq",
+        model=model,
+        temperature=0.0,
+        max_tokens=350,
+    )
+    assert isinstance(triplets, list)
+    assert len(triplets) <= 40

--- a/tests/semantic_extract/test_performance.py
+++ b/tests/semantic_extract/test_performance.py
@@ -168,12 +168,11 @@ class TestSemanticExtractImprovements(unittest.TestCase):
         texts = ["Text 1", "Text 2", "Text 3", "Text 4"]
         
         start_time = time.time()
-        # Run with 2 workers
-        results = extractor.extract(texts, max_workers=2)
+        results = extractor.extract(texts)
         end_time = time.time()
         
         duration = end_time - start_time
-        print(f"  Parallel NER (2 workers) took {duration:.4f}s")
+        print(f"  Parallel NER (default workers) took {duration:.4f}s")
         
         self.assertEqual(len(results), 4)
         
@@ -206,11 +205,11 @@ class TestSemanticExtractImprovements(unittest.TestCase):
         entities = [[], [], [], []]
         
         start_time = time.time()
-        results = extractor.extract(texts, entities, max_workers=2)
+        results = extractor.extract(texts, entities)
         end_time = time.time()
         
         duration = end_time - start_time
-        print(f"  Parallel RE (2 workers) took {duration:.4f}s")
+        print(f"  Parallel RE (default workers) took {duration:.4f}s")
         
         self.assertEqual(len(results), 4)
         
@@ -264,11 +263,11 @@ class TestSemanticExtractImprovements(unittest.TestCase):
         texts = ["Text 1", "Text 2", "Text 3", "Text 4"]
         
         start_time = time.time()
-        results = extractor.extract(texts, max_workers=2)
+        results = extractor.extract(texts)
         end_time = time.time()
         
         duration = end_time - start_time
-        print(f"  Parallel TE (2 workers) took {duration:.4f}s")
+        print(f"  Parallel TE (default workers) took {duration:.4f}s")
         
         self.assertEqual(len(results), 4)
         

--- a/tests/semantic_extract/test_regression_performance_edge_cases.py
+++ b/tests/semantic_extract/test_regression_performance_edge_cases.py
@@ -1,0 +1,123 @@
+import multiprocessing
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from semantica.semantic_extract.config import resolve_max_workers
+from semantica.semantic_extract.ner_extractor import Entity, NERExtractor
+from semantica.semantic_extract.relation_extractor import RelationExtractor
+from semantica.semantic_extract.triplet_extractor import TripletExtractor
+from semantica.semantic_extract.semantic_network_extractor import SemanticNetworkExtractor
+from semantica.semantic_extract.methods import filter_entities_for_text
+from semantica.semantic_extract.schemas import RelationsResponse, RelationOut
+
+
+def test_resolve_max_workers_defaults_and_clamps():
+    cpu_count = multiprocessing.cpu_count() or 1
+
+    assert resolve_max_workers(explicit=0) == 1
+    assert resolve_max_workers(explicit=-10) == 1
+    assert resolve_max_workers(explicit=1) == 1
+    assert resolve_max_workers(explicit=10**9) == min(cpu_count, 32)
+
+    assert resolve_max_workers(explicit=None, methods=["ml"]) == 1
+
+
+def test_filter_entities_for_text_keeps_short_tokens():
+    text = "US AI lab in NY"
+    entities = [
+        Entity(text="US", label="GPE", start_char=0, end_char=2, confidence=1.0),
+        Entity(text="AI", label="TECH", start_char=3, end_char=5, confidence=1.0),
+        Entity(text="NY", label="GPE", start_char=13, end_char=15, confidence=1.0),
+    ]
+    kept = filter_entities_for_text(text, entities, max_keep=2)
+    kept_texts = {e.text for e in kept}
+    assert "US" in kept_texts or "AI" in kept_texts or "NY" in kept_texts
+
+
+def test_pattern_batch_defaults_to_single_worker_low_latency():
+    extractor = NERExtractor(method="pattern")
+    texts = [f"Text {i}" for i in range(8)]
+    extractor.extract(texts)
+
+
+def test_relation_llm_prompt_filter_does_not_break_mapping():
+    entities = [Entity(text=f"VeryLongEntityName{i}", label="ORG", start_char=0, end_char=1, confidence=1.0) for i in range(120)]
+    ghost = Entity(text="Ghost", label="ORG", start_char=0, end_char=1, confidence=1.0)
+    entities.append(ghost)
+
+    captured = {}
+
+    class FakeLLM:
+        def is_available(self):
+            return True
+
+        def generate_typed(self, prompt, schema, **kwargs):
+            captured["prompt"] = prompt
+            return RelationsResponse(
+                relations=[
+                    RelationOut(subject="Ghost", predicate="related_to", object="VeryLongEntityName0", confidence=0.9)
+                ]
+            )
+
+    with patch("semantica.semantic_extract.methods.create_provider", return_value=FakeLLM()):
+        from semantica.semantic_extract.methods import extract_relations_llm
+
+        relations = extract_relations_llm(
+            "Short text mentioning VeryLongEntityName0 only.",
+            entities=entities,
+            provider="openai",
+            model="gpt-4",
+            max_entities_prompt=20,
+        )
+
+    assert "Ghost" not in captured["prompt"]
+    assert len(relations) == 1
+    assert relations[0].subject.text == "Ghost"
+
+
+def test_triplet_extractor_reuses_sub_extractors():
+    ner_instance = MagicMock()
+    ner_instance.extract_entities.return_value = [
+        Entity(text="A", label="PERSON", start_char=0, end_char=1, confidence=1.0)
+    ]
+
+    rel_instance = MagicMock()
+    rel_instance.extract_relations.return_value = []
+
+    ner_ctor = MagicMock(return_value=ner_instance)
+    rel_ctor = MagicMock(return_value=rel_instance)
+
+    with patch("semantica.semantic_extract.ner_extractor.NERExtractor", ner_ctor), patch(
+        "semantica.semantic_extract.relation_extractor.RelationExtractor", rel_ctor
+    ), patch("semantica.semantic_extract.methods.get_triplet_method", return_value=lambda *args, **kwargs: []):
+        extractor = TripletExtractor(method="pattern")
+        extractor.extract_triplets("A text.")
+        extractor.extract_triplets("A text again.")
+
+    assert ner_ctor.call_count == 1
+    assert rel_ctor.call_count == 1
+
+
+def test_semantic_network_extractor_reuses_sub_extractors():
+    ner_instance = MagicMock()
+    ner_instance.extract_entities.return_value = [
+        Entity(text="A", label="PERSON", start_char=0, end_char=1, confidence=1.0)
+    ]
+
+    rel_instance = MagicMock()
+    rel_instance.extract_relations.return_value = []
+
+    ner_ctor = MagicMock(return_value=ner_instance)
+    rel_ctor = MagicMock(return_value=rel_instance)
+
+    with patch("semantica.semantic_extract.ner_extractor.NERExtractor", ner_ctor), patch(
+        "semantica.semantic_extract.relation_extractor.RelationExtractor", rel_ctor
+    ):
+        extractor = SemanticNetworkExtractor(method="pattern")
+        extractor.extract_network("A text.")
+        extractor.extract_network("A text again.")
+
+    assert ner_ctor.call_count == 1
+    assert rel_ctor.call_count == 1


### PR DESCRIPTION
## Summary
This PR optimizes the `semantic_extract` module for lower latency and better throughput, especially for LLM-based flows, and adds targeted tests plus a real-use-case benchmark to prevent regressions.

## Key changes
- Centralized worker selection in `resolve_max_workers`:
  - Global `optimization.max_workers` default increased to 8.
  - ML methods default to single worker; pattern/regex/rules/LLM/huggingface use higher parallelism capped by CPU.
- LLM-based relations/triplets:
  - One LLM call per text chunk (no per-entity/pair loops).
  - Entity list downselection only for prompts; mapping back uses full entity list.
  - Global cache ensures repeated runs do not re-hit the LLM for identical inputs.
- Faster entity matching:
  - `match_entity` prefers exact/substring/word-boundary matches and only falls back to embeddings when needed.

## New tests and tools
- `tests/semantic_extract/test_regression_performance_edge_cases.py`:
  - Covers `resolve_max_workers`, entity filtering, and sub-extractor reuse.
- `tests/semantic_extract/test_performance.py`:
  - Ensures default workers provide parallel speedup vs `max_workers=1`.
- `tests/semantic_extract/perf_real_use_cases.py`:
  - Benchmarks NER, relations, triplets, events, semantic analysis, and semantic networks on 80 docs.
- `tests/semantic_extract/test_llm_smoke_groq.py`:
  - Groq LLM smoke test for NER/relations/triplets, enabled only when `GROQ_API_KEY` is set.

## Changelog
- Updated `[Unreleased]` section to document:
  - Semantic extract performance/regression work.
  - New concurrency defaults.
  - LLM entity matching optimizations.
  - Groq LLM smoke tests (env-based, no `.env` committed).

## Testing
```bash
python -m pytest tests/semantic_extract -q
python -m pytest tests/semantic_extract/test_regression_performance_edge_cases.py tests/semantic_extract/test_performance.py -q
python -m pytest -q
python -u tests/semantic_extract/perf_real_use_cases.py
```
All passing (exit code 0); perf script reports sub-ms per document for all stages in the benchmark.