### PR TITLE
chore: promote 0.3.0-alpha to 0.3.0-beta for internal testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0-beta] - 2026-03-07
 
 - **Multi-Founder LLM Extraction & Reasoner Inference Fix** (PR #354 by @KaifAhmad1):
   - Fixed `_parse_relation_result` in `methods.py` — unmatched subjects/objects now produce a synthetic `UNKNOWN` entity instead of silently dropping the relation; all LLM-returned co-founders are preserved

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "semantica"
-version = "0.3.0-alpha"
+version = "0.3.0-beta"
 description = "🧠 Semantica - An Open Source Framework for building Semantic Layers and Knowledge Engineering"
 readme = "README.md"
 license = { text = "MIT" }
@@ -15,7 +15,7 @@ maintainers = [{ name = "Hawksight AI", email = "semantica-dev@users.noreply.git
 requires-python = ">=3.8"
 
 classifiers = [
-  "Development Status :: 3 - Alpha",
+  "Development Status :: 4 - Beta",
   "Intended Audience :: Developers",
   "Intended Audience :: Science/Research",
   "License :: OSI Approved :: MIT License",

--- a/semantica/__init__.py
+++ b/semantica/__init__.py
@@ -10,7 +10,7 @@ Main exports:
     - Config: Configuration management
 """
 
-__version__ = "0.2.7"
+__version__ = "0.3.0-beta"
 __author__ = "Semantica Contributors"
 __license__ = "MIT"
 


### PR DESCRIPTION
Bumps version in pyproject.toml and semantica/__init__.py from 0.3.0-alpha to 0.3.0-beta, updates PyPI classifier to Development Status 4 - Beta, and promotes all Unreleased CHANGELOG entries under the [0.3.0-beta] section.

## Description

<!-- Provide a clear description of your changes -->

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Related Issues

<!-- Link related issues using keywords like "Closes", "Fixes", "Resolves" -->

Closes #
Fixes #

## Changes Made

<!-- List the main changes in this PR -->

- 
- 
- 

## Testing

<!-- Describe how you tested your changes -->

- [ ] Tested locally
- [ ] Added tests for new functionality
- [ ] Package builds successfully (`python -m build`)

### Test Commands

```bash
# Build the package
pip install build
python -m build

# Optional: Run your own tests
pytest tests/

# Optional: Format code
black semantica/
isort semantica/
```

## Documentation

- [ ] Updated relevant documentation
- [ ] Added code examples if applicable
- [ ] Updated API reference if adding new APIs
- [ ] Updated cookbook if adding new examples
- [ ] No documentation changes needed

## Breaking Changes

**Breaking Changes**: [Yes/No]

<!-- If yes, describe the impact and migration path -->

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] Package builds successfully

## Additional Notes

<!-- Any additional information for reviewers -->
