### PR TITLE
docs(readme): remove demo GIF, YouTube video is sufficient

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,17 +40,6 @@
 **[Watch on YouTube →](https://www.youtube.com/watch?v=QfnNZg4-dZA)**  
 *Knowledge Explorer · Context Graphs · Reasoning Engine · Decision Intelligence · Ontology Hub*
 
-<br/>
-
-### Knowledge Explorer in Action
-
-<img
-  src="docs/assets/img/semantica-knowledge-explorer-demo.gif"
-  alt="Semantica Knowledge Explorer — MTOR search, distance heatmap, and focused graph neighborhood"
-  width="960"
-/>
-
-*Search dense knowledge graphs, reveal distance intelligence, and focus local context in seconds.*
 
 </div>
 


### PR DESCRIPTION
## Summary

- Removes the `semantica-knowledge-explorer-demo.gif` from the README hero section
- The YouTube platform tour video (added in #603) covers all the same content at higher quality
- Keeps the section header and YouTube thumbnail/link

## Depends on

Builds on top of #603 (`readme/youtube-video-embed`). Merge that one first, then this.