### PR TITLE
Fix TypeError in AssociativeClassBuilder

### DIFF
--- a/semantica/ontology/associative_class.py
+++ b/semantica/ontology/associative_class.py
@@ -208,6 +208,7 @@ class AssociativeClassBuilder:
         person_class: str,
         organization_class: str,
         role_class: Optional[str] = None,
+        name: str = "Position",
         **options,
     ) -> AssociativeClass:
         """
@@ -243,15 +244,20 @@ class AssociativeClassBuilder:
         if role_class:
             connects.append(role_class)
 
+        temporal = options.pop("temporal", True)
+        user_props = options.pop("properties", {})
+
+        merged_props = {
+            "startDate": "xsd:date",
+            "endDate": "xsd:date",
+            **user_props,
+        }
+
         return self.create_associative_class(
-            name=options.get("name", "Position"),
+            name=name,
             connects=connects,
-            temporal=options.get("temporal", True),
-            properties={
-                "startDate": "xsd:date",
-                "endDate": "xsd:date",
-                **options.get("properties", {}),
-            },
+            temporal=temporal,
+            properties= merged_props,
             **options,
         )
 
@@ -282,15 +288,18 @@ class AssociativeClassBuilder:
             )
             ```
         """
+
+        user_props = options.pop("properties", {})
+        merged_props = {
+            "startDate": "xsd:dateTime",
+            "endDate": "xsd:dateTime",
+            **user_props,
+        }
         return self.create_associative_class(
             name=name,
             connects=connects,
             temporal=True,
-            properties={
-                "startDate": "xsd:dateTime",
-                "endDate": "xsd:dateTime",
-                **options.get("properties", {}),
-            },
+            properties=merged_props,
             **options,
         )
 


### PR DESCRIPTION
## Description

This PR addresses a `TypeError` in the `AssociativeClassBuilder`. The root cause was an argument collision between the explicit `name` parameter and the `**options` (kwargs) dict.

## Type of Change

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Related Issues

Fixes #277 

## Changes Made

<!-- List the main changes in this PR -->

-  **Fixed Argument Collision**: Updated `create_position_class` to explicitly define the `name` parameter and use `options.pop` to ensure it isn't passed twice to the internal builder.
- **Improved kwargs Handling**: Applied defensive "popping" for `temporal` and `properties` to prevent similar crashes.
- **Internal Consistency**: Refactored `create_temporal_association` to use the same safe merging logic for its properties.

## Testing

<!-- Describe how you tested your changes -->

- [x ] Tested locally
- [ ] Added tests for new functionality
- [x ] Package builds successfully (`python -m build`)

### Test Commands

I verified the fix by running a local benchmark script that previously crashed:

```
from semantica.ontology.associative_class import AssociativeClassBuilder
builder = AssociativeClassBuilder()
# This now works perfectly without a TypeError
builder.create_position_class(person_class="Person", organization_class="Org", name="Manager")
```

## Documentation

- [ ] Updated relevant documentation
- [ ] Added code examples if applicable
- [ ] Updated API reference if adding new APIs
- [ ] Updated cookbook if adding new examples
- [ x] No documentation changes needed

## Breaking Changes

**Breaking Changes**: No

<!-- If yes, describe the impact and migration path -->

## Checklist

- [x ] My code follows the project's style guidelines
- [ x] I have performed a self-review of my code
- [x ] I have commented my code, particularly in hard-to-understand areas
- [ x] My changes generate no new warnings
- [x ] Package builds successfully

