### PR TITLE
fix(triplet-store): resolve entity/class/property IRIs against ontolo…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- **Fix: TripletStore.store() IRI resolution regressions** (PR #447 follow-up by @KaifAhmad1):
+  - Fixed `AttributeError` crash when entity or relationship IDs are non-string types (e.g. integers emitted by `GraphBuilder`). `_resolve_iri()` previously called `.startswith()` directly on the raw ID; it now coerces any value to `str()` at entry, restoring the implicit stringification that the old f-string URN minting provided.
+  - Fixed W3C vocabulary prefixes (`owl:Thing`, `xsd:date`, `rdfs:Literal`, `skos:Concept`, etc.) being incorrectly re-namespaced under the ontology `base_uri` (e.g. `https://example.com/owl:Thing`) when `base_uri` was present. `_resolve_iri()` now consults a known-prefix expansion table (`xsd`, `rdf`, `rdfs`, `owl`, `skos`, `semantica`) before applying `base_uri`, matching the same prefix map already used in `BlazegraphStore`. Standard vocabulary IRIs are always expanded to their canonical W3C forms regardless of what `base_uri` is set to.
+  - Added 5 regression tests: integer IDs with and without `base_uri`, `owl:Thing` domain/range, `xsd:date` range, and `skos:Concept` parent class expansion. Total tests in `TestTripletStoreOntologyNamespace`: 14.
+
+- **Fix: TripletStore.store() ignores ontology namespace base_uri** (PR #447 by @KaifAhmad1):
+  - `store(knowledge_graph, ontology)` was minting `urn:entity:{id}`, `urn:class:{type}`, and `urn:property:{name}` URIs for all bare local names, even when `ontology.namespace.base_uri` was present. This made instance data and ontology class data irreconcilable in SPARQL joins.
+  - Extracts `base_uri` once from `ontology["namespace"]["base_uri"]` (with `ontology["uri"]` as fallback) and ensures a trailing separator so concatenation is always a valid IRI path.
+  - Introduced `_resolve_iri(local, kind)` closure applied to all 7 IRI-minting sites: entity URIs, entity types, relationship predicates, ontology class URIs, parent class URIs, property URIs, and domain/range URIs. Explicit `entity["uri"]` values are never overridden. Falls back to `urn:` only when no `base_uri` is available.
+  - Added 9 tests in `TestTripletStoreOntologyNamespace` covering all expansion paths, `urn:` fallback, explicit URI passthrough, top-level `uri` key fallback, and trailing-slash safety.
+
 - **Fix: Blazegraph literal serialization and SPARQL injection hardening** (PR #448 by @KaifAhmad1):
   - Fixed `_build_ntriples()`, `_build_insert_data()`, `find_triplets()`, and `delete_triplet()` in `BlazegraphStore` — all four methods previously unconditionally wrapped every triplet object in `<...>` as an IRI, causing Blazegraph to reject or misparse any triple whose object was a plain string, typed literal, or language-tagged literal.
   - Added `_format_object_for_sparql(triplet)` — central formatter that selects the correct SPARQL/N-Triples token: IRI (`<uri>`), typed literal (`"value"^^<datatype>`), language-tagged literal (`"value"@lang`), or plain literal (`"value"`).

--- a/semantica/triplet_store/triplet_store.py
+++ b/semantica/triplet_store/triplet_store.py
@@ -170,6 +170,30 @@ class TripletStore:
         RDFS_DOMAIN = "http://www.w3.org/2000/01/rdf-schema#domain"
         RDFS_RANGE = "http://www.w3.org/2000/01/rdf-schema#range"
 
+        # Resolve base URI from ontology — used to mint entity/class/property IRIs
+        # that are reconcilable with the ontology's own namespace.
+        ns = ontology.get("namespace") or {}
+        if isinstance(ns, dict):
+            base_uri = ns.get("base_uri") or ontology.get("uri") or ""
+        else:
+            base_uri = ontology.get("uri") or ""
+        # Ensure trailing separator so "base_uri + local" is always a valid IRI path.
+        if base_uri and not base_uri.endswith(("/", "#")):
+            base_uri = base_uri + "/"
+
+        def _resolve_iri(local: str, kind: str) -> str:
+            """Expand a bare local name to a full IRI.
+
+            If *base_uri* is available the local name is appended to it so the
+            resulting IRI sits in the same namespace as the ontology classes.
+            Falls back to ``urn:<kind>:<local>`` only when no base URI is known.
+            """
+            if local.startswith("http") or local.startswith("urn:"):
+                return local
+            if base_uri:
+                return f"{base_uri}{local}"
+            return f"urn:{kind}:{local}"
+
         # 1. Process Ontology
         classes = ontology.get("classes", [])
         properties = ontology.get("properties", [])
@@ -180,18 +204,13 @@ class TripletStore:
             if not cls_uri:
                 continue
 
-            if not cls_uri.startswith("http") and not cls_uri.startswith("urn:"):
-                # Fallback if no URI provided
-                cls_uri = f"urn:class:{cls_uri}"
-
+            cls_uri = _resolve_iri(cls_uri, "class")
             triplets.append(Triplet(cls_uri, RDF_TYPE, OWL_CLASS))
 
             # Hierarchy
             parent = cls.get("parent") or cls.get("subClassOf")
             if parent:
-                parent_uri = parent
-                if not parent.startswith("http") and not parent.startswith("urn:"):
-                    parent_uri = f"urn:class:{parent}"
+                parent_uri = _resolve_iri(parent, "class")
                 triplets.append(Triplet(cls_uri, RDFS_SUBCLASS, parent_uri))
 
         for prop in properties:
@@ -199,8 +218,7 @@ class TripletStore:
             if not prop_uri:
                 continue
 
-            if not prop_uri.startswith("http") and not prop_uri.startswith("urn:"):
-                prop_uri = f"urn:property:{prop_uri}"
+            prop_uri = _resolve_iri(prop_uri, "property")
 
             # Determine property type (Object or Datatype)
             # Default to ObjectProperty if not specified
@@ -218,9 +236,7 @@ class TripletStore:
                     domains = [domains]
 
                 for domain in domains:
-                    domain_uri = domain
-                    if not domain.startswith("http") and not domain.startswith("urn:"):
-                        domain_uri = f"urn:class:{domain}"
+                    domain_uri = _resolve_iri(domain, "class")
                     triplets.append(Triplet(prop_uri, RDFS_DOMAIN, domain_uri))
 
             if "range" in prop:
@@ -229,9 +245,7 @@ class TripletStore:
                     ranges = [ranges]
 
                 for range_ in ranges:
-                    range_uri = range_
-                    if not range_.startswith("http") and not range_.startswith("urn:"):
-                        range_uri = f"urn:class:{range_}"
+                    range_uri = _resolve_iri(range_, "class")
                     triplets.append(Triplet(prop_uri, RDFS_RANGE, range_uri))
 
         # 2. Process Knowledge Graph
@@ -245,28 +259,19 @@ class TripletStore:
             if not entity_id:
                 continue
 
-            entity_uri = entity.get("uri")
-            if not entity_uri:
-                entity_uri = f"urn:entity:{entity_id}"
-
+            entity_uri = entity.get("uri") or _resolve_iri(entity_id, "entity")
             entity_map[entity_id] = entity_uri
 
             # Entity Type
             entity_type = entity.get("type")
             if entity_type:
-                type_uri = entity_type
-                if not entity_type.startswith("http") and not entity_type.startswith(
-                    "urn:"
-                ):
-                    type_uri = f"urn:class:{entity_type}"
+                type_uri = _resolve_iri(entity_type, "class")
                 triplets.append(Triplet(entity_uri, RDF_TYPE, type_uri))
 
             # Entity Properties
             props = entity.get("properties", {})
             for k, v in props.items():
-                prop_uri = k
-                if not k.startswith("http") and not k.startswith("urn:"):
-                    prop_uri = f"urn:property:{k}"
+                prop_uri = _resolve_iri(k, "property")
                 triplets.append(Triplet(entity_uri, prop_uri, str(v)))
 
         for rel in relationships:
@@ -277,11 +282,9 @@ class TripletStore:
             if not source_id or not target_id or not rel_type:
                 continue
 
-            source_uri = entity_map.get(source_id, f"urn:entity:{source_id}")
-            target_uri = entity_map.get(target_id, f"urn:entity:{target_id}")
-            rel_uri = rel_type
-            if not rel_type.startswith("http") and not rel_type.startswith("urn:"):
-                rel_uri = f"urn:property:{rel_type}"
+            source_uri = entity_map.get(source_id) or _resolve_iri(source_id, "entity")
+            target_uri = entity_map.get(target_id) or _resolve_iri(target_id, "entity")
+            rel_uri = _resolve_iri(rel_type, "property")
 
             triplets.append(Triplet(source_uri, rel_uri, target_uri))
 

--- a/semantica/triplet_store/triplet_store.py
+++ b/semantica/triplet_store/triplet_store.py
@@ -181,15 +181,40 @@ class TripletStore:
         if base_uri and not base_uri.endswith(("/", "#")):
             base_uri = base_uri + "/"
 
-        def _resolve_iri(local: str, kind: str) -> str:
+        # Known W3C vocabulary prefixes — expanded before base_uri is applied so
+        # values like "owl:Thing" or "xsd:date" are never re-namespaced under
+        # the ontology's own base URI.
+        _KNOWN_PREFIXES = {
+            "xsd":      "http://www.w3.org/2001/XMLSchema#",
+            "rdf":      "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+            "rdfs":     "http://www.w3.org/2000/01/rdf-schema#",
+            "owl":      "http://www.w3.org/2002/07/owl#",
+            "skos":     "http://www.w3.org/2004/02/skos/core#",
+            "semantica": "https://semantica.dev/ontology/",
+        }
+
+        def _resolve_iri(local: object, kind: str) -> str:
             """Expand a bare local name to a full IRI.
 
-            If *base_uri* is available the local name is appended to it so the
-            resulting IRI sits in the same namespace as the ontology classes.
-            Falls back to ``urn:<kind>:<local>`` only when no base URI is known.
+            Accepts any type for *local* — non-strings are coerced via str()
+            so integer/numeric IDs passed from graph builders do not crash.
+
+            Resolution order:
+            1. Already an absolute IRI (http / https / urn:) → return as-is.
+            2. Known vocabulary prefix (xsd:, rdf:, rdfs:, owl:, skos:,
+               semantica:) → expand to the canonical W3C IRI.
+            3. base_uri is set → append local name to base_uri.
+            4. Fallback → ``urn:<kind>:<local>``.
             """
-            if local.startswith("http") or local.startswith("urn:"):
+            local = str(local) if local is not None else ""
+            if not local:
+                return f"urn:{kind}:unknown"
+            if local.startswith(("http://", "https://", "urn:")):
                 return local
+            if ":" in local:
+                prefix, name = local.split(":", 1)
+                if prefix in _KNOWN_PREFIXES:
+                    return f"{_KNOWN_PREFIXES[prefix]}{name}"
             if base_uri:
                 return f"{base_uri}{local}"
             return f"urn:{kind}:{local}"

--- a/tests/triplet_store/test_triplet_store.py
+++ b/tests/triplet_store/test_triplet_store.py
@@ -601,3 +601,78 @@ class TestTripletStoreOntologyNamespace(unittest.TestCase):
         subjects = {t.subject for t in captured}
         self.assertIn("https://example.com/alice", subjects)
         self.assertNotIn("https://example.com//alice", subjects)
+
+    # --- Bug: non-string IDs crash store ---
+
+    def test_integer_entity_id_does_not_crash(self, mock_bg):
+        """Integer entity IDs must be coerced to str, not crash with AttributeError."""
+        store, captured = self._make_store(mock_bg)
+        kg = {
+            "entities": [
+                {"id": 1, "type": "Person"},
+                {"id": 2, "type": "Person"},
+            ],
+            "relationships": [{"source": 1, "target": 2, "type": "knows"}],
+        }
+        store.store(kg, self._ontology())
+        subjects = {t.subject for t in captured}
+        self.assertIn(f"{self.BASE}1", subjects)
+        self.assertIn(f"{self.BASE}2", subjects)
+        predicates = {t.predicate for t in captured}
+        self.assertIn(f"{self.BASE}knows", predicates)
+
+    def test_integer_entity_id_fallback_to_urn(self, mock_bg):
+        """Integer IDs fall back to urn: when no base_uri is set."""
+        store, captured = self._make_store(mock_bg)
+        kg = {"entities": [{"id": 42, "type": "Person"}], "relationships": []}
+        ontology = {"classes": [], "properties": []}
+        store.store(kg, ontology)
+        subjects = {t.subject for t in captured}
+        self.assertIn("urn:entity:42", subjects)
+
+    # --- Bug: prefixed W3C terms mis-resolved under base_uri ---
+
+    def test_owl_thing_domain_not_rewritten_under_base_uri(self, mock_bg):
+        """owl:Thing in domain/range must expand to the W3C OWL IRI, not base_uri + 'owl:Thing'."""
+        store, captured = self._make_store(mock_bg)
+        ontology = {
+            "namespace": {"base_uri": self.BASE},
+            "classes": [],
+            "properties": [{"name": "hasThing", "domain": ["owl:Thing"], "range": ["owl:Thing"]}],
+        }
+        store.store({"entities": [], "relationships": []}, ontology)
+        RDFS_DOMAIN = "http://www.w3.org/2000/01/rdf-schema#domain"
+        RDFS_RANGE = "http://www.w3.org/2000/01/rdf-schema#range"
+        domain_objects = {t.object for t in captured if t.predicate == RDFS_DOMAIN}
+        range_objects = {t.object for t in captured if t.predicate == RDFS_RANGE}
+        self.assertIn("http://www.w3.org/2002/07/owl#Thing", domain_objects)
+        self.assertNotIn(f"{self.BASE}owl:Thing", domain_objects)
+        self.assertIn("http://www.w3.org/2002/07/owl#Thing", range_objects)
+
+    def test_xsd_date_range_not_rewritten_under_base_uri(self, mock_bg):
+        """xsd:date in range must expand to the W3C XSD IRI, not base_uri + 'xsd:date'."""
+        store, captured = self._make_store(mock_bg)
+        ontology = {
+            "namespace": {"base_uri": self.BASE},
+            "classes": [],
+            "properties": [{"name": "birthDate", "range": ["xsd:date"]}],
+        }
+        store.store({"entities": [], "relationships": []}, ontology)
+        RDFS_RANGE = "http://www.w3.org/2000/01/rdf-schema#range"
+        range_objects = {t.object for t in captured if t.predicate == RDFS_RANGE}
+        self.assertIn("http://www.w3.org/2001/XMLSchema#date", range_objects)
+        self.assertNotIn(f"{self.BASE}xsd:date", range_objects)
+
+    def test_rdfs_and_skos_prefixes_expanded_correctly(self, mock_bg):
+        """rdfs: and skos: prefixes in class URIs and parent links expand to W3C IRIs."""
+        store, captured = self._make_store(mock_bg)
+        ontology = {
+            "namespace": {"base_uri": self.BASE},
+            "classes": [{"name": "Concept", "parent": "skos:Concept"}],
+            "properties": [],
+        }
+        store.store({"entities": [], "relationships": []}, ontology)
+        RDFS_SUBCLASS = "http://www.w3.org/2000/01/rdf-schema#subClassOf"
+        parent_objects = {t.object for t in captured if t.predicate == RDFS_SUBCLASS}
+        self.assertIn("http://www.w3.org/2004/02/skos/core#Concept", parent_objects)
+        self.assertNotIn(f"{self.BASE}skos:Concept", parent_objects)

--- a/tests/triplet_store/test_triplet_store.py
+++ b/tests/triplet_store/test_triplet_store.py
@@ -482,3 +482,122 @@ class TestSKOSTripletStore(unittest.TestCase):
             return_value=QueryResult(bindings=[], variables=[])
         )
         self.assertEqual(store.get_skos_concepts(), [])
+
+
+@patch("semantica.triplet_store.blazegraph_store.BlazegraphStore")
+class TestTripletStoreOntologyNamespace(unittest.TestCase):
+    """Regression tests for Issue #447 — store() must use ontology namespace base_uri."""
+
+    BASE = "https://example.com/"
+
+    def _make_store(self, mock_bg):
+        """Return (store, captured_triplets_list).
+
+        add_triplets is patched so store() never touches the bulk_loader or
+        backend; instead every Triplet passed to it is appended to the list.
+        """
+        captured = []
+
+        def _capture(triplets, **_kw):
+            captured.extend(triplets)
+            return {"success": True}
+
+        with (
+            patch("semantica.triplet_store.triplet_store.get_logger", return_value=MagicMock()),
+            patch("semantica.triplet_store.triplet_store.get_progress_tracker", return_value=MagicMock()),
+        ):
+            store = TripletStore(backend="blazegraph")
+        store.add_triplets = _capture
+        return store, captured
+
+    def _ontology(self):
+        return {
+            "namespace": {"base_uri": self.BASE},
+            "classes": [{"name": "Person"}],
+            "properties": [{"name": "knows", "domain": ["Person"], "range": ["Person"]}],
+        }
+
+    def _kg(self):
+        return {
+            "entities": [
+                {"id": "alice", "type": "Person"},
+                {"id": "bob", "type": "Person"},
+            ],
+            "relationships": [{"source": "alice", "target": "bob", "type": "knows"}],
+        }
+
+    def test_entity_uri_uses_base_uri(self, mock_bg):
+        store, captured = self._make_store(mock_bg)
+        store.store(self._kg(), self._ontology())
+        subjects = {t.subject for t in captured}
+        self.assertIn(f"{self.BASE}alice", subjects)
+        self.assertIn(f"{self.BASE}bob", subjects)
+        self.assertNotIn("urn:entity:alice", subjects)
+
+    def test_entity_type_uses_base_uri(self, mock_bg):
+        store, captured = self._make_store(mock_bg)
+        store.store(self._kg(), self._ontology())
+        RDF_TYPE = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+        type_objects = {t.object for t in captured if t.predicate == RDF_TYPE}
+        self.assertIn(f"{self.BASE}Person", type_objects)
+        self.assertNotIn("urn:class:Person", type_objects)
+
+    def test_relationship_type_uses_base_uri(self, mock_bg):
+        store, captured = self._make_store(mock_bg)
+        store.store(self._kg(), self._ontology())
+        predicates = {t.predicate for t in captured}
+        self.assertIn(f"{self.BASE}knows", predicates)
+        self.assertNotIn("urn:property:knows", predicates)
+
+    def test_ontology_class_uri_uses_base_uri(self, mock_bg):
+        store, captured = self._make_store(mock_bg)
+        store.store(self._kg(), self._ontology())
+        OWL_CLASS = "http://www.w3.org/2002/07/owl#Class"
+        class_subjects = {t.subject for t in captured if t.object == OWL_CLASS}
+        self.assertIn(f"{self.BASE}Person", class_subjects)
+
+    def test_ontology_property_domain_range_use_base_uri(self, mock_bg):
+        store, captured = self._make_store(mock_bg)
+        store.store(self._kg(), self._ontology())
+        RDFS_DOMAIN = "http://www.w3.org/2000/01/rdf-schema#domain"
+        RDFS_RANGE = "http://www.w3.org/2000/01/rdf-schema#range"
+        domain_objects = {t.object for t in captured if t.predicate == RDFS_DOMAIN}
+        range_objects = {t.object for t in captured if t.predicate == RDFS_RANGE}
+        self.assertIn(f"{self.BASE}Person", domain_objects)
+        self.assertIn(f"{self.BASE}Person", range_objects)
+
+    def test_explicit_entity_uri_not_overridden(self, mock_bg):
+        store, captured = self._make_store(mock_bg)
+        kg = {"entities": [{"id": "alice", "uri": "https://other.org/Alice", "type": "Person"}], "relationships": []}
+        store.store(kg, self._ontology())
+        subjects = {t.subject for t in captured}
+        self.assertIn("https://other.org/Alice", subjects)
+        self.assertNotIn(f"{self.BASE}alice", subjects)
+
+    def test_no_base_uri_falls_back_to_urn(self, mock_bg):
+        store, captured = self._make_store(mock_bg)
+        kg = {"entities": [{"id": "alice", "type": "Person"}], "relationships": []}
+        ontology = {"classes": [{"name": "Person"}], "properties": []}
+        store.store(kg, ontology)
+        subjects = {t.subject for t in captured}
+        self.assertIn("urn:entity:alice", subjects)
+
+    def test_base_uri_via_top_level_uri_key(self, mock_bg):
+        """ontology['uri'] should work as a fallback when namespace dict is absent."""
+        store, captured = self._make_store(mock_bg)
+        ontology = {"uri": self.BASE, "classes": [{"name": "Person"}], "properties": []}
+        kg = {"entities": [{"id": "alice", "type": "Person"}], "relationships": []}
+        store.store(kg, ontology)
+        subjects = {t.subject for t in captured}
+        self.assertIn(f"{self.BASE}alice", subjects)
+
+    def test_trailing_slash_not_doubled(self, mock_bg):
+        """base_uri already ending with '/' must not produce 'base//local'."""
+        store, captured = self._make_store(mock_bg)
+        ontology = {"namespace": {"base_uri": "https://example.com/"}, "classes": [], "properties": []}
+        # Give alice a type so a triplet is emitted with alice as subject
+        kg = {"entities": [{"id": "alice", "type": "Person"}], "relationships": []}
+        store.store(kg, ontology)
+        subjects = {t.subject for t in captured}
+        self.assertIn("https://example.com/alice", subjects)
+        self.assertNotIn("https://example.com//alice", subjects)


### PR DESCRIPTION
## Problem

`TripletStore.store(knowledge_graph, ontology)` ignored `ontology.namespace.base_uri` entirely when resolving entity and type URIs.

Ontology **classes** were stored with their correct IRIs (e.g. `https://example.com/Person`) because they carry an explicit `uri` field. But **entities** in the knowledge graph always fell back to `urn:entity:{id}`, and their **types** always fell back to `urn:class:{type}` — even when a `namespace.base_uri` was present in the same ontology argument.

The result: ontology data and instance data landed in the triple store under completely different namespaces, so any SPARQL query joining them returned nothing.

**Before:**
```sparql
# Ontology stored as:
<https://example.com/Person> rdf:type owl:Class .

# Instance stored as:
<urn:entity:alice> rdf:type <urn:class:Person> .

# JOIN returns 0 results — namespaces never meet
SELECT ?e WHERE { ?e rdf:type <https://example.com/Person> }
```

**After:**
```sparql
# Both stored under the same namespace:
<https://example.com/Person> rdf:type owl:Class .
<https://example.com/alice>  rdf:type <https://example.com/Person> .

# JOIN works correctly
SELECT ?e WHERE { ?e rdf:type <https://example.com/Person> }
# → https://example.com/alice
```

---

## Root Cause

Every bare local name in `store()` was passed through a hardcoded fallback chain:

```python
if not entity_type.startswith("http") and not entity_type.startswith("urn:"):
    type_uri = f"urn:class:{entity_type}"
```

The same pattern appeared in 7 separate places — entity URIs, entity types, relationship predicates, ontology class URIs, parent class URIs, property URIs, and domain/range URIs — none of which consulted the ontology namespace.

---

## Changes

### `semantica/triplet_store/triplet_store.py`

- Extracts `base_uri` once at the start of `store()`:
  - Primary source: `ontology["namespace"]["base_uri"]`
  - Fallback: `ontology["uri"]`
  - Ensures a trailing `/` or `#` separator so `base_uri + local_name` is always a valid IRI path
- Introduces `_resolve_iri(local, kind)` closure:
  - If the value is already a full IRI (`http`, `https`, `urn:`) — return as-is
  - If `base_uri` is known — return `base_uri + local`
  - Otherwise — return `urn:<kind>:<local>` (unchanged fallback for callers with no namespace)
- Replaces all 7 hardcoded `urn:` fallback blocks with `_resolve_iri()`
- Explicit `entity["uri"]` values are **never overridden**

### `tests/triplet_store/test_triplet_store.py`

9 new tests in `TestTripletStoreOntologyNamespace`:

| Test | Scenario |
|---|---|
| `test_entity_uri_uses_base_uri` | Entity IDs expanded to `base_uri + id` |
| `test_entity_type_uses_base_uri` | `rdf:type` objects use ontology namespace |
| `test_relationship_type_uses_base_uri` | Relationship predicates use ontology namespace |
| `test_ontology_class_uri_uses_base_uri` | Ontology class subjects use ontology namespace |
| `test_ontology_property_domain_range_use_base_uri` | `rdfs:domain`/`rdfs:range` objects use ontology namespace |
| `test_explicit_entity_uri_not_overridden` | Explicit `entity["uri"]` is never replaced |
| `test_no_base_uri_falls_back_to_urn` | No namespace → `urn:` fallback preserved |
| `test_base_uri_via_top_level_uri_key` | `ontology["uri"]` works when `namespace` dict is absent |
| `test_trailing_slash_not_doubled` | `base_uri` already ending with `/` does not produce `//` |

---

## Test plan

- [ ] Run `python -m pytest tests/triplet_store/test_triplet_store.py -v` — all 32 tests pass
- [ ] Manual: call `store(kg, ontology)` where `ontology["namespace"]["base_uri"] = "https://example.com/"` and confirm entities and their types appear under `https://example.com/` in the triple store
- [ ] Manual: confirm a SPARQL `SELECT` joining ontology classes and instance data returns results
- [ ] Confirm existing behaviour is unchanged when `ontology` carries no `namespace` or `uri` key (URNs still emitted)

Fixes #447
