### PR TITLE
Fix LLM Relation Extraction

### DIFF
--- a/tests/integration/test_relations_groq.py
+++ b/tests/integration/test_relations_groq.py
@@ -1,0 +1,98 @@
+import os
+import unittest
+import time
+
+from semantica.semantic_extract import NERExtractor, RelationExtractor
+
+# Use environment variable for API key
+_GROQ_KEY = os.getenv("GROQ_API_KEY") or os.getenv("GROQ_TEST_API_KEY")
+@unittest.skipUnless(_GROQ_KEY, "Groq key not set; skipping live integration test")
+class TestGroqRelationsIntegration(unittest.TestCase):
+    def setUp(self):
+        self.api_key = _GROQ_KEY
+        self.model = "llama-3.1-8b-instant"
+        # Short, unambiguous finance snippet
+        self.text_short = (
+            "Apple reported revenue of $4.4 billion in Q1 2024 and provided guidance for FY 2025."
+        )
+        # Longer text to exercise chunking and ensure no hang
+        self.text_long = (
+            "Apple reported revenue of $4.4 billion in Q1 2024. "
+            "The company also reported growth of 12% year-over-year and provided guidance for FY 2025. "
+            "Microsoft reported revenue of $6.1 billion in Q2 2024 and expects sequential growth. "
+            "NVIDIA reported record revenue in 2024 Q1 and guided for higher revenue in Q2 2024. "
+        ) * 20  # expand length
+
+    def _extract_entities(self, text):
+        ner = NERExtractor(
+            method="llm",
+            provider="groq",
+            llm_model=self.model,
+            api_key=self.api_key,
+            temperature=0.0,
+        )
+        entities = ner.extract_entities(text, entity_types=["ORGANIZATION", "MONEY", "DATE", "EVENT", "PERCENT"])
+        self.assertIsInstance(entities, list)
+        return entities
+
+    def test_relations_short_text(self):
+        entities = self._extract_entities(self.text_short)
+        self.assertGreater(len(entities), 0, "NER should extract entities for short text")
+
+        relation_extractor = RelationExtractor(
+            method="llm",
+            relation_types=[
+                "HAS_REVENUE",
+                "HAS_GROWTH",
+                "PROVIDES_GUIDANCE",
+                "IN_QUARTER",
+                "FOR_PERIOD",
+                "RELATED_TO",
+            ],
+            provider="groq",
+            llm_model=self.model,
+            api_key=self.api_key,
+            temperature=0.0,
+            verbose=True,
+        )
+
+        start = time.time()
+        relations = relation_extractor.extract_relations(text=self.text_short, entities=entities)
+        elapsed = time.time() - start
+
+        self.assertIsInstance(relations, list)
+        # Ensure call completes reasonably fast (network dependent; allow generous bound)
+        self.assertLess(elapsed, 60, f"Extraction took too long: {elapsed:.2f}s")
+        # Do not strictly assert >0 as model output may vary, but log for diagnostics
+        if relations:
+            sample = relations[0]
+            self.assertTrue(hasattr(sample, "subject") and hasattr(sample, "predicate") and hasattr(sample, "object"))
+
+    def test_relations_long_text_chunking(self):
+        entities = self._extract_entities(self.text_long)
+        self.assertGreater(len(entities), 0, "NER should extract entities for long text")
+
+        relation_extractor = RelationExtractor(
+            method="llm",
+            relation_types=["RELATED_TO", "HAS_REVENUE", "IN_QUARTER"],
+            provider="groq",
+            llm_model=self.model,
+            api_key=self.api_key,
+            temperature=0.0,
+            verbose=True,
+        )
+
+        start = time.time()
+        relations = relation_extractor.extract_relations(text=self.text_long, entities=entities)
+        elapsed = time.time() - start
+
+        self.assertIsInstance(relations, list)
+        # Ensure completion (chunked path) and no hang
+        self.assertLess(elapsed, 120, f"Chunked extraction took too long: {elapsed:.2f}s")
+        if relations:
+            for r in relations[:3]:
+                self.assertTrue(hasattr(r, "subject") and hasattr(r, "predicate") and hasattr(r, "object"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_relations_llm.py
+++ b/tests/test_relations_llm.py
@@ -1,0 +1,118 @@
+import unittest
+
+from semantica.semantic_extract.methods import extract_relations_llm
+from semantica.semantic_extract.ner_extractor import Entity
+
+
+class FakeProvider:
+    def __init__(self, typed_payload=None, structured_payload=None):
+        self._typed_payload = typed_payload
+        self._structured_payload = structured_payload
+
+    def is_available(self):
+        return True
+
+    # Simulate typed output return: can be dict or an object with relations
+    def generate_typed(self, prompt, schema, **kwargs):
+        return self._typed_payload if self._typed_payload is not None else {"relations": []}
+
+    def generate_structured(self, prompt, **kwargs):
+        return self._structured_payload if self._structured_payload is not None else {"relations": []}
+
+
+class TestLLMRelationExtraction(unittest.TestCase):
+    def setUp(self):
+        # Minimal realistic text and entities
+        self.text = "Apple reported revenue of $4.4 billion in Q1 2024."
+        self.entities = [
+            Entity(text="Apple", label="ORGANIZATION", start_char=0, end_char=5, confidence=0.99),
+            Entity(text="$4.4 billion", label="MONEY", start_char=26, end_char=39, confidence=0.99),
+            Entity(text="Q1 2024", label="DATE", start_char=43, end_char=51, confidence=0.99),
+        ]
+
+    def _monkeypatch_provider(self, provider_instance):
+        # Monkeypatch create_provider used by extract_relations_llm
+        import semantica.semantic_extract.methods as methods
+        self._orig_create_provider = methods.create_provider
+
+        def _fake_create_provider(provider, model=None, **kwargs):
+            return provider_instance
+
+        methods.create_provider = _fake_create_provider
+
+    def tearDown(self):
+        # Restore original create_provider if patched
+        try:
+            import semantica.semantic_extract.methods as methods
+            if hasattr(self, "_orig_create_provider"):
+                methods.create_provider = self._orig_create_provider
+        except Exception:
+            pass
+
+    def test_typed_relations_parsed(self):
+        # Typed returns a dict compatible with parser
+        typed_payload = {
+            "relations": [
+                {
+                    "subject": "Apple",
+                    "predicate": "HAS_REVENUE",
+                    "object": "$4.4 billion",
+                    "confidence": 0.92,
+                },
+                {
+                    "subject": "Apple",
+                    "predicate": "IN_QUARTER",
+                    "object": "Q1 2024",
+                    "confidence": 0.9,
+                },
+            ]
+        }
+        fake = FakeProvider(typed_payload=typed_payload)
+        self._monkeypatch_provider(fake)
+
+        rels = extract_relations_llm(
+            text=self.text,
+            entities=self.entities,
+            provider="groq",
+            model="llama-3.1-8b-instant",
+            relation_types=["HAS_REVENUE", "IN_QUARTER"],
+            verbose=True,
+        )
+        self.assertGreaterEqual(len(rels), 2, "Expected at least two relations from typed payload")
+        preds = {(r.subject.text, r.predicate, r.object.text) for r in rels}
+        self.assertIn(("Apple", "HAS_REVENUE", "$4.4 billion"), preds)
+        self.assertIn(("Apple", "IN_QUARTER", "Q1 2024"), preds)
+
+    def test_structured_fallback_used(self):
+        # Typed returns zero, structured has content
+        typed_payload = {"relations": []}
+        structured_payload = {
+            "relations": [
+                {
+                    "subject": "Apple",
+                    "predicate": "HAS_REVENUE",
+                    "object": "$4.4 billion",
+                    "confidence": 0.88,
+                }
+            ]
+        }
+        fake = FakeProvider(typed_payload=typed_payload, structured_payload=structured_payload)
+        self._monkeypatch_provider(fake)
+
+        rels = extract_relations_llm(
+            text=self.text,
+            entities=self.entities,
+            provider="groq",
+            model="llama-3.1-8b-instant",
+            relation_types=["HAS_REVENUE"],
+            verbose=True,
+        )
+        self.assertEqual(len(rels), 1, "Expected fallback to structured JSON to yield one relation")
+        r = rels[0]
+        self.assertEqual(r.subject.text, "Apple")
+        self.assertEqual(r.object.text, "$4.4 billion")
+        self.assertEqual(r.predicate, "HAS_REVENUE")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem
LLM relation extraction with Groq made successful API calls but returned zero relations due to post-response parsing issues.

## Solution
- Normalize typed responses from instructor/OpenAI/Groq to consistent format
- Add JSON fallback when typed parsing yields no relations
- Remove unused kwargs (`max_tokens`, `max_entities_prompt`) from internals
- Add comprehensive unit and integration tests

## Changes
- **Backend**: Harden response parsing and add fallback in `methods.py`
- **Tests**: Unit tests with mocked provider + integration tests for Groq
- **API**: Only forward `temperature` and `verbose` kwargs to providers

## Usage
```python
relation_extractor = RelationExtractor(
    method="llm",
    relation_types=["HAS_REVENUE", "IN_QUARTER", "RELATED_TO"],
    provider="groq",
    llm_model="llama-3.1-8b-instant",
    api_key=GROQ_API_KEY,
    verbose=True
)

relations = relation_extractor.extract_relations(text=text, entities=entities)
```

## Testing
```bash
# Unit tests
python -m unittest tests.test_relations_llm

# Integration tests (requires GROQ_API_KEY)
python -m unittest tests.integration.test_relations_groq
```

## Breaking Changes
Removed support for `max_entities_prompt` and `max_tokens` kwargs in relation extraction (were previously ignored).

## Verification
✅ Tested with Groq llama-3.1-8b-instant
✅ Relations extracted from short and long texts
✅ Integration tests pass with real API calls
✅ Unit tests cover both response paths
