### PR TITLE
Potential fix for code scanning alert no. 34: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/semantica-agi/semantica/security/code-scanning/34](https://github.com/semantica-agi/semantica/security/code-scanning/34)

Add an explicit top-level `permissions` block in `.github/workflows/ci.yml` so all jobs inherit minimal token scope unless overridden. For this workflow, the least-privilege baseline is:

- `contents: read`

This preserves current functionality (`actions/checkout` can read repository contents) while preventing unnecessary write scopes.

Change region: near the top of `.github/workflows/ci.yml`, after `name` and before `on` (or immediately after `on`; top-level is preferred for all jobs).  
No imports, methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
