### PR TITLE
Fix Blazegraph literal serialization in bulk loader (Fixes #448)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- **Fix: Blazegraph literal serialization and SPARQL injection hardening** (PR #448 by @KaifAhmad1):
+  - Fixed `_build_ntriples()`, `_build_insert_data()`, `find_triplets()`, and `delete_triplet()` in `BlazegraphStore` — all four methods previously unconditionally wrapped every triplet object in `<...>` as an IRI, causing Blazegraph to reject or misparse any triple whose object was a plain string, typed literal, or language-tagged literal.
+  - Added `_format_object_for_sparql(triplet)` — central formatter that selects the correct SPARQL/N-Triples token: IRI (`<uri>`), typed literal (`"value"^^<datatype>`), language-tagged literal (`"value"@lang`), or plain literal (`"value"`).
+  - Added `_resolve_datatype_iri(datatype)` — expands prefixed datatype names (`xsd:integer`, `rdf:langString`, `rdfs:Literal`, `owl:real`, `skos:notation`) to their full IRIs instead of producing invalid `<xsd:integer>` tokens. Accepts full `http/https/urn` IRIs and already-bracketed IRIs after whitespace validation. Rejects unknown prefixes and bare local names with a clear `ValueError`.
+  - Added language-tag validation against RFC 5646 (`^[a-zA-Z]{1,8}(-[a-zA-Z0-9]{1,8})*$`) — values containing whitespace, dots, or other punctuation (e.g. `"en . CLEAR ALL #"`) raise `ValueError` before interpolation, closing a SPARQL injection vector in `metadata["lang"]` / `metadata["language"]`.
+  - Added datatype-string validation — whitespace and SPARQL-delimiting characters inside `metadata["datatype"]` / `metadata["literal_datatype"]` raise `ValueError`, closing the parallel injection vector for typed literals.
+  - Added `_is_uri_value(value)` — URI detection using `urlparse`; rejects strings that only start with a URI scheme but contain whitespace (e.g. `"http not a uri"` is serialised as a literal, not an IRI).
+  - Added `_escape_literal(value)` — escapes `\`, `"`, `\n`, `\r`, `\t` inside literal strings before SPARQL interpolation.
+  - New test file `tests/triplet_store/test_blazegraph_store.py` — 15 offline unit tests covering URI serialization, plain/typed/language-tagged/escaped literals, prefix expansion, IRI passthrough, injection rejection, and `_build_insert_data` delegation; all run without a live Blazegraph instance.
+
 - **OWLGenerator user-facing schema compatibility fixes** (Issue #446):
   - Fixed OWL class/property IRI identifier fallback order to prefer `label` and then `name`.
   - Fixed datatype property handling to accept scalar and list `range` values in rdflib path (including `xsd:*`, full IRIs, and local names), preventing list-based `.startswith()` crashes.

--- a/semantica/triplet_store/blazegraph_store.py
+++ b/semantica/triplet_store/blazegraph_store.py
@@ -28,7 +28,7 @@ License: MIT
 """
 
 from typing import Any, Dict, List, Optional
-from urllib.parse import urljoin
+from urllib.parse import urljoin, urlparse
 
 import requests
 
@@ -238,7 +238,7 @@ class BlazegraphStore:
             lines = []
             for triplet in triplets:
                 lines.append(
-                    f"<{triplet.subject}> <{triplet.predicate}> <{triplet.object}> ."
+                    f"<{triplet.subject}> <{triplet.predicate}> {self._format_object_for_sparql(triplet)} ."
                 )
             return "\n".join(lines)
         else:
@@ -249,8 +249,55 @@ class BlazegraphStore:
         """Build SPARQL INSERT DATA clause."""
         lines = []
         for triplet in triplets:
-            lines.append(f"<{triplet.subject}> <{triplet.predicate}> <{triplet.object}> .")
+            lines.append(
+                f"<{triplet.subject}> <{triplet.predicate}> {self._format_object_for_sparql(triplet)} ."
+            )
         return " ".join(lines)
+
+    def _format_object_for_sparql(self, triplet: Triplet) -> str:
+        """Format triplet object as IRI or literal for SPARQL/N-Triples style syntax."""
+        obj = triplet.object
+        metadata = triplet.metadata or {}
+
+        if self._is_uri_value(obj):
+            if obj.startswith("<") and obj.endswith(">"):
+                return obj
+            return f"<{obj}>"
+
+        escaped = self._escape_literal(obj)
+        datatype = metadata.get("datatype") or metadata.get("literal_datatype")
+        language = metadata.get("lang") or metadata.get("language")
+
+        if datatype:
+            datatype_iri = datatype
+            if not datatype_iri.startswith("<"):
+                datatype_iri = f"<{datatype_iri}>"
+            return f"\"{escaped}\"^^{datatype_iri}"
+
+        if language:
+            return f"\"{escaped}\"@{language}"
+
+        return f"\"{escaped}\""
+
+    def _is_uri_value(self, value: str) -> bool:
+        """Detect if a value should be serialized as an IRI."""
+        if not isinstance(value, str) or not value:
+            return False
+        if value.startswith("<") and value.endswith(">"):
+            return True
+        parsed = urlparse(value)
+        return parsed.scheme in {"http", "https", "urn"}
+
+    def _escape_literal(self, value: str) -> str:
+        """Escape string literal for SPARQL."""
+        return (
+            str(value)
+            .replace("\\", "\\\\")
+            .replace("\"", "\\\"")
+            .replace("\n", "\\n")
+            .replace("\r", "\\r")
+            .replace("\t", "\\t")
+        )
 
     def add_triplet(self, triplet: Triplet, **options) -> Dict[str, Any]:
         """Add single triplet."""
@@ -275,7 +322,9 @@ class BlazegraphStore:
         if predicate:
             where_clauses.append(f"?p = <{predicate}>")
         if object:
-            where_clauses.append(f"?o = <{object}>")
+            where_clauses.append(
+                f"?o = {self._format_object_for_sparql(Triplet(subject='', predicate='', object=object))}"
+            )
 
         where_clause = " ".join(where_clauses) if where_clauses else ""
         query = f"SELECT ?s ?p ?o WHERE {{ ?s ?p ?o {where_clause} }}"
@@ -303,7 +352,10 @@ class BlazegraphStore:
 
         update_endpoint = self._get_update_endpoint()
 
-        query = f"DELETE DATA {{ <{triplet.subject}> <{triplet.predicate}> <{triplet.object}> }}"
+        query = (
+            f"DELETE DATA {{ <{triplet.subject}> <{triplet.predicate}> "
+            f"{self._format_object_for_sparql(triplet)} }}"
+        )
 
         try:
             response = requests.post(

--- a/semantica/triplet_store/blazegraph_store.py
+++ b/semantica/triplet_store/blazegraph_store.py
@@ -27,6 +27,7 @@ Author: Semantica Contributors
 License: MIT
 """
 
+import re
 from typing import Any, Dict, List, Optional
 from urllib.parse import urljoin, urlparse
 
@@ -254,6 +255,18 @@ class BlazegraphStore:
             )
         return " ".join(lines)
 
+    # Known prefix expansions for XSD and common RDF vocabularies
+    _KNOWN_PREFIXES: Dict[str, str] = {
+        "xsd": "http://www.w3.org/2001/XMLSchema#",
+        "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+        "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+        "owl": "http://www.w3.org/2002/07/owl#",
+        "skos": "http://www.w3.org/2004/02/skos/core#",
+    }
+
+    # RFC 5646 language tag: primary subtag optionally followed by '-' + subtags
+    _LANG_TAG_RE = re.compile(r"^[a-zA-Z]{1,8}(-[a-zA-Z0-9]{1,8})*$")
+
     def _format_object_for_sparql(self, triplet: Triplet) -> str:
         """Format triplet object as IRI or literal for SPARQL/N-Triples style syntax."""
         obj = triplet.object
@@ -261,6 +274,9 @@ class BlazegraphStore:
 
         if self._is_uri_value(obj):
             if obj.startswith("<") and obj.endswith(">"):
+                inner = obj[1:-1]
+                if " " in inner or ">" in inner:
+                    raise ValueError(f"IRI contains invalid characters: {obj!r}")
                 return obj
             return f"<{obj}>"
 
@@ -269,15 +285,53 @@ class BlazegraphStore:
         language = metadata.get("lang") or metadata.get("language")
 
         if datatype:
-            datatype_iri = datatype
-            if not datatype_iri.startswith("<"):
-                datatype_iri = f"<{datatype_iri}>"
+            datatype_iri = self._resolve_datatype_iri(datatype)
             return f"\"{escaped}\"^^{datatype_iri}"
 
         if language:
+            if not self._LANG_TAG_RE.match(str(language)):
+                raise ValueError(
+                    f"Invalid language tag {language!r}: must match RFC 5646 "
+                    f"(letters/digits and hyphens only, e.g. 'en', 'en-US')"
+                )
             return f"\"{escaped}\"@{language}"
 
         return f"\"{escaped}\""
+
+    def _resolve_datatype_iri(self, datatype: str) -> str:
+        """Expand a datatype string to a validated SPARQL IRI token.
+
+        Accepts:
+        - Already-wrapped IRIs: ``<http://...>``
+        - Full IRIs:            ``http://...`` / ``https://...`` / ``urn:...``
+        - Known prefixed names: ``xsd:integer``, ``rdf:langString``, etc.
+
+        Raises ValueError for anything else.
+        """
+        datatype = str(datatype)
+
+        # Already angle-bracketed — validate the inner IRI contains no whitespace
+        if datatype.startswith("<") and datatype.endswith(">"):
+            inner = datatype[1:-1]
+            if not inner or re.search(r"[\s<>\"{}|\\^`]", inner):
+                raise ValueError(f"Invalid datatype IRI: {datatype!r}")
+            return datatype
+
+        # Full absolute IRI without brackets
+        parsed = urlparse(datatype)
+        if parsed.scheme in {"http", "https", "urn"} and not re.search(r"[\s<>\"{}|\\^`]", datatype):
+            return f"<{datatype}>"
+
+        # Prefixed form — expand known prefixes only
+        if ":" in datatype:
+            prefix, local = datatype.split(":", 1)
+            if prefix in self._KNOWN_PREFIXES and re.match(r"^[A-Za-z0-9_\-\.]+$", local):
+                return f"<{self._KNOWN_PREFIXES[prefix]}{local}>"
+
+        raise ValueError(
+            f"Unsupported datatype {datatype!r}: use a full IRI (http/https/urn), "
+            f"an angle-bracketed IRI, or a known prefix (xsd/rdf/rdfs/owl/skos)."
+        )
 
     def _is_uri_value(self, value: str) -> bool:
         """Detect if a value should be serialized as an IRI."""
@@ -286,7 +340,10 @@ class BlazegraphStore:
         if value.startswith("<") and value.endswith(">"):
             return True
         parsed = urlparse(value)
-        return parsed.scheme in {"http", "https", "urn"}
+        if parsed.scheme not in {"http", "https", "urn"}:
+            return False
+        # Reject strings that only look like URIs (e.g. "http not a uri")
+        return not re.search(r"\s", value)
 
     def _escape_literal(self, value: str) -> str:
         """Escape string literal for SPARQL."""

--- a/tests/triplet_store/test_blazegraph_store.py
+++ b/tests/triplet_store/test_blazegraph_store.py
@@ -1,0 +1,113 @@
+import unittest
+import os
+import sys
+from unittest.mock import patch
+
+PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)
+
+from semantica.semantic_extract.triplet_extractor import Triplet
+from semantica.triplet_store.blazegraph_store import BlazegraphStore
+
+
+class TestBlazegraphStoreSerialization(unittest.TestCase):
+    @patch.object(BlazegraphStore, "_connect", autospec=True)
+    def test_format_object_serializes_uri_object(self, _mock_connect):
+        store = BlazegraphStore(endpoint="http://localhost:9999/blazegraph")
+        triplet = Triplet(
+            subject="urn:entity:person:1",
+            predicate="urn:property:knows",
+            object="urn:entity:person:2",
+        )
+        obj = store._format_object_for_sparql(triplet)
+        self.assertEqual(
+            obj,
+            "<urn:entity:person:2>",
+        )
+
+    @patch.object(BlazegraphStore, "_connect", autospec=True)
+    def test_format_object_serializes_literal_object(self, _mock_connect):
+        store = BlazegraphStore(endpoint="http://localhost:9999/blazegraph")
+        triplet = Triplet(
+            subject="urn:entity:person:1",
+            predicate="urn:property:name",
+            object="Jane Doe",
+        )
+        obj = store._format_object_for_sparql(triplet)
+        self.assertEqual(
+            obj,
+            "\"Jane Doe\"",
+        )
+
+    @patch.object(BlazegraphStore, "_connect", autospec=True)
+    def test_format_object_escapes_literal_object(self, _mock_connect):
+        store = BlazegraphStore(endpoint="http://localhost:9999/blazegraph")
+        triplet = Triplet(
+            subject="urn:entity:person:1",
+            predicate="urn:property:note",
+            object='line "one"\\line2',
+        )
+        obj = store._format_object_for_sparql(triplet)
+        self.assertEqual(
+            obj,
+            "\"line \\\"one\\\"\\\\line2\"",
+        )
+
+    @patch.object(BlazegraphStore, "_connect", autospec=True)
+    def test_format_object_serializes_typed_literal(self, _mock_connect):
+        store = BlazegraphStore(endpoint="http://localhost:9999/blazegraph")
+        triplet = Triplet(
+            subject="urn:entity:person:1",
+            predicate="urn:property:age",
+            object="42",
+            metadata={"datatype": "http://www.w3.org/2001/XMLSchema#integer"},
+        )
+        obj = store._format_object_for_sparql(triplet)
+        self.assertEqual(
+            obj,
+            "\"42\"^^<http://www.w3.org/2001/XMLSchema#integer>",
+        )
+
+    @patch.object(BlazegraphStore, "_connect", autospec=True)
+    def test_build_insert_data_uses_formatter(self, _mock_connect):
+        store = BlazegraphStore(endpoint="http://localhost:9999/blazegraph")
+        triplet = Triplet(
+            subject="urn:entity:person:1",
+            predicate="urn:property:name",
+            object="Jane Doe",
+        )
+        with patch.object(store, "_format_object_for_sparql", return_value="\"Jane Doe\"") as mock_fmt:
+            insert_data = store._build_insert_data([triplet])
+            mock_fmt.assert_called_once_with(triplet)
+            self.assertEqual(
+                insert_data,
+                "<urn:entity:person:1> <urn:property:name> \"Jane Doe\" .",
+            )
+
+    @patch.object(BlazegraphStore, "_connect", autospec=True)
+    def test_format_object_serializes_language_literal(self, _mock_connect):
+        store = BlazegraphStore(endpoint="http://localhost:9999/blazegraph")
+        triplet = Triplet(
+            subject="urn:entity:person:1",
+            predicate="urn:property:label",
+            object="Color",
+            metadata={"lang": "en"},
+        )
+        obj = store._format_object_for_sparql(triplet)
+        self.assertEqual(obj, "\"Color\"@en")
+
+    @patch.object(BlazegraphStore, "_connect", autospec=True)
+    def test_format_object_does_not_treat_invalid_uri_like_text_as_uri(self, _mock_connect):
+        store = BlazegraphStore(endpoint="http://localhost:9999/blazegraph")
+        triplet = Triplet(
+            subject="urn:entity:person:1",
+            predicate="urn:property:note",
+            object="http not a uri",
+        )
+        obj = store._format_object_for_sparql(triplet)
+        self.assertEqual(obj, "\"http not a uri\"")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/triplet_store/test_blazegraph_store.py
+++ b/tests/triplet_store/test_blazegraph_store.py
@@ -108,6 +108,118 @@ class TestBlazegraphStoreSerialization(unittest.TestCase):
         obj = store._format_object_for_sparql(triplet)
         self.assertEqual(obj, "\"http not a uri\"")
 
+    # --- Bug 1: prefixed datatype expansion ---
+
+    @patch.object(BlazegraphStore, "_connect", autospec=True)
+    def test_format_object_expands_xsd_prefix_to_full_iri(self, _mock_connect):
+        store = BlazegraphStore(endpoint="http://localhost:9999/blazegraph")
+        triplet = Triplet(
+            subject="urn:entity:person:1",
+            predicate="urn:property:age",
+            object="42",
+            metadata={"datatype": "xsd:integer"},
+        )
+        obj = store._format_object_for_sparql(triplet)
+        self.assertEqual(
+            obj,
+            "\"42\"^^<http://www.w3.org/2001/XMLSchema#integer>",
+        )
+
+    @patch.object(BlazegraphStore, "_connect", autospec=True)
+    def test_format_object_expands_rdf_prefix_to_full_iri(self, _mock_connect):
+        store = BlazegraphStore(endpoint="http://localhost:9999/blazegraph")
+        triplet = Triplet(
+            subject="urn:entity:person:1",
+            predicate="urn:property:value",
+            object="hello",
+            metadata={"datatype": "rdf:langString"},
+        )
+        obj = store._format_object_for_sparql(triplet)
+        self.assertEqual(
+            obj,
+            "\"hello\"^^<http://www.w3.org/1999/02/22-rdf-syntax-ns#langString>",
+        )
+
+    @patch.object(BlazegraphStore, "_connect", autospec=True)
+    def test_format_object_rejects_unknown_prefix(self, _mock_connect):
+        store = BlazegraphStore(endpoint="http://localhost:9999/blazegraph")
+        triplet = Triplet(
+            subject="urn:entity:person:1",
+            predicate="urn:property:value",
+            object="hello",
+            metadata={"datatype": "myns:customType"},
+        )
+        with self.assertRaises(ValueError):
+            store._format_object_for_sparql(triplet)
+
+    # --- Bug 2: metadata injection validation ---
+
+    @patch.object(BlazegraphStore, "_connect", autospec=True)
+    def test_format_object_rejects_injected_lang_tag(self, _mock_connect):
+        store = BlazegraphStore(endpoint="http://localhost:9999/blazegraph")
+        triplet = Triplet(
+            subject="urn:entity:person:1",
+            predicate="urn:property:label",
+            object="Color",
+            metadata={"lang": "en . CLEAR ALL #"},
+        )
+        with self.assertRaises(ValueError):
+            store._format_object_for_sparql(triplet)
+
+    @patch.object(BlazegraphStore, "_connect", autospec=True)
+    def test_format_object_rejects_datatype_with_whitespace(self, _mock_connect):
+        store = BlazegraphStore(endpoint="http://localhost:9999/blazegraph")
+        triplet = Triplet(
+            subject="urn:entity:person:1",
+            predicate="urn:property:age",
+            object="42",
+            metadata={"datatype": "http://example.org/type CLEAR ALL"},
+        )
+        with self.assertRaises(ValueError):
+            store._format_object_for_sparql(triplet)
+
+    @patch.object(BlazegraphStore, "_connect", autospec=True)
+    def test_format_object_accepts_full_iri_datatype_no_brackets(self, _mock_connect):
+        store = BlazegraphStore(endpoint="http://localhost:9999/blazegraph")
+        triplet = Triplet(
+            subject="urn:entity:person:1",
+            predicate="urn:property:age",
+            object="42",
+            metadata={"datatype": "http://www.w3.org/2001/XMLSchema#integer"},
+        )
+        obj = store._format_object_for_sparql(triplet)
+        self.assertEqual(
+            obj,
+            "\"42\"^^<http://www.w3.org/2001/XMLSchema#integer>",
+        )
+
+    @patch.object(BlazegraphStore, "_connect", autospec=True)
+    def test_format_object_accepts_bracketed_iri_datatype(self, _mock_connect):
+        store = BlazegraphStore(endpoint="http://localhost:9999/blazegraph")
+        triplet = Triplet(
+            subject="urn:entity:person:1",
+            predicate="urn:property:age",
+            object="42",
+            metadata={"datatype": "<http://www.w3.org/2001/XMLSchema#integer>"},
+        )
+        obj = store._format_object_for_sparql(triplet)
+        self.assertEqual(
+            obj,
+            "\"42\"^^<http://www.w3.org/2001/XMLSchema#integer>",
+        )
+
+    @patch.object(BlazegraphStore, "_connect", autospec=True)
+    def test_format_object_accepts_hyphenated_lang_tag(self, _mock_connect):
+        store = BlazegraphStore(endpoint="http://localhost:9999/blazegraph")
+        triplet = Triplet(
+            subject="urn:entity:person:1",
+            predicate="urn:property:label",
+            object="Colour",
+            metadata={"lang": "en-GB"},
+        )
+        obj = store._format_object_for_sparql(triplet)
+        self.assertEqual(obj, "\"Colour\"@en-GB")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Problem

All triplet objects in `BlazegraphStore` were unconditionally serialized as IRIs (`<object>`), even when the object was a plain string literal, a typed literal (e.g. `xsd:integer`), or a language-tagged literal (e.g. `"Color"@en`).

This caused Blazegraph to reject or silently misparse any triple whose object was not a valid absolute IRI — including names, labels, numeric values, and any literal data stored in the graph.

Affected methods:
- `_build_ntriples()` — used in N-Triples bulk uploads
- `_build_insert_data()` — used in SPARQL `INSERT DATA` updates
- `find_triplets()` — object filter in `WHERE` clause
- `delete_triplet()` — `DELETE DATA` statement

---

## Changes

### `semantica/triplet_store/blazegraph_store.py`

- Added `_format_object_for_sparql(triplet)` — central formatter that detects whether the object value is a URI or literal and produces the correct SPARQL/N-Triples token:
  - URIs (`http://`, `https://`, `urn:`, or already angle-bracketed) → `<uri>`
  - Typed literals (via `metadata["datatype"]` or `metadata["literal_datatype"]`) → `"value"^^<datatype>`
  - Language-tagged literals (via `metadata["lang"]` or `metadata["language"]`) → `"value"@lang`
  - Plain literals → `"value"`
- Added `_is_uri_value(value)` — URI detection using `urlparse`, avoids false positives on strings like `"http not a uri"`
- Added `_escape_literal(value)` — escapes `\`, `"`, `\n`, `\r`, `\t` inside literal strings
- Updated all four affected call sites to use `_format_object_for_sparql()`
- Added `urlparse` to imports

### `tests/triplet_store/test_blazegraph_store.py` *(new file)*

7 unit tests covering the serialization logic, all running offline via `unittest.mock`:

| Test | Scenario |
|---|---|
| `test_format_object_serializes_uri_object` | `urn:` object → IRI token |
| `test_format_object_serializes_literal_object` | plain string → quoted literal |
| `test_format_object_escapes_literal_object` | `"` and `\` in literal → escaped |
| `test_format_object_serializes_typed_literal` | `metadata["datatype"]` → `^^<xsd:integer>` |
| `test_format_object_serializes_language_literal` | `metadata["lang"]` → `@en` tag |
| `test_build_insert_data_uses_formatter` | `_build_insert_data` delegates to `_format_object_for_sparql` |
| `test_format_object_does_not_treat_invalid_uri_like_text_as_uri` | `"http not a uri"` → literal, not IRI |

---

## Test plan

- [ ] Run `python -m pytest tests/triplet_store/test_blazegraph_store.py -v` — all 7 tests pass offline
- [ ] Manual integration check against a live Blazegraph instance: insert triples with plain literals, typed literals (`xsd:integer`, `xsd:date`), and language-tagged literals; confirm SPARQL `SELECT` returns correct values
- [ ] Confirm `find_triplets(object="some literal")` no longer generates invalid SPARQL
- [ ] Confirm `delete_triplet()` with a literal-object triple issues a valid `DELETE DATA` statement


Fixes #448
