### PR TITLE
Remove duplicate root route registration in Explorer app

### DIFF
--- a/semantica/explorer/app.py
+++ b/semantica/explorer/app.py
@@ -157,17 +157,6 @@ def create_app(session: Optional[GraphSession] = None) -> FastAPI:
             "status": "active",
         }
 
-    @app.get("/", include_in_schema=False)
-    async def root():
-        index_path = Path(__file__).resolve().parent.parent / "static" / "index.html"
-        if index_path.is_file():
-            return FileResponse(index_path)
-        return HTMLResponse(
-            '<!doctype html><html lang="en"><head><meta charset="UTF-8">'
-            '<title>Semantica Knowledge Explorer</title></head>'
-            '<body><div id="root"></div></body></html>'
-        )
-
     static_dir = Path(__file__).resolve().parent.parent / "static"
     if static_dir.is_dir():
         assets_dir = static_dir / "assets"


### PR DESCRIPTION
## Summary

Removes a duplicate FastAPI root route registration in `semantica/explorer/app.py`.

The file contained two identical definitions of:

```python
@app.get("/", include_in_schema=False)
async def root():
```

Both implementations were identical. This change removes the duplicate registration and keeps the existing behavior unchanged.

## Validation

Tested locally after the change:

* Started Explorer with an empty graph.
* Started Explorer with `cookbook/use_cases/biomedical/drug_target_kg.json`.
* Verified landing page loads correctly.
* Verified "Open Semantica Explorer" opens the graph workspace.
* Verified graph visualization renders successfully.
* Verified API endpoints continue to respond normally.
* Verified no functional behavior changes.

## Notes

This is a cleanup-only change with no intended behavioral impact.
