### PR TITLE
fix: use RLock in ResourceScheduler to prevent deadlock

### DIFF
--- a/semantica/pipeline/resource_scheduler.py
+++ b/semantica/pipeline/resource_scheduler.py
@@ -109,7 +109,7 @@ class ResourceScheduler:
 
         self.resources: Dict[str, Resource] = {}
         self.allocations: Dict[str, ResourceAllocation] = {}
-        self.lock = threading.Lock()
+        self.lock = threading.RLock()  # RLock: allocate_resources holds lock and calls allocate_cpu/memory/gpu which also acquire it
 
         self._initialize_resources()
 


### PR DESCRIPTION
## Summary

- `ResourceScheduler.allocate_resources()` acquires `self.lock` (line 205) and then calls `allocate_cpu()`, `allocate_memory()`, and `allocate_gpu()`, each of which also attempt to acquire the same `self.lock` (lines 266, 305, 340).
- With `threading.Lock()` (non-reentrant), this causes a **deadlock** whenever `build_knowledge_base()` triggers the pipeline resource allocation path.
- Fix: change `threading.Lock()` → `threading.RLock()` so the same thread can re-enter the lock without blocking itself.

## Reproduction

```python
from semantica.core import Semantica, ConfigManager

config_manager = ConfigManager()
config = config_manager.load_from_file("config.yaml")

framework = Semantica(config=config)
framework.initialize()

# This hangs indefinitely (deadlock in ResourceScheduler.allocate_cpu)
kb_result = framework.build_knowledge_base(
    sources=["welcome_docs/apple.txt"],
)
```

## Change

One-line change in `semantica/pipeline/resource_scheduler.py`:

```diff
-        self.lock = threading.Lock()
+        self.lock = threading.RLock()
```

## Test plan

- [x] Verified `build_knowledge_base()` completes without deadlock after fix
- [x] Full pipeline (ingest → parse → extract → build KG → visualize → export) runs successfully
- [ ] Existing test suite passes