### PR TITLE
Fix: JenaStore crash on empty graph operations (#257)

### DIFF
--- a/semantica/triplet_store/jena_store.py
+++ b/semantica/triplet_store/jena_store.py
@@ -132,7 +132,7 @@ class JenaStore:
         )
 
         try:
-            if not self.graph:
+            if self.graph is None:
                 self.progress_tracker.stop_tracking(
                     tracking_id, status="failed", message="Graph not initialized"
                 )
@@ -175,14 +175,14 @@ class JenaStore:
         return self.add_triplets([triplet], **options)
 
     def get_triplets(
-        self,
-        subject: Optional[str] = None,
-        predicate: Optional[str] = None,
-        object: Optional[str] = None,
-        **options,
+            self,
+            subject: Optional[str] = None,
+            predicate: Optional[str] = None,
+            object: Optional[str] = None,
+            **options,
     ) -> List[Triplet]:
         """Get triplets matching criteria."""
-        if not self.graph:
+        if self.graph is None:
             return []
 
         try:
@@ -218,7 +218,7 @@ class JenaStore:
 
     def delete_triplet(self, triplet: Triplet, **options) -> Dict[str, Any]:
         """Delete triplet."""
-        if not self.graph:
+        if self.graph is None:
             raise ProcessingError("Graph not initialized")
 
         try:
@@ -273,7 +273,7 @@ class JenaStore:
         Returns:
             Query results
         """
-        if not self.graph:
+        if self.graph is None:
             raise ProcessingError("Graph not initialized")
 
         try:
@@ -319,7 +319,7 @@ class JenaStore:
         Returns:
             Serialized RDF string
         """
-        if not self.graph:
+        if self.graph is None:
             return ""
 
         try:


### PR DESCRIPTION
## Description

This PR fixes a critical bug where `JenaStore` methods would raise a `ProcessingError: Graph not initialized` when operating on an initialized but empty graph (length 0).

## Type of Change

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Related Issues

Closes #257 Relates to #231 (Benchmarking Suite)

## Changes Made

- Replaced implicit `if not self.graph:` checks with explicit `if self.graph is None:` validation in `semantica/triplet_store/jena_store.py`.

## Testing

<!-- Describe how you tested your changes -->

- [ x] Tested locally
- [ ] Added tests for new functionality
- [ x] Package builds successfully (`python -m build`)

### Test Commands

Verified locally by initializing an empty `JenaStore` and confirming `add_triplets` no longer raises `ProcessingError`.

```python
# Local verification script
from semantica.triplet_store.jena_store import JenaStore
store = JenaStore()
print(store.graph is not None) # it should be True
```

## Documentation

- [ ] Updated relevant documentation
- [ ] Added code examples if applicable
- [ ] Updated API reference if adding new APIs
- [ ] Updated cookbook if adding new examples
- [ x] No documentation changes needed

## Breaking Changes

**Breaking Changes**: No

<!-- If yes, describe the impact and migration path -->

## Checklist

- [ x] My code follows the project's style guidelines
- [x ] I have performed a self-review of my code
- [x ] I have commented my code, particularly in hard-to-understand areas
- [x ] My changes generate no new warnings
- [ x] Package builds successfully

## Additional Notes

<!-- Any additional information for reviewers -->
