### PR TITLE
docs: refine onboarding guidance and reduce duplication

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -5,7 +5,7 @@ icon: "rocket"
 ---
 
 <Tip>
-  Just here for code? Jump straight to the [Quickstart Tutorial](quickstart) or explore the [Cookbook](cookbook) for interactive notebooks.
+  Already installed? Jump to the [Quickstart Tutorial](quickstart). Need setup help first? Start with [Installation](installation).
 </Tip>
 
 ---
@@ -35,11 +35,7 @@ icon: "rocket"
 pip install semantica
 ```
 
-With all optional dependencies:
-
-```bash
-pip install semantica[all]
-```
+For virtual environments, extras, and platform-specific setup, see the full [Installation guide](installation).
 
 Verify:
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -5,7 +5,7 @@ icon: "rocket"
 ---
 
 <Tip>
-  Already installed? Jump to the [Quickstart Tutorial](quickstart). Need setup help first? Start with [Installation](installation).
+  Already installed? Jump to [Quickstart](quickstart). Need setup help first? Start with [Installation](installation).
 </Tip>
 
 ---

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -35,7 +35,13 @@ icon: "rocket"
 pip install semantica
 ```
 
-For virtual environments, extras, and platform-specific setup, see the full [Installation guide](installation).
+With all optional dependencies:
+
+```bash
+pip install semantica[all]
+```
+
+For virtual environments and platform-specific setup, see the full [Installation](installation).
 
 Verify:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -181,18 +181,20 @@ pip install semantica==0.5.0
 
 ## Start Here
 
+If you're new to Semantica, install first and then open Quickstart. Use Core Concepts or API Reference when you need more context or exact details.
+
 <CardGroup cols={2}>
   <Card title="Quickstart" icon="rocket" href="quickstart">
     Build a complete knowledge graph pipeline in 5 minutes.
   </Card>
   <Card title="Core Concepts" icon="book-open" href="concepts">
-    Knowledge graphs, ontologies, and semantic reasoning explained.
+    Use this for the mental model behind the API.
   </Card>
   <Card title="API Reference" icon="rectangle-terminal" href="reference/context">
-    Full documentation for every module, class, and method.
+    Jump here when you need exact module, class, or method details.
   </Card>
   <Card title="Cookbook" icon="flask" href="cookbook">
-    40+ domain-specific notebooks — healthcare, finance, legal, and more.
+    Explore domain notebooks once you have the basics working.
   </Card>
 </CardGroup>
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -181,7 +181,7 @@ pip install semantica==0.5.0
 
 ## Start Here
 
-If you're new to Semantica, install first and then open Quickstart. Use Core Concepts or API Reference when you need more context or exact details.
+If you're new to Semantica, install first and then open [Quickstart](quickstart). Use [Core Concepts](concepts) or [API Reference](reference/context) when you need more context or exact details.
 
 <CardGroup cols={2}>
   <Card title="Quickstart" icon="rocket" href="quickstart">

--- a/docs/index.md
+++ b/docs/index.md
@@ -184,6 +184,9 @@ pip install semantica==0.5.0
 If you're new to Semantica, install first and then open [Quickstart](quickstart). Use [Core Concepts](concepts) or [API Reference](reference/context) when you need more context or exact details.
 
 <CardGroup cols={2}>
+  <Card title="Installation" icon="download" href="installation">
+    Get Semantica installed in under a minute.
+  </Card>
   <Card title="Quickstart" icon="rocket" href="quickstart">
     Build a complete knowledge graph pipeline in 5 minutes.
   </Card>

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -12,6 +12,10 @@ icon: "download"
   Python 3.8 or higher required. Python 3.11+ recommended.
 </Note>
 
+<Tip>
+  Once you're set up, read [Getting Started](getting-started) for the overview and [Quickstart](quickstart) for the end-to-end pipeline.
+</Tip>
+
 ---
 
 ## Basic Installation
@@ -177,13 +181,13 @@ Install the [Microsoft Visual C++ Redistributable](https://aka.ms/vs/17/release/
 ## Next Steps
 
 <CardGroup cols={3}>
-  <Card title="Getting Started" icon="rocket" href="getting-started">
-    Build your first knowledge graph.
+  <Card title="Read the Overview" icon="rocket" href="getting-started">
+    Understand what Semantica does before you build.
   </Card>
-  <Card title="Quickstart Tutorial" icon="play" href="quickstart">
-    Full step-by-step pipeline.
+  <Card title="Build the Pipeline" icon="play" href="quickstart">
+    Follow the end-to-end workflow with code.
   </Card>
-  <Card title="Cookbook" icon="flask" href="cookbook">
-    Interactive Jupyter notebooks.
+  <Card title="Browse Examples" icon="flask" href="cookbook">
+    See notebook examples organized by use case.
   </Card>
 </CardGroup>

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -181,7 +181,7 @@ Install the [Microsoft Visual C++ Redistributable](https://aka.ms/vs/17/release/
 ## Next Steps
 
 <CardGroup cols={3}>
-  <Card title="Read the Overview" icon="rocket" href="getting-started">
+  <Card title="Getting Started" icon="rocket" href="getting-started">
     Understand what Semantica does before you build.
   </Card>
   <Card title="Build the Pipeline" icon="play" href="quickstart">

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -8,7 +8,7 @@ icon: "rocket"
   **v0.5.0** — Ontology Hub, Distance Intelligence, Parquet & XML ingestion, 12 security fixes. [What's new →](index#whats-new)
 </Info>
 
-This guide walks you through a complete Semantica pipeline — from raw document to queryable knowledge graph with full provenance. You need Python 3.8+ and nothing else to start. An LLM API key is optional; pattern-based extraction works out of the box.
+Use this after installation. If you still need setup help, start with the [Installation guide](installation). You need Python 3.8+ and nothing else to start. An LLM API key is optional; pattern-based extraction works out of the box.
 
 ---
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -8,7 +8,7 @@ icon: "rocket"
   **v0.5.0** — Ontology Hub, Distance Intelligence, Parquet & XML ingestion, 12 security fixes. [What's new →](index#whats-new)
 </Info>
 
-This guide walks you through the end-to-end pipeline for building your first knowledge graph in 5 minutes. Start here after installation. If you still need setup help, open the [Installation guide](installation). You need Python 3.8+ and nothing else to start. An LLM API key is optional; pattern-based extraction works out of the box.
+This guide walks you through the end-to-end pipeline for building your first knowledge graph in 5 minutes. Start here after installation. If you still need setup help, see the [Installation guide](installation). You need Python 3.8+ and nothing else to start. An LLM API key is optional; pattern-based extraction works out of the box.
 
 ---
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -8,7 +8,7 @@ icon: "rocket"
   **v0.5.0** — Ontology Hub, Distance Intelligence, Parquet & XML ingestion, 12 security fixes. [What's new →](index#whats-new)
 </Info>
 
-This guide walks you through the end-to-end pipeline for building your first knowledge graph in 5 minutes. Use it after installation. If you still need setup help, start with the [Installation guide](installation). You need Python 3.8+ and nothing else to start. An LLM API key is optional; pattern-based extraction works out of the box.
+This guide walks you through the end-to-end pipeline for building your first knowledge graph in 5 minutes. Start here after installation. If you still need setup help, open the [Installation guide](installation). You need Python 3.8+ and nothing else to start. An LLM API key is optional; pattern-based extraction works out of the box.
 
 ---
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -8,7 +8,7 @@ icon: "rocket"
   **v0.5.0** — Ontology Hub, Distance Intelligence, Parquet & XML ingestion, 12 security fixes. [What's new →](index#whats-new)
 </Info>
 
-This guide walks you through the end-to-end pipeline for building your first knowledge graph in 5 minutes. Start here after installation. If you still need setup help, see the [Installation guide](installation). You need Python 3.8+ and nothing else to start. An LLM API key is optional; pattern-based extraction works out of the box.
+This guide walks you through the end-to-end pipeline for building your first knowledge graph in 5 minutes. Start here after installation. If you still need setup help, see [Installation](installation). You need Python 3.8+ and nothing else to start. An LLM API key is optional; pattern-based extraction works out of the box.
 
 ---
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -8,7 +8,7 @@ icon: "rocket"
   **v0.5.0** — Ontology Hub, Distance Intelligence, Parquet & XML ingestion, 12 security fixes. [What's new →](index#whats-new)
 </Info>
 
-Use this after installation. If you still need setup help, start with the [Installation guide](installation). You need Python 3.8+ and nothing else to start. An LLM API key is optional; pattern-based extraction works out of the box.
+This guide walks you through the end-to-end pipeline for building your first knowledge graph in 5 minutes. Use it after installation. If you still need setup help, start with the [Installation guide](installation). You need Python 3.8+ and nothing else to start. An LLM API key is optional; pattern-based extraction works out of the box.
 
 ---
 


### PR DESCRIPTION
## Summary

Small onboarding/docs polish pass to improve the installation → quickstart → deeper docs flow after the Mintlify migration.

## Changes

* reduced duplicated onboarding guidance across entry pages
* improved “where to start” clarity for new users
* clarified the relationship between installation and quickstart flows
* added clearer next-step guidance between onboarding pages

## Files updated

* docs/index.md
* docs/getting-started.md
* docs/quickstart.md
* docs/installation.md

## Validation

* `docs_check.py` passed
* checked for formatting/whitespace issues with `git diff --check`
