### PR TITLE
fix(benchmarks): restore Python 3.8 compatibility in runner

### DIFF
--- a/benchmarks/benchmarks_runner.py
+++ b/benchmarks/benchmarks_runner.py
@@ -9,8 +9,8 @@ from rich.rule import Rule
 
 console = Console()
 
-
-def _discover_modules() -> list[str]:
+from typing import List
+def _discover_modules() -> List[str]:
     benchmarks_dir = "benchmarks"
     _excluded = {"results", "__pycache__"}
     return sorted(


### PR DESCRIPTION
## Summary

Fixes a Python 3.8 compatibility issue in `benchmarks/benchmarks_runner.py`.

`pyproject.toml` currently declares support for Python `>=3.8`, but the benchmark runner used PEP 585 built-in generics (`list[str]`) which require Python 3.9+.

This change restores compatibility by switching to `typing.List`.

## Changes

* added `from typing import List`
* replaced `list[str]` with `List[str]`

## Validation

Validated locally with:

```bash
python benchmarks/benchmarks_runner.py --help
python -m py_compile benchmarks/benchmarks_runner.py
```

Benchmark runner executes normally after the change.

## Context

Identified during benchmark infrastructure audit work related to epic #570 / issue #575.
