### PR TITLE
docs(readme): add YouTube platform tour video and improve demo section

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,17 +23,36 @@
 
 > **Most AI agents act without a trail. Semantica adds the layer your stack is missing: structured context graphs, auditable decision records, and full provenance from every output back to its source — so your AI isn't just powerful, it's accountable.**
 
-<p align="center">
+## 🎬 See Semantica in Action
+
+<div align="center">
+
+### ▶️ Full Platform Walkthrough
+
+<a href="https://www.youtube.com/watch?v=QfnNZg4-dZA" target="_blank">
   <img
-    src="docs/assets/img/semantica-knowledge-explorer-demo.gif"
-    alt="Semantica Knowledge Explorer demo showing MTOR search, distance heatmap, and focused graph neighborhood"
+    src="https://img.youtube.com/vi/QfnNZg4-dZA/maxresdefault.jpg"
+    alt="▶ Semantica Knowledge Explorer Tour — Click to Watch on YouTube"
     width="960"
   />
-</p>
+</a>
 
-<p align="center">
-  <em>Search dense knowledge graphs, reveal distance intelligence, and focus local context in seconds.</em>
-</p>
+**[Watch on YouTube →](https://www.youtube.com/watch?v=QfnNZg4-dZA)**  
+*Knowledge Explorer · Context Graphs · Reasoning Engine · Decision Intelligence · Ontology Hub*
+
+<br/>
+
+### Knowledge Explorer in Action
+
+<img
+  src="docs/assets/img/semantica-knowledge-explorer-demo.gif"
+  alt="Semantica Knowledge Explorer — MTOR search, distance heatmap, and focused graph neighborhood"
+  width="960"
+/>
+
+*Search dense knowledge graphs, reveal distance intelligence, and focus local context in seconds.*
+
+</div>
 
 🌍 [🇺🇸 English](https://readme-i18n.com/Hawksight-AI/semantica?lang=en) · [🇩🇪 Deutsch](https://readme-i18n.com/Hawksight-AI/semantica?lang=de) · [🇫🇷 Français](https://readme-i18n.com/Hawksight-AI/semantica?lang=fr) · [🇪🇸 Español](https://readme-i18n.com/Hawksight-AI/semantica?lang=es) · [🇮🇹 Italiano](https://readme-i18n.com/Hawksight-AI/semantica?lang=it) · [🇵🇹 Português](https://readme-i18n.com/Hawksight-AI/semantica?lang=pt) · [🇸🇦 العربية](https://readme-i18n.com/Hawksight-AI/semantica?lang=ar) · [🇵🇰 اردو](https://readme-i18n.com/Hawksight-AI/semantica?lang=ur) · [🇮🇳 हिन्दी](https://readme-i18n.com/Hawksight-AI/semantica?lang=hi) · [🇨🇳 中文](https://readme-i18n.com/Hawksight-AI/semantica?lang=zh) · [🇯🇵 日本語](https://readme-i18n.com/Hawksight-AI/semantica?lang=ja) · [🇰🇷 한국어](https://readme-i18n.com/Hawksight-AI/semantica?lang=ko)
 


### PR DESCRIPTION
## Summary

- Adds a clickable YouTube thumbnail for the **Semantica Knowledge Explorer Tour** ([youtu.be/QfnNZg4-dZA](https://youtu.be/QfnNZg4-dZA)) at full 960px width above the existing GIF
- Replaces the single bare GIF block with a structured **"See Semantica in Action"** section containing two named subsections: *Full Platform Walkthrough* (video) and *Knowledge Explorer in Action* (GIF)
- Adds a bold **Watch on YouTube →** text link and an italic feature-list subtitle beneath the thumbnail
- Keeps the original GIF at full size with its caption

## Test plan

- [ ] Verify YouTube thumbnail renders and is clickable on the GitHub README page
- [ ] Verify GIF still displays at full width below the video section
- [ ] Confirm all links resolve correctly (YouTube URL, Watch on YouTube link)