### PR TITLE
feat(benchmarks): add module-level filtering for benchmark runner (#575)

### DIFF
--- a/benchmarks/benchmarks_runner.py
+++ b/benchmarks/benchmarks_runner.py
@@ -10,10 +10,23 @@ from rich.rule import Rule
 console = Console()
 
 
+def _discover_modules() -> list[str]:
+    benchmarks_dir = "benchmarks"
+    _excluded = {"results", "__pycache__"}
+    return sorted(
+        d for d in os.listdir(benchmarks_dir)
+        if os.path.isdir(os.path.join(benchmarks_dir, d))
+        and not d.startswith(("_", "."))
+        and d not in _excluded
+    )
+
+
 def run_benchmarks():
     """
     Master Runner for Semantica Benchmarks.
     """
+    available_modules = _discover_modules()
+
     parser = argparse.ArgumentParser(description="Run Semantica Benchmarks")
     parser.add_argument(
         "--strict", action="store_true", help="Fail script if performance regresses"
@@ -21,13 +34,12 @@ def run_benchmarks():
     parser.add_argument(
         "--module",
         type=str,
-        choices=[
-            "context", "context_graph_effectiveness", "context_memory", 
-            "core_processing", "export", "input_layer", "normalize", 
-            "ontology", "output_orchestration", "quality_assurance", 
-            "storage", "visualization"
-        ],
-        help="Run benchmarks for specific module only"
+        choices=available_modules,
+        help=(
+            "Run benchmarks for a specific module only "
+            "(default: all modules). "
+            f"Available: {', '.join(available_modules)}"
+        ),
     )
     args = parser.parse_args()
 
@@ -39,9 +51,16 @@ def run_benchmarks():
     current_json = f"benchmarks/results/run_{timestamp}.json"
     baseline_json = "benchmarks/results/baseline.json"
 
-    # Build test path based on module selection
-    module_path = args.module + "/" if args.module else ""
-    test_path = f"benchmarks/{module_path}"
+    if args.module:
+        test_path = os.path.join("benchmarks", args.module)
+        if not os.path.isdir(test_path):
+            console.print(
+                f"[bold red] ✗[/bold red] Module directory not found: {test_path}"
+            )
+            sys.exit(1)
+        console.print(f"[dim]Module filter:[/dim] {args.module}")
+    else:
+        test_path = "benchmarks/"
 
     cmd = [
         sys.executable,

--- a/benchmarks/benchmarks_runner.py
+++ b/benchmarks/benchmarks_runner.py
@@ -18,6 +18,17 @@ def run_benchmarks():
     parser.add_argument(
         "--strict", action="store_true", help="Fail script if performance regresses"
     )
+    parser.add_argument(
+        "--module",
+        type=str,
+        choices=[
+            "context", "context_graph_effectiveness", "context_memory", 
+            "core_processing", "export", "input_layer", "normalize", 
+            "ontology", "output_orchestration", "quality_assurance", 
+            "storage", "visualization"
+        ],
+        help="Run benchmarks for specific module only"
+    )
     args = parser.parse_args()
 
     console.print(Rule("[bold cyan]Semantica Benchmark Suite[/bold cyan]", style="cyan"))
@@ -28,11 +39,15 @@ def run_benchmarks():
     current_json = f"benchmarks/results/run_{timestamp}.json"
     baseline_json = "benchmarks/results/baseline.json"
 
+    # Build test path based on module selection
+    module_path = args.module + "/" if args.module else ""
+    test_path = f"benchmarks/{module_path}"
+
     cmd = [
         sys.executable,
         "-m",
         "pytest",
-        "benchmarks/",
+        test_path,
         "-p", "no:typeguard",
         "-p", "no:langsmith",
         "--benchmark-only",


### PR DESCRIPTION
## Summary

Part of #575 — Infrastructure, New Module Tracks & Dataset Registry.

Adds a minimal `--module` flag to `benchmarks/benchmarks_runner.py` to allow running benchmarks for a specific benchmark module directory.

Example:

```bash 
python benchmarks/benchmarks_runner.py --module core_processing
```

## Changes

* added optional `--module` CLI argument
* added argparse validation using `choices=`
* replaced hardcoded benchmark path with dynamic module-based path selection
* preserved default behavior when `--module` is not provided

## Validation

Validated:

* `--help` output
* valid module selection
* invalid module rejection through argparse validation

## Notes

* uses pytest native path filtering only
* no new dependencies added
* no benchmark logic changes
* no multi-module support added in this PR
* fully backward compatible
