### PR TITLE
Fix #541: Convert mcp_server to package structure for pipx installation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -223,6 +223,7 @@ semantica = "semantica.cli:main"
 semantica-server = "semantica.server:main"
 semantica-worker = "semantica.worker:main"
 semantica-explorer = "semantica.explorer:main"
+semantica-mcp = "semantica.mcp_server:main"
 
 # ---------------- TOOLING ----------------
 [tool.setuptools.packages.find]

--- a/semantica/mcp_server/__init__.py
+++ b/semantica/mcp_server/__init__.py
@@ -14,13 +14,24 @@ Configure in your tool's MCP settings:
     {
         "mcpServers": {
             "semantica": {
+                "command": "semantica-mcp"
+            }
+        }
+    }
+
+Or using python -m:
+    {
+        "mcpServers": {
+            "semantica": {
                 "command": "python",
                 "args": ["-m", "semantica.mcp_server"]
             }
         }
     }
 
-Run directly:
+Run directly for testing:
+    semantica-mcp
+    # or
     python -m semantica.mcp_server
 
 Environment variables:
@@ -71,9 +82,7 @@ def _tool_extract_entities(args: dict) -> dict:
     if not text:
         return {"error": "text is required"}
     from semantica.semantic_extract import NamedEntityRecognizer
-    from semantica.semantic_extract.cache import _result_cache
-    _result_cache.clear()
-    entities = NamedEntityRecognizer().extract(text)
+    entities = NamedEntityRecognizer().extract_entities(text)
     return {
         "entities": [
             {"label": getattr(e, "label", str(e)),
@@ -91,10 +100,8 @@ def _tool_extract_relations(args: dict) -> dict:
     if not text:
         return {"error": "text is required"}
     from semantica.semantic_extract import RelationExtractor, TripletExtractor
-    from semantica.semantic_extract.cache import _result_cache
-    _result_cache.clear()
-    relations = RelationExtractor().extract(text)
-    triplets = TripletExtractor().extract(text)
+    relations = RelationExtractor().extract_relations(text)
+    triplets = TripletExtractor().extract_triplets(text)
     return {
         "relations": [
             {"source": getattr(r, "source", None),
@@ -600,7 +607,3 @@ def _run_stdio():
 
 def main():
     _run_stdio()
-
-
-if __name__ == "__main__":
-    main()

--- a/semantica/mcp_server/__main__.py
+++ b/semantica/mcp_server/__main__.py
@@ -1,0 +1,8 @@
+"""
+Entry point for python -m semantica.mcp_server
+"""
+
+from semantica.mcp_server import main
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
Fixes the issue where `semantica.mcp_server` module was not available after installation with pipx, causing the error: `No module named semantica.mcp_server`.

## Problem
When users installed semantica using pipx and tried to run the MCP server with `python -m semantica.mcp_server`, it failed because:
- `mcp_server.py` was a single file module, not a package structure
- Python's `-m` flag requires a package (directory with `__init__.py`) to work correctly
- No console script entry point was available

## Solution

### 1. Package Structure Conversion
- Converted `semantica/mcp_server.py` → `semantica/mcp_server/` package
- Created `semantica/mcp_server/__init__.py` (contains the main server code)
- Created `semantica/mcp_server/__main__.py` (entry point for `python -m`)
- Deleted old single-file module

### 2. Console Script Entry Point
Added `semantica-mcp` console script in `pyproject.toml`:
```toml
[project.scripts]
semantica-mcp = "semantica.mcp_server:main"
```

### 3. API Compatibility Fixes
Fixed method calls to match the actual semantic_extract API:
- `NamedEntityRecognizer().extract()` → `extract_entities()`
- `RelationExtractor().extract()` → `extract_relations()`
- `TripletExtractor().extract()` → `extract_triplets()`
- Removed non-existent `_result_cache` imports and `clear()` calls

### 4. Documentation Updates
Updated usage documentation to show both methods:
- **Method 1**: `semantica-mcp` (console script - recommended)
- **Method 2**: `python -m semantica.mcp_server` (python module)

## Changes Made
- `pyproject.toml`: Added `semantica-mcp` console script entry point
- `semantica/mcp_server/`: Created new package structure
  - `__init__.py`: Main server code (moved from mcp_server.py)
  - `__main__.py`: Entry point for `python -m` execution
- `semantica/mcp_server.py`: Deleted (converted to package)

## Verification

### MCP Protocol Tests
All tests passed successfully:
- ✅ Initialize - Server responds with correct protocol version and capabilities
- ✅ Tools List - All 12 tools registered and listed correctly
- ✅ Resources List - All 3 resources registered and listed correctly
- ✅ Ping - Server responds to health checks
- ✅ Entity Extraction - Tool successfully extracts entities from text
- ✅ Graph Summary - Tool returns graph statistics
- ✅ Resource Read - Schema info resource returns correct metadata

### Installation Verification
- ✅ Module can be imported: `from semantica.mcp_server import main`
- ✅ Module can be run with: `python -m semantica.mcp_server`
- ✅ Console script will be available after installation: `semantica-mcp`

## Usage After Installation

### Method 1 - Console Script (Recommended)
```json
{
    "mcpServers": {
        "semantica": {
            "command": "semantica-mcp"
        }
    }
}
```

### Method 2 - Python Module
```json
{
    "mcpServers": {
        "semantica": {
            "command": "python",
            "args": ["-m", "semantica.mcp_server"]
        }
    }
}
```

## Impact
- ✅ Resolves pipx installation issue for MCP server
- ✅ Provides two ways to run the server: console script or python -m
- ✅ Maintains backward compatibility with existing MCP configurations
- ✅ Fixes API compatibility issues with semantic_extract module
- ✅ Improves user experience with simpler console script command

## Testing
The MCP server was tested with:
- MCP protocol initialization handshake
- All 12 tool handlers (extract_entities, extract_relations, record_decision, etc.)
- All 3 resource handlers (graph/summary, decisions/list, schema/info)
- Entity extraction from sample text
- Graph summary retrieval
- Resource reading operations

## Related Issues
Closes #541

## Breaking Changes
None. This change is backward compatible and adds a new console script entry point.
