### PR TITLE
feat(explorer): refine focused neighborhood view

### DIFF
--- a/explorer/src/workspaces/GraphWorkspace/GraphCanvas.tsx
+++ b/explorer/src/workspaces/GraphWorkspace/GraphCanvas.tsx
@@ -1241,13 +1241,15 @@ export const GraphCanvas = forwardRef<GraphCanvasHandle, GraphCanvasProps>(
         return;
       }
 
-      const bounds = computeGraphSpaceBounds(currentDisplayGraph, selectionNodeIds);
+      const bounds = computeDisplayedNodeBounds(sigma, selectionNodeIds);
       if (!bounds) {
         if (attempt < 3) {
-          debugGraphRuntime("camera-selection-deferred", {
+          debugGraphRuntime("camera-selection-display-bounds-deferred", {
             nodeId,
             graphVersion: graphVersionRef.current,
             attempt: attempt + 1,
+            viewMode: viewModeRef.current,
+            contextCount: selectionNodeIds.length,
           });
           if (deferredFocusFrameRef.current !== null) {
             window.cancelAnimationFrame(deferredFocusFrameRef.current);
@@ -1257,10 +1259,11 @@ export const GraphCanvas = forwardRef<GraphCanvasHandle, GraphCanvasProps>(
             centerSelectionInViewInternal(nodeId, attempt + 1);
           });
         } else {
-          debugGraphRuntime("camera-selection-fallback-fit", {
+          debugGraphRuntime("camera-selection-display-bounds-fallback-fit", {
             nodeId,
             graphVersion: graphVersionRef.current,
             viewMode: viewModeRef.current,
+            contextCount: selectionNodeIds.length,
           });
           fitDisplayGraphInView();
         }
@@ -1286,6 +1289,7 @@ export const GraphCanvas = forwardRef<GraphCanvasHandle, GraphCanvasProps>(
       animateCameraToBounds("fit-selection-context", selectionBBox, {
         nodeId,
         contextCount: bounds.count,
+        boundsSource: "displayed-selection-context",
         minX: bounds.minX,
         maxX: bounds.maxX,
         minY: bounds.minY,
@@ -1296,6 +1300,63 @@ export const GraphCanvas = forwardRef<GraphCanvasHandle, GraphCanvasProps>(
         referenceMaxY: globalBounds?.maxY ?? null,
       });
     }, [animateCameraToBounds, fitDisplayGraphInView]);
+
+    const centerFocusedSelectionInView = useCallback((nodeId: string) => {
+      const sigma = sigmaRef.current;
+      if (!sigma) {
+        return;
+      }
+
+      const currentDisplayGraph = displayGraphRef.current;
+      const selectionNodeIds = collectSelectionContextNodeIds(
+        currentDisplayGraph,
+        displayStateRef.current,
+        nodeId,
+      );
+      if (selectionNodeIds.length === 0) {
+        debugGraphRuntime("camera-focused-selection-missing-node", {
+          nodeId,
+          graphVersion: graphVersionRef.current,
+          viewMode: viewModeRef.current,
+        });
+        return;
+      }
+
+      const bounds = computeDisplayedNodeBounds(sigma, selectionNodeIds);
+      if (!bounds) {
+        debugGraphRuntime("camera-focused-selection-display-bounds-missing", {
+          nodeId,
+          graphVersion: graphVersionRef.current,
+          viewMode: viewModeRef.current,
+          contextCount: selectionNodeIds.length,
+        });
+        return;
+      }
+
+      const camera = sigma.getCamera();
+      const currentCameraState = camera.getState();
+      const target = {
+        x: (bounds.minX + bounds.maxX) / 2,
+        y: (bounds.minY + bounds.maxY) / 2,
+        ratio: currentCameraState.ratio,
+        angle: currentCameraState.angle,
+      };
+
+      debugGraphRuntime("camera-focused-selection-center", {
+        nodeId,
+        graphVersion: graphVersionRef.current,
+        viewMode: viewModeRef.current,
+        contextCount: bounds.count,
+        targetX: target.x,
+        targetY: target.y,
+        preservedRatio: target.ratio,
+      });
+
+      void camera.animate(
+        target,
+        { duration: GRAPH_THEME.motion.cameraMs, easing: "quadraticOut" },
+      );
+    }, []);
 
     const centerGroupedSelectionInView = useCallback((nodeId: string) => {
       const sigma = sigmaRef.current;
@@ -1415,13 +1476,14 @@ export const GraphCanvas = forwardRef<GraphCanvasHandle, GraphCanvasProps>(
         onEdgeSelectionChange: (edgeId: string) => onEdgeClickRef.current?.(edgeId),
         focusNodeInView,
         centerSelectionInView,
+        centerFocusedSelectionInView,
         centerGroupedSelectionInView,
         fitCurrentView,
         dispatchAction,
       };
       behaviorContextRef.current = context;
       return context;
-    }, [centerGroupedSelectionInView, centerSelectionInView, dispatchAction, fitCurrentView, focusNodeInView]);
+    }, [centerFocusedSelectionInView, centerGroupedSelectionInView, centerSelectionInView, dispatchAction, fitCurrentView, focusNodeInView]);
 
     const dispatchToBehaviors = useCallback((
       hook: "onNodeEnter" | "onNodeLeave" | "onNodeClick" | "onEdgeClick" | "onStageClick" | "onCameraChange",

--- a/explorer/src/workspaces/GraphWorkspace/behaviors/focusCameraBehavior.ts
+++ b/explorer/src/workspaces/GraphWorkspace/behaviors/focusCameraBehavior.ts
@@ -15,6 +15,11 @@ export const focusCameraBehavior: GraphBehavior = {
       return true;
     }
 
+    if (action.type === "centerFocusedSelection") {
+      context.centerFocusedSelectionInView(action.nodeId);
+      return true;
+    }
+
     if (action.type === "centerGroupedSelection") {
       context.centerGroupedSelectionInView(action.nodeId);
       return true;

--- a/explorer/src/workspaces/GraphWorkspace/behaviors/searchFocusBehavior.ts
+++ b/explorer/src/workspaces/GraphWorkspace/behaviors/searchFocusBehavior.ts
@@ -28,7 +28,11 @@ export function createSearchFocusBehavior(): GraphBehavior {
       lastSelectedNodeId = nextSelectedNodeId;
       lastViewMode = nextViewMode;
       context.dispatchAction({
-        type: nextViewMode === "grouped" ? "centerGroupedSelection" : "centerSelection",
+        type: nextViewMode === "grouped"
+          ? "centerGroupedSelection"
+          : nextViewMode === "focused"
+            ? "centerFocusedSelection"
+            : "centerSelection",
         nodeId: nextSelectedNodeId,
       });
     },

--- a/explorer/src/workspaces/GraphWorkspace/behaviors/types.ts
+++ b/explorer/src/workspaces/GraphWorkspace/behaviors/types.ts
@@ -8,6 +8,7 @@ export type GraphBehaviorActionRequest =
   | { type: "fitView" }
   | { type: "focusNode"; nodeId: string }
   | { type: "centerSelection"; nodeId: string }
+  | { type: "centerFocusedSelection"; nodeId: string }
   | { type: "centerGroupedSelection"; nodeId: string };
 
 export interface GraphBehaviorContext {
@@ -20,6 +21,7 @@ export interface GraphBehaviorContext {
   onEdgeSelectionChange: (edgeId: string) => void;
   focusNodeInView: (nodeId: string) => void;
   centerSelectionInView: (nodeId: string) => void;
+  centerFocusedSelectionInView: (nodeId: string) => void;
   centerGroupedSelectionInView: (nodeId: string) => void;
   fitCurrentView: () => void;
   dispatchAction: (action: GraphBehaviorActionRequest) => void;

--- a/explorer/src/workspaces/GraphWorkspace/graphSceneState.ts
+++ b/explorer/src/workspaces/GraphWorkspace/graphSceneState.ts
@@ -28,8 +28,6 @@ import type {
 } from "./types";
 
 const MAX_FOCUS_NEIGHBORS = GRAPH_THEME.focus.maxNeighbors;
-const FOCUS_RING_CAPACITY = GRAPH_THEME.focus.ringCapacity;
-const FOCUS_RING_GAP = GRAPH_THEME.focus.ringGap;
 const FOCUS_PRIMARY_LABELS = GRAPH_THEME.focus.primaryLabels;
 const COLLAPSE_VISIBLE_NEIGHBORS = 8;
 const GROUP_SAMPLE_MEMBERS = 8;
@@ -64,6 +62,13 @@ const OWNED_DISPLAY_META: GraphDisplayMeta = {
   positionSource: "display",
   tracksStoreNodePositions: false,
   hasSyntheticNodes: true,
+};
+
+const FOCUSED_DISPLAY_META: GraphDisplayMeta = {
+  layoutMode: "owned",
+  positionSource: "display",
+  tracksStoreNodePositions: false,
+  hasSyntheticNodes: false,
 };
 
 function getOverviewPresenceBoost(cameraRatio: number) {
@@ -1395,6 +1400,188 @@ function createCollapsedNeighborhoodGraph(
   return collapsedGraph;
 }
 
+type FocusedNeighborZone = "primary" | "secondary";
+
+type FocusedNeighborEntry = {
+  id: string;
+  attrs: NodeAttributes;
+  isPath: boolean;
+  zone: FocusedNeighborZone;
+  weight: number;
+  degree: number;
+  score: number;
+  labelPriority: number;
+  radius: number;
+  x: number;
+  y: number;
+  size: number;
+};
+
+const FOCUS_PRIMARY_ANCHOR_DEGREES = [-90, -18, 42, 110, 180, -150, -72];
+const FOCUS_SECONDARY_ANCHOR_DEGREES = [-56, -6, 54, 122, 174, -140, -92, -34, 90, 146];
+
+function angleDegreesToRadians(angle: number) {
+  return (angle * Math.PI) / 180;
+}
+
+function getAnchoredAngles(count: number, anchorDegrees: readonly number[]): number[] {
+  if (count <= 0) {
+    return [];
+  }
+  if (count <= anchorDegrees.length) {
+    return anchorDegrees.slice(0, count).map(angleDegreesToRadians);
+  }
+  return Array.from({ length: count }, (_value, index) => ((Math.PI * 2 * index) / count) - Math.PI / 2);
+}
+
+function seedFocusedRing(
+  entries: FocusedNeighborEntry[],
+  radius: number,
+  anchorDegrees: readonly number[],
+) {
+  const anchors = getAnchoredAngles(entries.length, anchorDegrees);
+  entries.forEach((entry, index) => {
+    const angle = anchors[index] ?? ((Math.PI * 2 * index) / Math.max(entries.length, 1)) - Math.PI / 2;
+    entry.radius = radius;
+    entry.x = Math.cos(angle) * radius;
+    entry.y = Math.sin(angle) * radius;
+  });
+}
+
+function relaxFocusedNeighborPositions(
+  entries: FocusedNeighborEntry[],
+  selectedRadius: number,
+) {
+  if (entries.length === 0) {
+    return;
+  }
+
+  const iterations = GRAPH_THEME.focus.overlapIterations;
+  const padding = GRAPH_THEME.focus.overlapPadding;
+  for (let iteration = 0; iteration < iterations; iteration += 1) {
+    for (let leftIndex = 0; leftIndex < entries.length; leftIndex += 1) {
+      const left = entries[leftIndex];
+      for (let rightIndex = leftIndex + 1; rightIndex < entries.length; rightIndex += 1) {
+        const right = entries[rightIndex];
+        const dx = right.x - left.x;
+        const dy = right.y - left.y;
+        const distance = Math.hypot(dx, dy) || 0.001;
+        const minimumDistance = (left.size / 2) + (right.size / 2) + padding;
+        if (distance >= minimumDistance) {
+          continue;
+        }
+
+        const overlap = minimumDistance - distance;
+        const ux = dx / distance;
+        const uy = dy / distance;
+        const shift = overlap * 0.5;
+        left.x -= ux * shift;
+        left.y -= uy * shift;
+        right.x += ux * shift;
+        right.y += uy * shift;
+      }
+    }
+
+    entries.forEach((entry) => {
+      const distanceFromCenter = Math.hypot(entry.x, entry.y) || 0.001;
+      const centerMinimum = selectedRadius + (entry.size / 2) + padding * 0.8;
+      if (distanceFromCenter < centerMinimum) {
+        const push = centerMinimum - distanceFromCenter;
+        entry.x += (entry.x / distanceFromCenter) * push;
+        entry.y += (entry.y / distanceFromCenter) * push;
+      }
+
+      const desiredRadius = entry.radius;
+      if (desiredRadius > 0) {
+        const drift = desiredRadius - Math.hypot(entry.x, entry.y);
+        const currentDistance = Math.hypot(entry.x, entry.y) || 0.001;
+        entry.x += (entry.x / currentDistance) * drift * 0.1;
+        entry.y += (entry.y / currentDistance) * drift * 0.1;
+      }
+    });
+  }
+}
+
+function buildFocusedNeighbors(
+  nodeId: string,
+  visibleNeighborIds: string[],
+  rankedNeighbors: string[],
+  pathNodeIds: Set<string>,
+): FocusedNeighborEntry[] {
+  const rankedIndex = new Map(rankedNeighbors.map((neighborId, index) => [neighborId, index]));
+  const neighbors = visibleNeighborIds
+    .map((neighborId) => {
+      const attrs = graph.getNodeAttributes(neighborId) as NodeAttributes;
+      const weight = getEdgeWeightBetween(nodeId, neighborId);
+      const degree = graph.hasNode(neighborId) ? graph.degree(neighborId) : 0;
+      const rank = rankedIndex.get(neighborId) ?? rankedNeighbors.length;
+      const isPath = pathNodeIds.has(neighborId);
+      const score = (isPath ? 10_000 : 0) + (weight * 100) + (degree * 2) + Math.max(0, MAX_FOCUS_NEIGHBORS - rank);
+      return {
+        id: neighborId,
+        attrs,
+        isPath,
+        zone: "secondary" as FocusedNeighborZone,
+        weight,
+        degree,
+        score,
+        labelPriority: 0,
+        radius: 0,
+        x: 0,
+        y: 0,
+        size: Math.max(Number(attrs.baseSize ?? attrs.size ?? 4), 1),
+      };
+    })
+    .sort((left, right) => {
+      if (right.score !== left.score) {
+        return right.score - left.score;
+      }
+      return left.id.localeCompare(right.id);
+    });
+
+  const primaryTarget = Math.min(
+    GRAPH_THEME.focus.primaryRingSlots,
+    Math.max(FOCUS_PRIMARY_LABELS, Math.ceil(neighbors.length * 0.45)),
+  );
+  let primaryCount = 0;
+  neighbors.forEach((entry) => {
+    if (primaryCount < primaryTarget || entry.isPath) {
+      entry.zone = "primary";
+      primaryCount += 1;
+    }
+  });
+
+  const primaryEntries = neighbors.filter((entry) => entry.zone === "primary");
+  const secondaryEntries = neighbors.filter((entry) => entry.zone === "secondary");
+  seedFocusedRing(primaryEntries, GRAPH_THEME.focus.primaryRadius, FOCUS_PRIMARY_ANCHOR_DEGREES);
+  seedFocusedRing(secondaryEntries, GRAPH_THEME.focus.secondaryRadius, FOCUS_SECONDARY_ANCHOR_DEGREES);
+
+  neighbors.forEach((entry, index) => {
+    const primaryLabelBoost = entry.zone === "primary" && index < FOCUS_PRIMARY_LABELS;
+    entry.labelPriority = entry.isPath || primaryLabelBoost ? 1.15 : entry.zone === "primary" ? 0.7 : 0.35;
+    entry.size = entry.isPath
+      ? Math.max(Number(entry.attrs.baseSize ?? entry.attrs.size ?? 4) * 1.16, GRAPH_THEME.focus.primaryNeighborMinSize)
+      : entry.zone === "primary"
+        ? Math.max(Number(entry.attrs.baseSize ?? entry.attrs.size ?? 4) * 1.08, GRAPH_THEME.focus.primaryNeighborMinSize)
+        : Math.max(Number(entry.attrs.baseSize ?? entry.attrs.size ?? 4) * 0.86, GRAPH_THEME.focus.secondaryNeighborMinSize);
+  });
+
+  relaxFocusedNeighborPositions(neighbors, GRAPH_THEME.focus.selectedMinSize);
+  return neighbors;
+}
+
+function scoreFocusedSupportEdge(
+  attrs: EdgeAttributes,
+  sourceId: string,
+  targetId: string,
+  primaryNeighborIds: Set<string>,
+) {
+  const rawEdgeCount = collectRawEdgeIds(attrs).length;
+  const weight = Number(attrs.representativeWeight ?? attrs.weight ?? 1);
+  const primaryBoost = primaryNeighborIds.has(sourceId) && primaryNeighborIds.has(targetId) ? 1.5 : 0;
+  return weight * 4 + rawEdgeCount + primaryBoost;
+}
+
 function aggregateDisplayGraph(graphRef: GraphRef): Graph<NodeAttributes, EdgeAttributes> {
   const aggregated = new Graph<NodeAttributes, EdgeAttributes>({
     type: "directed",
@@ -1826,9 +2013,12 @@ export function createFocusedGraph(
       };
   const visibleNeighborIds = rankedNeighbors.filter((neighborId) => collapsedState.selectedVisibleNeighborIds.includes(neighborId));
   const focusIds = new Set<string>([nodeId, ...visibleNeighborIds]);
-  const labelledNeighborIds = new Set(visibleNeighborIds.slice(0, FOCUS_PRIMARY_LABELS));
   const pathNodeIds = new Set(activePath);
   const pathEdgeIds = buildPathEdgeSet(graph, activePath, activePathEdgeIds);
+  const neighborEntries = buildFocusedNeighbors(nodeId, visibleNeighborIds, rankedNeighbors, pathNodeIds);
+  const primaryNeighborIds = new Set(
+    neighborEntries.filter((entry) => entry.zone === "primary").map((entry) => entry.id),
+  );
 
   const addNode = (id: string, attrs: NodeAttributes) => {
     if (!focused.hasNode(id)) {
@@ -1837,31 +2027,37 @@ export function createFocusedGraph(
   };
 
   const selectedAttrs = graph.getNodeAttributes(nodeId) as NodeAttributes;
-  const selectedState = resolveNodeElementStyle(GRAPH_THEME, "inspection", "selected", selectedAttrs, selectedAttrs.label);
+  const selectedState = resolveNodeElementStyle(
+    GRAPH_THEME,
+    "inspection",
+    "selected",
+    {
+      ...selectedAttrs,
+      labelPriority: 2,
+      labelVisibilityPolicy: "always",
+      haloColor: withAlpha(GRAPH_THEME.palette.accent.selected, 0.26),
+    },
+    selectedAttrs.label,
+  );
   addNode(nodeId, {
     ...selectedAttrs,
-    x: Number.isFinite(selectedAttrs.x) ? selectedAttrs.x : 0,
-    y: Number.isFinite(selectedAttrs.y) ? selectedAttrs.y : 0,
+    x: 0,
+    y: 0,
     color: selectedState.color,
-    size: Math.max(selectedState.size, 22),
+    size: Math.max(selectedState.size * 1.08, GRAPH_THEME.focus.selectedMinSize),
     baseColor: selectedState.color,
-    baseSize: Math.max(selectedState.size, 22),
+    baseSize: Math.max(selectedState.size * 1.08, GRAPH_THEME.focus.selectedMinSize),
     label: selectedState.label,
+    labelPriority: 2,
+    labelVisibilityPolicy: "always",
+    ringColor: GRAPH_THEME.palette.accent.selected,
+    haloColor: withAlpha(GRAPH_THEME.palette.accent.selected, 0.24),
   });
 
-  visibleNeighborIds.forEach((neighborId, index) => {
-    const baseAttrs = graph.getNodeAttributes(neighborId) as NodeAttributes;
-    const ring = Math.floor(index / FOCUS_RING_CAPACITY);
-    const ringIndex = index % FOCUS_RING_CAPACITY;
-    const itemsInRing = Math.min(
-      FOCUS_RING_CAPACITY,
-      rankedNeighbors.length - ring * FOCUS_RING_CAPACITY,
-    );
-    const radius = FOCUS_RING_GAP * (ring + 1);
-    const angle = (Math.PI * 2 * ringIndex) / itemsInRing - Math.PI / 2;
-    const visualState: GraphNodeVisualState = pathNodeIds.has(neighborId)
+  neighborEntries.forEach((entry) => {
+    const visualState: GraphNodeVisualState = entry.isPath
       ? "path"
-      : labelledNeighborIds.has(neighborId)
+      : entry.zone === "primary"
         ? "neighbor"
         : "default";
     const style = resolveNodeElementStyle(
@@ -1869,50 +2065,137 @@ export function createFocusedGraph(
       "inspection",
       visualState,
       {
-        ...baseAttrs,
-        labelPriority: labelledNeighborIds.has(neighborId) || pathNodeIds.has(neighborId)
-          ? Math.max(Number(baseAttrs.labelPriority ?? 0), 1)
-          : 0,
+        ...entry.attrs,
+        labelPriority: entry.labelPriority,
+        labelVisibilityPolicy: entry.isPath || entry.zone === "primary" ? "priority" : "none",
+        haloColor: entry.isPath
+          ? withAlpha(GRAPH_THEME.palette.accent.path, 0.16)
+          : entry.zone === "primary"
+            ? withAlpha(entry.attrs.color, 0.12)
+            : withAlpha(entry.attrs.color, 0.06),
       },
-      baseAttrs.label,
+      entry.attrs.label,
     );
 
-    addNode(neighborId, {
-      ...baseAttrs,
-      x: Number.isFinite(baseAttrs.x) ? baseAttrs.x : Math.cos(angle) * radius,
-      y: Number.isFinite(baseAttrs.y) ? baseAttrs.y : Math.sin(angle) * radius,
+    addNode(entry.id, {
+      ...entry.attrs,
+      x: entry.x,
+      y: entry.y,
       color: style.color,
-      size: Math.max(style.size, 8.5),
+      size: Math.max(entry.size, style.size),
       baseColor: style.color,
-      baseSize: Math.max(style.size, 8.5),
+      baseSize: Math.max(entry.size, style.size),
       label: style.label,
+      labelPriority: entry.labelPriority,
+      labelVisibilityPolicy: entry.isPath || entry.zone === "primary" ? "priority" : "none",
+      haloColor: entry.isPath
+        ? withAlpha(GRAPH_THEME.palette.accent.path, 0.16)
+        : entry.zone === "primary"
+          ? withAlpha(style.color, 0.1)
+          : withAlpha(style.color, 0.05),
     });
   });
 
-  for (const source of focusIds) {
-    for (const target of focusIds) {
-      if (source === target) {
-        continue;
-      }
-      forEachDirectedEdgeBetween(graph, source, target, (edgeId, attrs) => {
-        const state: GraphEdgeVisualState = pathEdgeIds.has(edgeId)
-          ? "path"
-          : source === nodeId || target === nodeId
-            ? "selected"
-            : "neighbor";
-        const style = resolveEdgeElementStyle(GRAPH_THEME, "inspection", state, attrs, source, target);
-        focused.mergeDirectedEdgeWithKey(edgeId, source, target, {
-          ...attrs,
-          type: style.type,
-          size: style.size,
-          color: style.color,
-          baseSize: style.size,
-          baseColor: style.color,
-          curvature: style.curvature,
-        });
-      });
-    }
+  const focusedEdgeIds = collectFocusEdgeIds(graph, focusIds);
+  const retainedSupportEdgeIds = new Set(
+    Array.from(focusedEdgeIds)
+      .filter((edgeId) => {
+        if (!graph.hasEdge(edgeId) || pathEdgeIds.has(edgeId)) {
+          return false;
+        }
+        const [edgeSourceId, edgeTargetId] = graph.extremities(edgeId);
+        return edgeSourceId !== nodeId && edgeTargetId !== nodeId;
+      })
+      .sort((leftEdgeId, rightEdgeId) => {
+        const leftAttrs = graph.getEdgeAttributes(leftEdgeId) as EdgeAttributes;
+        const rightAttrs = graph.getEdgeAttributes(rightEdgeId) as EdgeAttributes;
+        const [leftSourceId, leftTargetId] = graph.extremities(leftEdgeId);
+        const [rightSourceId, rightTargetId] = graph.extremities(rightEdgeId);
+        const scoreDelta = scoreFocusedSupportEdge(
+          rightAttrs,
+          rightSourceId,
+          rightTargetId,
+          primaryNeighborIds,
+        ) - scoreFocusedSupportEdge(
+          leftAttrs,
+          leftSourceId,
+          leftTargetId,
+          primaryNeighborIds,
+        );
+        if (scoreDelta !== 0) {
+          return scoreDelta;
+        }
+        return leftEdgeId.localeCompare(rightEdgeId);
+      })
+      .slice(0, GRAPH_THEME.focus.supportEdgeBudget),
+  );
+  let loggedFocusedEdgeSkip = false;
+
+  if (DEBUG_GRAPH_SCENE_STATE) {
+    console.debug("[graphSceneState]", "focused-graph-build", {
+      nodeId,
+      focusedNodeCount: focusIds.size,
+      focusedEdgeCount: focusedEdgeIds.size,
+      retainedSupportEdgeCount: retainedSupportEdgeIds.size,
+    });
   }
+
+  focusedEdgeIds.forEach((edgeId) => {
+    if (!graph.hasEdge(edgeId)) {
+      return;
+    }
+
+    const [edgeSourceId, edgeTargetId] = graph.extremities(edgeId);
+    if (!focusIds.has(edgeSourceId) || !focusIds.has(edgeTargetId)) {
+      if (DEBUG_GRAPH_SCENE_STATE && !loggedFocusedEdgeSkip) {
+        loggedFocusedEdgeSkip = true;
+        console.debug("[graphSceneState]", "focused-edge-skipped-outside-focus", {
+          nodeId,
+          edgeId,
+          edgeSourceId,
+          edgeTargetId,
+          focusedNodeCount: focusIds.size,
+        });
+      }
+      return;
+    }
+
+    const attrs = graph.getEdgeAttributes(edgeId) as EdgeAttributes;
+    const isPathEdge = pathEdgeIds.has(edgeId);
+    const isSelectedIncidentEdge = edgeSourceId === nodeId || edgeTargetId === nodeId;
+    if (!isPathEdge && !isSelectedIncidentEdge && !retainedSupportEdgeIds.has(edgeId)) {
+      return;
+    }
+    const state: GraphEdgeVisualState = pathEdgeIds.has(edgeId)
+      ? "path"
+      : edgeSourceId === nodeId || edgeTargetId === nodeId
+        ? "selected"
+        : "neighbor";
+    const style = resolveEdgeElementStyle(GRAPH_THEME, "inspection", state, attrs, edgeSourceId, edgeTargetId);
+    const styledEdgeSize = Number(style.size ?? attrs.size ?? attrs.baseSize ?? 1);
+    const styledEdgeColor = style.color ?? attrs.color ?? GRAPH_THEME.palette.muted.edgeFocus;
+    const renderedSize = isSelectedIncidentEdge
+      ? Math.max(styledEdgeSize, 2)
+      : isPathEdge
+        ? Math.max(styledEdgeSize, 2.4)
+        : Math.max(styledEdgeSize * 0.62, 0.85);
+    const renderedColor = isSelectedIncidentEdge
+      ? styledEdgeColor
+      : isPathEdge
+        ? styledEdgeColor
+        : withAlpha(styledEdgeColor, 0.34);
+    focused.mergeDirectedEdgeWithKey(edgeId, edgeSourceId, edgeTargetId, {
+      ...attrs,
+      type: isSelectedIncidentEdge || isPathEdge ? style.type : "line",
+      size: renderedSize,
+      color: renderedColor,
+      baseSize: renderedSize,
+      baseColor: renderedColor,
+      curvature: isSelectedIncidentEdge || isPathEdge ? style.curvature : 0,
+      arrowVisibilityPolicy: isSelectedIncidentEdge || isPathEdge ? attrs.arrowVisibilityPolicy : "hidden",
+      visualPriority: isPathEdge ? 1.5 : isSelectedIncidentEdge ? 1.2 : 0.34,
+    });
+  });
 
   return aggregateDisplayGraph(focused);
 }
@@ -1964,7 +2247,7 @@ export function resolveDisplayGraph(
     return {
       graph: createFocusedGraph(selectedNodeId, activePath, activePathEdgeIds, shouldCollapseNeighborhood),
       state: displayState,
-      meta: MIRRORED_DISPLAY_META,
+      meta: FOCUSED_DISPLAY_META,
     };
   }
 

--- a/explorer/src/workspaces/GraphWorkspace/graphSceneState.ts
+++ b/explorer/src/workspaces/GraphWorkspace/graphSceneState.ts
@@ -1493,10 +1493,12 @@ function relaxFocusedNeighborPositions(
 
       const desiredRadius = entry.radius;
       if (desiredRadius > 0) {
-        const drift = desiredRadius - Math.hypot(entry.x, entry.y);
-        const currentDistance = Math.hypot(entry.x, entry.y) || 0.001;
-        entry.x += (entry.x / currentDistance) * drift * 0.1;
-        entry.y += (entry.y / currentDistance) * drift * 0.1;
+        const currentDistance = Math.hypot(entry.x, entry.y);
+        if (currentDistance > centerMinimum) {
+          const drift = desiredRadius - currentDistance;
+          entry.x += (entry.x / currentDistance) * drift * GRAPH_THEME.focus.ringAttractionStrength;
+          entry.y += (entry.y / currentDistance) * drift * GRAPH_THEME.focus.ringAttractionStrength;
+        }
       }
     });
   }
@@ -1516,7 +1518,7 @@ function buildFocusedNeighbors(
       const degree = graph.hasNode(neighborId) ? graph.degree(neighborId) : 0;
       const rank = rankedIndex.get(neighborId) ?? rankedNeighbors.length;
       const isPath = pathNodeIds.has(neighborId);
-      const score = (isPath ? 10_000 : 0) + (weight * 100) + (degree * 2) + Math.max(0, MAX_FOCUS_NEIGHBORS - rank);
+      const score = (isPath ? GRAPH_THEME.focus.pathScoreBoost : 0) + (weight * GRAPH_THEME.focus.weightScoreScale) + (degree * GRAPH_THEME.focus.degreeScoreScale) + Math.max(0, MAX_FOCUS_NEIGHBORS - rank);
       return {
         id: neighborId,
         attrs,
@@ -1543,11 +1545,13 @@ function buildFocusedNeighbors(
     GRAPH_THEME.focus.primaryRingSlots,
     Math.max(FOCUS_PRIMARY_LABELS, Math.ceil(neighbors.length * 0.45)),
   );
-  let primaryCount = 0;
+  let nonPathPrimaryCount = 0;
   neighbors.forEach((entry) => {
-    if (primaryCount < primaryTarget || entry.isPath) {
+    if (entry.isPath || nonPathPrimaryCount < primaryTarget) {
       entry.zone = "primary";
-      primaryCount += 1;
+      if (!entry.isPath) {
+        nonPathPrimaryCount += 1;
+      }
     }
   });
 
@@ -1559,11 +1563,12 @@ function buildFocusedNeighbors(
   neighbors.forEach((entry, index) => {
     const primaryLabelBoost = entry.zone === "primary" && index < FOCUS_PRIMARY_LABELS;
     entry.labelPriority = entry.isPath || primaryLabelBoost ? 1.15 : entry.zone === "primary" ? 0.7 : 0.35;
+    const baseNodeSize = Number(entry.attrs.baseSize ?? entry.attrs.size ?? 4);
     entry.size = entry.isPath
-      ? Math.max(Number(entry.attrs.baseSize ?? entry.attrs.size ?? 4) * 1.16, GRAPH_THEME.focus.primaryNeighborMinSize)
+      ? Math.max(baseNodeSize * GRAPH_THEME.focus.pathNodeSizeScale, GRAPH_THEME.focus.primaryNeighborMinSize)
       : entry.zone === "primary"
-        ? Math.max(Number(entry.attrs.baseSize ?? entry.attrs.size ?? 4) * 1.08, GRAPH_THEME.focus.primaryNeighborMinSize)
-        : Math.max(Number(entry.attrs.baseSize ?? entry.attrs.size ?? 4) * 0.86, GRAPH_THEME.focus.secondaryNeighborMinSize);
+        ? Math.max(baseNodeSize * GRAPH_THEME.focus.primaryNodeSizeScale, GRAPH_THEME.focus.primaryNeighborMinSize)
+        : Math.max(baseNodeSize * GRAPH_THEME.focus.secondaryNodeSizeScale, GRAPH_THEME.focus.secondaryNeighborMinSize);
   });
 
   relaxFocusedNeighborPositions(neighbors, GRAPH_THEME.focus.selectedMinSize);
@@ -1578,8 +1583,8 @@ function scoreFocusedSupportEdge(
 ) {
   const rawEdgeCount = collectRawEdgeIds(attrs).length;
   const weight = Number(attrs.representativeWeight ?? attrs.weight ?? 1);
-  const primaryBoost = primaryNeighborIds.has(sourceId) && primaryNeighborIds.has(targetId) ? 1.5 : 0;
-  return weight * 4 + rawEdgeCount + primaryBoost;
+  const primaryBoost = primaryNeighborIds.has(sourceId) && primaryNeighborIds.has(targetId) ? GRAPH_THEME.focus.primaryEdgeBoost : 0;
+  return weight * GRAPH_THEME.focus.edgeWeightScoreScale + rawEdgeCount + primaryBoost;
 }
 
 function aggregateDisplayGraph(graphRef: GraphRef): Graph<NodeAttributes, EdgeAttributes> {
@@ -2068,11 +2073,6 @@ export function createFocusedGraph(
         ...entry.attrs,
         labelPriority: entry.labelPriority,
         labelVisibilityPolicy: entry.isPath || entry.zone === "primary" ? "priority" : "none",
-        haloColor: entry.isPath
-          ? withAlpha(GRAPH_THEME.palette.accent.path, 0.16)
-          : entry.zone === "primary"
-            ? withAlpha(entry.attrs.color, 0.12)
-            : withAlpha(entry.attrs.color, 0.06),
       },
       entry.attrs.label,
     );
@@ -2129,8 +2129,6 @@ export function createFocusedGraph(
       })
       .slice(0, GRAPH_THEME.focus.supportEdgeBudget),
   );
-  let loggedFocusedEdgeSkip = false;
-
   if (DEBUG_GRAPH_SCENE_STATE) {
     console.debug("[graphSceneState]", "focused-graph-build", {
       nodeId,
@@ -2146,20 +2144,6 @@ export function createFocusedGraph(
     }
 
     const [edgeSourceId, edgeTargetId] = graph.extremities(edgeId);
-    if (!focusIds.has(edgeSourceId) || !focusIds.has(edgeTargetId)) {
-      if (DEBUG_GRAPH_SCENE_STATE && !loggedFocusedEdgeSkip) {
-        loggedFocusedEdgeSkip = true;
-        console.debug("[graphSceneState]", "focused-edge-skipped-outside-focus", {
-          nodeId,
-          edgeId,
-          edgeSourceId,
-          edgeTargetId,
-          focusedNodeCount: focusIds.size,
-        });
-      }
-      return;
-    }
-
     const attrs = graph.getEdgeAttributes(edgeId) as EdgeAttributes;
     const isPathEdge = pathEdgeIds.has(edgeId);
     const isSelectedIncidentEdge = edgeSourceId === nodeId || edgeTargetId === nodeId;

--- a/explorer/src/workspaces/GraphWorkspace/graphTheme.ts
+++ b/explorer/src/workspaces/GraphWorkspace/graphTheme.ts
@@ -184,9 +184,17 @@ export interface GraphTheme {
   };
   focus: {
     maxNeighbors: number;
-    ringCapacity: number;
-    ringGap: number;
     primaryLabels: number;
+    primaryRingSlots: number;
+    secondaryRingSlots: number;
+    primaryRadius: number;
+    secondaryRadius: number;
+    overlapPadding: number;
+    overlapIterations: number;
+    selectedMinSize: number;
+    primaryNeighborMinSize: number;
+    secondaryNeighborMinSize: number;
+    supportEdgeBudget: number;
   };
   motion: {
     cameraMs: number;
@@ -496,9 +504,17 @@ export const GRAPH_THEME: GraphTheme = {
   },
   focus: {
     maxNeighbors: 16,
-    ringCapacity: 6,
-    ringGap: 250,
     primaryLabels: 6,
+    primaryRingSlots: 7,
+    secondaryRingSlots: 10,
+    primaryRadius: 170,
+    secondaryRadius: 310,
+    overlapPadding: 18,
+    overlapIterations: 18,
+    selectedMinSize: 24,
+    primaryNeighborMinSize: 11.5,
+    secondaryNeighborMinSize: 7.2,
+    supportEdgeBudget: 10,
   },
   motion: {
     cameraMs: 380,

--- a/explorer/src/workspaces/GraphWorkspace/graphTheme.ts
+++ b/explorer/src/workspaces/GraphWorkspace/graphTheme.ts
@@ -191,10 +191,19 @@ export interface GraphTheme {
     secondaryRadius: number;
     overlapPadding: number;
     overlapIterations: number;
+    ringAttractionStrength: number;
     selectedMinSize: number;
     primaryNeighborMinSize: number;
     secondaryNeighborMinSize: number;
+    pathNodeSizeScale: number;
+    primaryNodeSizeScale: number;
+    secondaryNodeSizeScale: number;
     supportEdgeBudget: number;
+    pathScoreBoost: number;
+    weightScoreScale: number;
+    degreeScoreScale: number;
+    edgeWeightScoreScale: number;
+    primaryEdgeBoost: number;
   };
   motion: {
     cameraMs: number;
@@ -511,10 +520,19 @@ export const GRAPH_THEME: GraphTheme = {
     secondaryRadius: 310,
     overlapPadding: 18,
     overlapIterations: 18,
+    ringAttractionStrength: 0.1,
     selectedMinSize: 24,
     primaryNeighborMinSize: 11.5,
     secondaryNeighborMinSize: 7.2,
+    pathNodeSizeScale: 1.16,
+    primaryNodeSizeScale: 1.08,
+    secondaryNodeSizeScale: 0.86,
     supportEdgeBudget: 10,
+    pathScoreBoost: 10_000,
+    weightScoreScale: 100,
+    degreeScoreScale: 2,
+    edgeWeightScoreScale: 4,
+    primaryEdgeBoost: 1.5,
   },
   motion: {
     cameraMs: 380,


### PR DESCRIPTION
## Summary
This PR fixes and turns Focused mode into a clearer, calmer way to inspect a node and its neighborhood.

Focused mode now behaves like a dedicated local view:
- the selected node stays centered
- key neighbors are laid out in a stable, layered structure
- unnecessary edge clutter is reduced
- camera movement is smoother and less disruptive

## What Changed

### Focused graph layout
- Replaced the old ring/starburst layout with a more stable, deterministic neighborhood layout  
- Always centers the selected node  
- Organizes neighbors into primary and secondary rings based on importance and path relevance  
- Adds a light no-overlap pass so nodes and labels don’t collide, without introducing jitter  

### Focused visual hierarchy
- Added focused-specific layout and styling in the graph theme  
- Increased visual prominence of the selected node  
- Made important neighbors easier to read while keeping less relevant ones subdued  
- Kept path highlighting strong so active paths still stand out  

### Focused edge readability
- Prioritized clarity over showing every possible edge  
- Always shows edges connected to the selected node  
- Always shows path edges  
- Keeps only the strongest additional connections between neighbors  
- Softens secondary edges so the view reads as a clean neighborhood, not a tangled web  

### Focused ownership and camera behavior
- Focused graphs now own their layout positions, so the structure stays stable  
- Added a focused-specific camera behavior  
- Selection recenters gently while preserving zoom, instead of jumping like the full-graph view  

## Result
Focused mode now feels like a purpose-built inspection tool:
- clear center vs. periphery
- less visual noise
- more stable structure
- smoother, calmer navigation

## Validation
- `npx tsc -b` passes

## Manual checks
- Enter Focused mode from different nodes  
- Confirm the selected node is clearly centered and neighbors are easy to read  
- Check that weaker connections are reduced  
- Verify path highlighting still stands out  
- Click around within Focused mode and confirm the camera movement stays smooth  