### PR TITLE
security: remove leaked Groq API keys from advanced_rag, blockchain/01, biomedical notebooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Leaked Groq API keys removed from cookbook notebooks** — 6 hardcoded `GROQ_API_KEY` values (`gsk_...`) stripped from configuration cells in `supply_chain/01`, `intelligence/01`, `cybersecurity/01`, `cybersecurity/02`, `finance/01`, and `blockchain/02`; fallback replaced with empty string (secret scanning alerts #1–#6). Keys were already publicly exposed — rotate them in the Groq console.
 
+- **Leaked Groq API keys removed from additional cookbook notebooks** — 6 distinct hardcoded `GROQ_API_KEY` values stripped from 4 additional notebooks: `advanced_rag/01_GraphRAG_Complete`, `advanced_rag/02_RAG_vs_GraphRAG_Comparison`, `blockchain/01_DeFi_Protocol_Intelligence`, and `biomedical/01_Drug_Discovery_Pipeline` (secret scanning alerts #1–#6). Affected keys: `gsk_SLLE0...`, `gsk_S4dBVJ...`, `gsk_SLOv6...`, `gsk_lR6Qcj...`, `gsk_ToJis6...`, `gsk_LmbQBr...`; all publicly exposed since Dec 2025 — revoke in the Groq console and close the GitHub secret scanning alerts as "Revoked" in the Security tab.
+
 ---
 
 ## [0.5.0] - 2026-05-11


### PR DESCRIPTION
## Summary

- Documents the removal of 6 hardcoded `GROQ_API_KEY` fallback values from 4 additional cookbook notebooks, resolving secret scanning alerts #1–#6
- Keys were already stripped from HEAD in commit `a5da533` ("chore: resolve dependencies, migrate Gemini SDK, and sanitize notebooks") — this PR adds the CHANGELOG entry and closes the tracking gap

## Affected notebooks (4)

| Notebook | Keys removed |
|---|---|
| `cookbook/use_cases/advanced_rag/01_GraphRAG_Complete.ipynb` | `gsk_ToJis6...`, `gsk_SLOv6...` |
| `cookbook/use_cases/advanced_rag/02_RAG_vs_GraphRAG_Comparison.ipynb` | `gsk_SLLE0...`, `gsk_SLOv6...`, `gsk_ToJis6...` |
| `cookbook/use_cases/blockchain/01_DeFi_Protocol_Intelligence.ipynb` | `gsk_S4dBVJ...`, `gsk_lR6Qcj...` |
| `cookbook/use_cases/biomedical/01_Drug_Discovery_Pipeline.ipynb` | `gsk_ToJis6...`, `gsk_LmbQBr...` |

All instances replaced with `os.getenv("GROQ_API_KEY", "")` — empty-string fallback, no hardcoded value.

## Keys that must be revoked manually

These keys are publicly exposed since Dec 2025 and **must be rotated in the Groq console**:

- `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`
- `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`
- `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`
- `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`
- `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`
- `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`

After rotation, close GitHub secret scanning alerts #1–#6 as **"Revoked"** in the Security tab.

## Test plan

- [x] Grep confirms 0 occurrences of `gsk_` in all 4 notebooks on current HEAD
- [x] All notebooks use `os.getenv("GROQ_API_KEY", "")` pattern
- [ ] Revoke all 6 keys in Groq console
- [ ] Close secret scanning alerts #1–#6 as "Revoked" in GitHub Security tab