### PR TITLE
Discord Links Update

### DIFF
--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -7,7 +7,7 @@ Check the [docs folder](https://github.com/Hawksight-AI/semantica/tree/main/docs
 
 ### 💬 Community Support
 - **GitHub Discussions**: [Ask questions](https://github.com/Hawksight-AI/semantica/discussions)
-- **Discord**: Join our [Discord server](https://discord.gg/semantica) for real-time chat
+- **Discord**: Join our [Discord server](https://discord.gg/ggb7vWeP) for real-time chat
 
 ### 💭 Discussions
 Join the conversation on [GitHub Discussions](https://github.com/Hawksight-AI/semantica/discussions):

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,9 +2,9 @@
 
 Thank you for your interest in contributing! Every contribution, no matter how small, is valuable. 🎉
 
-⭐ **Give us a Star** • 🍴 **[Fork Semantica](https://github.com/Hawksight-AI/semantica/fork)** • 💬 **Join our [Discord](https://discord.gg/vqRt2qbx)**
+⭐ **Give us a Star** • 🍴 **[Fork Semantica](https://github.com/Hawksight-AI/semantica/fork)** • 💬 **Join our [Discord](https://discord.gg/ggb7vWeP)**
 
-> **New to contributing?** Start with a [`good first issue`](https://github.com/Hawksight-AI/semantica/labels/good%20first%20issue) or join our [Discord](https://discord.gg/vqRt2qbx) community.
+> **New to contributing?** Start with a [`good first issue`](https://github.com/Hawksight-AI/semantica/labels/good%20first%20issue) or join our [Discord](https://discord.gg/ggb7vWeP) community.
 
 ---
 
@@ -15,7 +15,7 @@ Thank you for your interest in contributing! Every contribution, no matter how s
 3. Make your changes
 4. Submit a pull request!
 
-**Need help?** Join [Discord](https://discord.gg/vqRt2qbx) or [GitHub Discussions](https://github.com/Hawksight-AI/semantica/discussions)
+**Need help?** Join [Discord](https://discord.gg/ggb7vWeP) or [GitHub Discussions](https://github.com/Hawksight-AI/semantica/discussions)
 
 ---
 
@@ -108,7 +108,7 @@ Thank you for your interest in contributing! Every contribution, no matter how s
 
 **What:** Help others in the community
 
-**Where:** [Discord](https://discord.gg/vqRt2qbx), [GitHub Discussions](https://github.com/Hawksight-AI/semantica/discussions)
+**Where:** [Discord](https://discord.gg/ggb7vWeP), [GitHub Discussions](https://github.com/Hawksight-AI/semantica/discussions)
 
 **Examples:** Answer questions, review PRs, share your projects
 
@@ -326,7 +326,7 @@ result = instance.method()
 
 ## 🆘 Getting Help
 
-- 💬 [Discord](https://discord.gg/vqRt2qbx) - Real-time chat
+- 💬 [Discord](https://discord.gg/ggb7vWeP) - Real-time chat
 - 💭 [GitHub Discussions](https://github.com/Hawksight-AI/semantica/discussions) - Q&A
 - 🐛 [GitHub Issues](https://github.com/Hawksight-AI/semantica/issues) - Bug reports
 
@@ -363,4 +363,4 @@ This project follows a [Code of Conduct](CODE_OF_CONDUCT.md). Be respectful and 
 
 Every contribution matters - whether it's a single line of code, a typo fix, a helpful answer, or a bug report. We appreciate you! 🙏
 
-⭐ **Give us a Star** • 🍴 **[Fork Semantica](https://github.com/Hawksight-AI/semantica/fork)** • 💬 **Join our [Discord](https://discord.gg/vqRt2qbx)**
+⭐ **Give us a Star** • 🍴 **[Fork Semantica](https://github.com/Hawksight-AI/semantica/fork)** • 💬 **Join our [Discord](https://discord.gg/ggb7vWeP)**

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -4,7 +4,7 @@ Thank you to all the people who have contributed to Semantica! 🎉
 
 This project follows the [all-contributors](https://allcontributors.org) specification. Contributions of any kind are welcome!
 
-⭐ **Give us a Star** • 🍴 **Fork us** • 💬 **Join our [Discord](https://discord.gg/vqRt2qbx)**
+⭐ **Give us a Star** • 🍴 **Fork us** • 💬 **Join our [Discord](https://discord.gg/ggb7vWeP)**
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![PyPI](https://img.shields.io/pypi/v/semantica.svg)](https://pypi.org/project/semantica/)
 [![Total Downloads](https://static.pepy.tech/badge/semantica)](https://pepy.tech/project/semantica)
 [![CI](https://github.com/Hawksight-AI/semantica/workflows/CI/badge.svg)](https://github.com/Hawksight-AI/semantica/actions)
-[![Discord](https://img.shields.io/badge/Discord-Join-7289da?logo=discord&logoColor=white)](https://discord.gg/RgaGTj9J)
+[![Discord](https://img.shields.io/badge/Discord-Join-7289da?logo=discord&logoColor=white)](https://discord.gg/ggb7vWeP)
 
 ### ⭐ Give us a Star • 🍴 Fork us • 💬 Join our Discord
 
@@ -47,7 +47,7 @@ kg = GraphBuilder().build({"entities": entities, "relationships": []})
 print(f"Built KG with {len(kg.get('entities', []))} entities")
 ```
 
-**[📖 Full Quick Start](#-quick-start)** • **[🍳 Cookbook Examples](#-semantica-cookbook)** • **[💬 Join Discord](https://discord.gg/RgaGTj9J)** • **[⭐ Star Us](https://github.com/Hawksight-AI/semantica)**
+**[📖 Full Quick Start](#-quick-start)** • **[🍳 Cookbook Examples](#-semantica-cookbook)** • **[💬 Join Discord](https://discord.gg/ggb7vWeP)** • **[⭐ Star Us](https://github.com/Hawksight-AI/semantica)**
 
 ---
 
@@ -952,7 +952,7 @@ print(f"Found {len(results)} results")
 
 | **Channel** | **Purpose** |
 |:-----------:|:-----------|
-| [**Discord**](https://discord.gg/pMHguUzG) | Real-time help, showcases |
+| [**Discord**](https://discord.gg/ggb7vWeP) | Real-time help, showcases |
 | [**GitHub Discussions**](https://github.com/Hawksight-AI/semantica/discussions) | Q&A, feature requests |
 
 ### Learning Resources
@@ -963,7 +963,7 @@ print(f"Found {len(results)} results")
 Enterprise support, professional services, and commercial licensing will be available in the future. For now, we offer community support through Discord and GitHub Discussions.
 
 **Current Support:**
-- **Community Support** - Free support via [Discord](https://discord.gg/pMHguUzG) and [GitHub Discussions](https://github.com/Hawksight-AI/semantica/discussions)
+- **Community Support** - Free support via [Discord](https://discord.gg/ggb7vWeP) and [GitHub Discussions](https://github.com/Hawksight-AI/semantica/discussions)
 - **Bug Reports** - [GitHub Issues](https://github.com/Hawksight-AI/semantica/issues)
 
 **Future Enterprise Offerings:**
@@ -1015,4 +1015,4 @@ Semantica is licensed under the **MIT License** - see the [LICENSE](https://gith
 **Built by the Semantica Community**
 
 
-[GitHub](https://github.com/Hawksight-AI/semantica) • [Discord](https://discord.gg/RgaGTj9J)
+[GitHub](https://github.com/Hawksight-AI/semantica) • [Discord](https://discord.gg/ggb7vWeP)

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -27,7 +27,7 @@ Start with our comprehensive documentation:
 
 **Best for**: Real-time chat and quick questions
 
-- [Join Discord](https://discord.gg/pMHguUzG)
+- [Join Discord](https://discord.gg/ggb7vWeP)
 
 #### GitHub Issues
 

--- a/semantica/change_management/change_management_usage.md
+++ b/semantica/change_management/change_management_usage.md
@@ -1041,4 +1041,4 @@ manager = TemporalVersionManager(storage_path="large_data.db")
 For questions or issues:
 - GitHub Issues: https://github.com/Hawksight-AI/semantica/issues
 - Documentation: https://semantica.readthedocs.io
-- Community: https://discord.gg/semantica
+- Community: https://discord.gg/ggb7vWeP


### PR DESCRIPTION
## Summary
Updates all Discord links across documentation to point to the correct server.

## Changes
- **6 files updated**: README.md, CONTRIBUTING.md, CONTRIBUTORS.md, SUPPORT.md, .github/SUPPORT.md, semantica/change_management/change_management_usage.md
- **15 links updated**: All Discord links now point to `https://discord.gg/ggb7vWeP`
- **Consistent reference**: Ensures users join the correct Discord server

## Impact
- Fixes broken/incorrect Discord links
- Improves user experience with correct community access
- No breaking changes - purely documentation updates

## Testing
- Verified all links point to the correct Discord server
- No functional code changes
