### PR TITLE
feat: Add integrations module placeholder for future framework integr…

### DIFF
--- a/semantica/integrations/__init__.py
+++ b/semantica/integrations/__init__.py
@@ -1,0 +1,19 @@
+"""
+Semantica Integrations Module
+
+Placeholder for future integration adapters with agentic frameworks and SDKs.
+Exposes Semantica's semantic intelligence (knowledge graphs, ontologies, provenance
+tracking, semantic extraction) as native components within their respective frameworks.
+
+Planned Integrations:
+    - Agno Framework (Issue #249): Semantic memory and knowledge graph integration
+    - Google ADK (Issue #251): Semantic tools and memory interfaces
+    - Claude Agent SDK (Issue #250): Custom tools and hooks for explainable AI
+
+All integrations will be opt-in via pip extras with zero breaking changes.
+
+Status: Placeholder for future implementation
+"""
+
+__version__ = "0.1.0"
+__all__ = []


### PR DESCRIPTION
### Add Integrations Module Placeholder

Adds `semantica/integrations/` module with placeholder documentation for future framework integrations (Agno, Google ADK, Claude Agent SDK) as outlined in issues #249, #250, and #251.