### PR TITLE
fix(explorer): auto-settle full graph layout

### DIFF
--- a/explorer/src/workspaces/GraphWorkspace/GraphCanvas.tsx
+++ b/explorer/src/workspaces/GraphWorkspace/GraphCanvas.tsx
@@ -137,6 +137,8 @@ const FA2_SETTINGS = {
   },
 };
 
+const FULL_GRAPH_LAYOUT_SETTLE_MS = 4_500;
+
 const GROUPED_FA2_SETTINGS = {
   iterations: GRAPH_THEME.grouped.layout.iterations,
   settings: {
@@ -1302,6 +1304,7 @@ export const GraphCanvas = forwardRef<GraphCanvasHandle, GraphCanvasProps>(
     const layoutSyncFrameRef = useRef<number | null>(null);
     const layoutSyncTickRef = useRef(0);
     const deferredFocusFrameRef = useRef<number | null>(null);
+    const fullGraphLayoutSettleTimeoutRef = useRef<number | null>(null);
     const groupedLayoutSettleTimeoutRef = useRef<number | null>(null);
     const reducerWarningStateRef = useRef<{ missingEdges: Set<string>; missingNodes: Set<string> }>({
       missingEdges: new Set<string>(),
@@ -2416,6 +2419,10 @@ export const GraphCanvas = forwardRef<GraphCanvasHandle, GraphCanvasProps>(
 
       if (!isLayoutRunning) {
         fa2Ref.current?.stop();
+        if (fullGraphLayoutSettleTimeoutRef.current !== null) {
+          window.clearTimeout(fullGraphLayoutSettleTimeoutRef.current);
+          fullGraphLayoutSettleTimeoutRef.current = null;
+        }
         if (groupedLayoutSettleTimeoutRef.current !== null) {
           window.clearTimeout(groupedLayoutSettleTimeoutRef.current);
           groupedLayoutSettleTimeoutRef.current = null;
@@ -2450,6 +2457,10 @@ export const GraphCanvas = forwardRef<GraphCanvasHandle, GraphCanvasProps>(
         window.clearTimeout(groupedLayoutSettleTimeoutRef.current);
         groupedLayoutSettleTimeoutRef.current = null;
       }
+      if (fullGraphLayoutSettleTimeoutRef.current !== null) {
+        window.clearTimeout(fullGraphLayoutSettleTimeoutRef.current);
+        fullGraphLayoutSettleTimeoutRef.current = null;
+      }
 
       if (usingGroupedOwnedLayout) {
         groupedLayoutSettleTimeoutRef.current = window.setTimeout(() => {
@@ -2463,6 +2474,19 @@ export const GraphCanvas = forwardRef<GraphCanvasHandle, GraphCanvasProps>(
             size: displayGraphRef.current.size,
           });
         }, GRAPH_THEME.grouped.layout.settleMs);
+      } else {
+        fullGraphLayoutSettleTimeoutRef.current = window.setTimeout(() => {
+          fa2Ref.current?.stop();
+          fullGraphLayoutSettleTimeoutRef.current = null;
+          onLayoutRunningChange?.(false);
+          debugGraphRuntime("full-layout-auto-settled", {
+            graphVersion: graphVersionRef.current,
+            viewMode: viewModeRef.current,
+            layoutMode: displayMetaRef.current.layoutMode,
+            order: displayGraphRef.current.order,
+            size: displayGraphRef.current.size,
+          });
+        }, FULL_GRAPH_LAYOUT_SETTLE_MS);
       }
 
       if (displayMeta.layoutMode === "mirrored" && sigma) {
@@ -2494,6 +2518,10 @@ export const GraphCanvas = forwardRef<GraphCanvasHandle, GraphCanvasProps>(
 
         return () => {
           disposed = true;
+          if (fullGraphLayoutSettleTimeoutRef.current !== null) {
+            window.clearTimeout(fullGraphLayoutSettleTimeoutRef.current);
+            fullGraphLayoutSettleTimeoutRef.current = null;
+          }
           if (groupedLayoutSettleTimeoutRef.current !== null) {
             window.clearTimeout(groupedLayoutSettleTimeoutRef.current);
             groupedLayoutSettleTimeoutRef.current = null;
@@ -2507,6 +2535,10 @@ export const GraphCanvas = forwardRef<GraphCanvasHandle, GraphCanvasProps>(
       }
 
       return () => {
+        if (fullGraphLayoutSettleTimeoutRef.current !== null) {
+          window.clearTimeout(fullGraphLayoutSettleTimeoutRef.current);
+          fullGraphLayoutSettleTimeoutRef.current = null;
+        }
         if (groupedLayoutSettleTimeoutRef.current !== null) {
           window.clearTimeout(groupedLayoutSettleTimeoutRef.current);
           groupedLayoutSettleTimeoutRef.current = null;
@@ -2517,6 +2549,10 @@ export const GraphCanvas = forwardRef<GraphCanvasHandle, GraphCanvasProps>(
 
     useEffect(() => {
       return () => {
+        if (fullGraphLayoutSettleTimeoutRef.current !== null) {
+          window.clearTimeout(fullGraphLayoutSettleTimeoutRef.current);
+          fullGraphLayoutSettleTimeoutRef.current = null;
+        }
         if (groupedLayoutSettleTimeoutRef.current !== null) {
           window.clearTimeout(groupedLayoutSettleTimeoutRef.current);
           groupedLayoutSettleTimeoutRef.current = null;

--- a/explorer/src/workspaces/GraphWorkspace/GraphWorkspace.tsx
+++ b/explorer/src/workspaces/GraphWorkspace/GraphWorkspace.tsx
@@ -1148,7 +1148,6 @@ export function GraphWorkspace({ externalFocusNodeId, externalFocusToken }: Grap
   const sceneRef = useRef<GraphSceneHandle>(null);
   const lastExternalFocusTokenRef = useRef<number | undefined>(undefined);
   const pluginRuntimeRef = useRef<GraphSceneRuntime | null>(null);
-  const settlingOverlayTimeoutRef = useRef<number | null>(null);
   const pluginInteractionStateRef = useRef<GraphInteractionState>({
     hoveredNodeId: null,
     selectedNodeId: "",
@@ -1175,10 +1174,6 @@ export function GraphWorkspace({ externalFocusNodeId, externalFocusToken }: Grap
       setGraphReady(true);
       setGraphVersion((current) => current + 1);
       setIsLayoutRunning(!graphSummary.layoutReady);
-      if (settlingOverlayTimeoutRef.current !== null) {
-        window.clearTimeout(settlingOverlayTimeoutRef.current);
-        settlingOverlayTimeoutRef.current = null;
-      }
 
       if (graphSummary.layoutReady) {
         setLoadingProgress(null);
@@ -1197,21 +1192,17 @@ export function GraphWorkspace({ externalFocusNodeId, externalFocusToken }: Grap
         layoutSource: graphSummary.layoutSource,
         layoutState: "bootstrapping",
       }));
-      settlingOverlayTimeoutRef.current = window.setTimeout(() => {
-        setLoadingProgress((current) => (current?.phase === "stabilizing_layout" ? null : current));
-        settlingOverlayTimeoutRef.current = null;
-      }, 900);
     },
     onProgress: handleLoadProgress,
   });
 
   useEffect(() => {
-    return () => {
-      if (settlingOverlayTimeoutRef.current !== null) {
-        window.clearTimeout(settlingOverlayTimeoutRef.current);
-      }
-    };
-  }, []);
+    if (isLayoutRunning) {
+      return;
+    }
+
+    setLoadingProgress((current) => (current?.phase === "stabilizing_layout" ? null : current));
+  }, [isLayoutRunning]);
 
   useEffect(() => {
     let cancelled = false;


### PR DESCRIPTION
## Summary
Fixes Knowledge Explorer graph jitter by automatically stopping the Full Graph layout after it settles.

## Changes
- Auto-stop Full Graph ForceAtlas2 layout after 4.5 seconds.
- Clear layout timers safely on pause, reload, mode switch, and unmount.
- Keep the “stabilizing layout” status tied to the real layout state instead of a fixed 900ms timeout.

## Verification
- `npx tsc -b`
- `npm run test:graph-workspace`