### PR TITLE
test: register integration mark and tidy ingest test warnings

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+markers =
+    integration: marks tests as integration (deselect with '-m "not integration"')
+addopts = -ra


### PR DESCRIPTION
Follow-up to #239 to keep ingest tests hermetic and CI output clean.

## Summary
- Register `integration` pytest mark to silence unknown-mark warnings.
- Ensure ingest tests run cleanly without optional cloud SDKs.

## Changes
- Add `pytest.ini` with `integration` mark and `-ra` reporting.
- tests/ingest/test_file_ingestor.py: pre-mock `boto3` so `@patch("boto3.client")` works without the SDK.
- semantica/ingest/feed_ingestor.py: make `FeedParser._parse_date` raise `ValueError` on invalid inputs (matches tests).

## Why
- Less CI noise; more deterministic, hermetic tests; clearer date-parsing errors.

## Testing
- `pytest -q tests/ingest/` (95 passed locally)
- Optional: `pytest --cov=semantica tests/ingest/`

## Compatibility
- `_parse_date` now raises on invalid input (private helper; low risk).

## Acknowledgements
- Thanks to @Mohammed2372 for the comprehensive ingest tests in #239 (fixes #232).