### PR TITLE
fix: replace invalid Mintlify theme 'venus' with 'mint'

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://mintlify.com/docs.json",
-  "theme": "venus",
+  "theme": "mint",
   "name": "Semantica",
   "description": "The Accountability and Context Layer for AI — Context Graphs · Decision Intelligence · Full Provenance",
   "colors": {


### PR DESCRIPTION
## Summary

- Fixes the CI build failure caused by an invalid `theme` value in `docs/docs.json`
- `"venus"` is not a valid Mintlify v4 theme
- Changed to `"mint"` which is a valid value and matches the green primary color (`#10B981`)

## Error fixed

```
🚨 Invalid docs.json:
#.theme: Invalid discriminator value. Expected 'mint' | 'maple' | 'palm' | 'willow' | 'linden' | 'almond' | 'aspen' | 'luma' | 'sequoia'
error prebuild step failed
```

## Change

```diff
- "theme": "venus",
+ "theme": "mint",
```