### PR TITLE
Circular import between `pipeline_builder` and `pipeline_validator`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,12 +17,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **API Parameter Handling**:
     - Limited kwargs forwarded in chunked extraction helper to prevent parameter leakage
     - Ensured minimal, safe parameters are passed to provider calls
+- **Pipeline Circular Import (Issues #192, #193)**:
+    - Fixed circular import between `pipeline_builder` and `pipeline_validator` triggered during `semantica.pipeline` import
+    - Lazy-loaded `PipelineValidator` inside `PipelineBuilder.__init__` and guarded type hints with `TYPE_CHECKING`
+    - Ensured `from semantica.deduplication import DuplicateDetector` no longer fails even when pipeline module is imported
 
 ### Added
 - **Comprehensive Test Suite**:
     - Added unit tests (`tests/test_relations_llm.py`) with mocked LLM provider covering both typed and structured response paths
     - Added integration tests (`tests/integration/test_relations_groq.py`) for real Groq API calls with environment variable API key
     - Tests validate relation extraction completion and result parsing across different response formats
+- **Amazon Neptune Dev Environment**:
+    - Added CloudFormation template (`cookbook/introduction/neptune-setup.yaml`) to provision a dev Neptune cluster with public endpoint and IAM auth enabled
+    - Documented deployment, cost estimates, and IAM User vs IAM Role best practices in `cookbook/introduction/21_Amazon_Neptune_Store.ipynb`
+    - Added `cfn-lint` to `.pre-commit-config.yaml` for validating CloudFormation templates while excluding `neptune-setup.yaml` from generic YAML linters
 
 ### Changed
 - **Relation Extraction API**:

--- a/semantica/pipeline/pipeline_builder.py
+++ b/semantica/pipeline/pipeline_builder.py
@@ -32,12 +32,14 @@ License: MIT
 
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any, Callable, Dict, List, Optional, Union
+from typing import Any, Callable, Dict, List, Optional, Union, TYPE_CHECKING
 
 from ..utils.exceptions import ProcessingError, ValidationError
 from ..utils.logging import get_logger
 from ..utils.progress_tracker import get_progress_tracker
-from .pipeline_validator import PipelineValidator
+
+if TYPE_CHECKING:
+    from .pipeline_validator import PipelineValidator
 
 
 class StepStatus(Enum):
@@ -103,6 +105,8 @@ class PipelineBuilder:
         # Ensure progress tracker is enabled
         if not self.progress_tracker.enabled:
             self.progress_tracker.enabled = True
+
+        from .pipeline_validator import PipelineValidator
 
         self.validator = PipelineValidator(**self.config)
         self.steps: List[PipelineStep] = []

--- a/tests/pipeline/test_pipeline.py
+++ b/tests/pipeline/test_pipeline.py
@@ -107,5 +107,25 @@ class TestPipelineModule(unittest.TestCase):
         
         self.assertEqual(execution_order, ["A", "B", "C"])
 
+    def test_imports_no_circular_dependencies(self):
+        import semantica
+
+        _ = semantica.pipeline
+
+        from semantica.pipeline import PipelineBuilder, PipelineValidator
+        from semantica.deduplication import DuplicateDetector
+
+        builder = PipelineBuilder()
+        builder.add_step("step1", "dummy")
+        pipeline = builder.build("import_test_pipeline")
+
+        validator = PipelineValidator()
+        result = validator.validate_pipeline(pipeline)
+
+        self.assertTrue(result.valid)
+
+        detector = DuplicateDetector()
+        self.assertIsNotNone(detector)
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Description

This PR fixes a circular import between `semantica.pipeline.pipeline_builder` and `semantica.pipeline.pipeline_validator` that caused an `ImportError` when importing only the deduplication module:

```bash
python -c "from semantica.deduplication import DuplicateDetector"
```

The fix lazily imports `PipelineValidator` inside `PipelineBuilder.__init__` and uses `TYPE_CHECKING` for type hints, breaking the import-time cycle while preserving behavior. A regression test and changelog entries are included.

Fixes #192  
Fixes #193  

---

## Background

**Original issue**

Importing `semantica` (and therefore `semantica.pipeline`) led to a circular import:

- `pipeline_builder.py`:

  ```python
  from .pipeline_validator import PipelineValidator
  ```

- `pipeline_validator.py`:

  ```python
  from .pipeline_builder import Pipeline, PipelineBuilder, PipelineStep
  ```

When `semantica.__init__` accessed `semantica.pipeline`, the cycle was triggered and:

```python
from semantica.deduplication import DuplicateDetector
```

failed with:

> ImportError: cannot import name 'Pipeline' from partially initialized module 'semantica.pipeline.pipeline_builder'

The minimal patch suggested in the issue was to move the `PipelineValidator` import into `PipelineBuilder.__init__` and guard type hints with `TYPE_CHECKING`.

---

## Changes Made

### 1. Break circular import in pipeline

**File:** `semantica/pipeline/pipeline_builder.py`

- Removed the top-level import that caused the cycle:

  ```python
  from .pipeline_validator import PipelineValidator
  ```

- Added `TYPE_CHECKING` guard for type hints:

  ```python
  from typing import Any, Callable, Dict, List, Optional, Union, TYPE_CHECKING

  from ..utils.exceptions import ProcessingError, ValidationError
  from ..utils.logging import get_logger
  from ..utils.progress_tracker import get_progress_tracker

  if TYPE_CHECKING:
      from .pipeline_validator import PipelineValidator
  ```

- Lazily import `PipelineValidator` inside `PipelineBuilder.__init__`:

  ```python
  if not self.progress_tracker.enabled:
      self.progress_tracker.enabled = True

  from .pipeline_validator import PipelineValidator

  self.validator = PipelineValidator(**self.config)
  ```

This ensures `pipeline_builder` no longer imports `PipelineValidator` at module load time, while `pipeline_validator` continues to import `Pipeline` / `PipelineBuilder` only inside methods, breaking the cycle.

---

### 2. Add regression test for imports

**File:** `tests/pipeline/test_pipeline.py`

Added a regression test that covers the problematic path and ensures pipeline/deduplication imports work together:

```python
def test_imports_no_circular_dependencies(self):
    import semantica

    _ = semantica.pipeline

    from semantica.pipeline import PipelineBuilder, PipelineValidator
    from semantica.deduplication import DuplicateDetector

    builder = PipelineBuilder()
    builder.add_step("step1", "dummy")
    pipeline = builder.build("import_test_pipeline")

    validator = PipelineValidator()
    result = validator.validate_pipeline(pipeline)

    self.assertTrue(result.valid)

    detector = DuplicateDetector()
    self.assertIsNotNone(detector)
```

This test will fail if:

- Importing `semantica` / `semantica.pipeline` triggers a circular import, or
- Importing `DuplicateDetector` indirectly pulls in a broken `Pipeline`/`PipelineBuilder` import path.

---

### 3. Update changelog

**File:** `CHANGELOG.md` (under `[Unreleased]`)

Added:

- **Pipeline Circular Import (Issues #192, #193)**:
  - Fixed circular import between `pipeline_builder` and `pipeline_validator` triggered during `semantica.pipeline` import.
  - Lazy-loaded `PipelineValidator` inside `PipelineBuilder.__init__` and guarded type hints with `TYPE_CHECKING`.
  - Ensured `from semantica.deduplication import DuplicateDetector` no longer fails even when pipeline module is imported.

Also included the already-merged Amazon Neptune changes for completeness:

- **Amazon Neptune Dev Environment**:
  - Added CloudFormation template (`cookbook/introduction/neptune-setup.yaml`) to provision a dev Neptune cluster with public endpoint and IAM auth enabled.
  - Documented deployment, cost estimates, and IAM User vs IAM Role best practices in `cookbook/introduction/21_Amazon_Neptune_Store.ipynb`.
  - Added `cfn-lint` to `.pre-commit-config.yaml` for validating CloudFormation templates while excluding `neptune-setup.yaml` from generic YAML linters.

---

## Testing

All tests were run from the project root.

**Targeted checks:**

```bash
# Original repro command from the issue
python -c "from semantica.deduplication import DuplicateDetector"

# Regression test for circular imports
pytest tests/pipeline/test_pipeline.py -k test_imports_no_circular_dependencies -vv
```

**Full test suite:**

```bash
pytest
```

- `test_imports_no_circular_dependencies` passes.
- `from semantica.deduplication import DuplicateDetector` no longer raises `ImportError`.
- The full test suite passes aside from any pre-existing unrelated failures, none of which are introduced by this PR.

---

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)  
- [ ] New feature  
- [ ] Breaking change  
- [x] Documentation update (changelog)

---

## Checklist

- [x] My code follows the project's style guidelines  
- [x] I have added/updated tests that cover my changes  
- [x] All relevant tests pass (`pytest`, targeted and full)  
- [x] Changelog updated under `[Unreleased]`  
- [x] Changes are pushed to branch `utils` (not `main`)