### PR TITLE
docs: replace all card blocks with animated bullet points (premium UI overhaul)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -185,17 +185,7 @@ Centralized `ConfigManager` with environment variable overrides. No magic defaul
 | **Deduplication v2** | `blocking_v2`, `hybrid_v2`, `semantic_v2`: up to 7x faster than v1 |
 | **Indexed search** | Explorer search at 0.004ms on 118k nodes (v0.5.0) |
 
-<CardGroup cols={2}>
-  <Card title="Modules" icon="cubes" href="modules">
-    Full module documentation with code examples.
-  </Card>
-  <Card title="Learning More" icon="graduation-cap" href="learning-more">
-    Configuration reference, performance guide, and troubleshooting.
-  </Card>
-  <Card title="Pipeline Reference" icon="gear" href="reference/pipeline">
-    Pipeline orchestration, workers, and retry policies.
-  </Card>
-  <Card title="Core Reference" icon="network-wired" href="reference/core">
-    Framework lifecycle, plugin registry, and configuration.
-  </Card>
-</CardGroup>
+- [Modules](modules) — Full module documentation with code examples.
+- [Learning More](learning-more) — Configuration reference, performance guide, and troubleshooting.
+- [Pipeline Reference](reference/pipeline) — Pipeline orchestration, workers, and retry policies.
+- [Core Reference](reference/core) — Framework lifecycle, plugin registry, and configuration.

--- a/docs/assets/custom.css
+++ b/docs/assets/custom.css
@@ -110,6 +110,47 @@ nav a,
 }
 
 /* ============================================================
+   BULLET POINTS — cursor-animated hover (premium feel)
+   ============================================================ */
+ul > li,
+ol > li {
+  position: relative;
+  transition:
+    background-color 0.18s ease,
+    box-shadow 0.18s ease,
+    color 0.15s ease;
+  border-radius: 4px;
+  cursor: default;
+}
+
+ul > li:hover,
+ol > li:hover {
+  background-color: rgba(16, 185, 129, 0.06);
+  box-shadow: inset 3px 0 0 #10B981;
+  color: rgba(255, 255, 255, 0.95);
+}
+
+/* Animate the bullet marker green on hover */
+ul > li:hover::marker,
+ol > li:hover::marker {
+  color: #10B981;
+}
+
+/* Slide-in left accent bar for nested lists */
+ul > li > ul > li:hover,
+ol > li > ul > li:hover {
+  background-color: rgba(16, 185, 129, 0.04);
+  box-shadow: inset 2px 0 0 rgba(16, 185, 129, 0.6);
+}
+
+/* Strong text inside list items — subtle green tint on parent hover */
+ul > li:hover > strong,
+ol > li:hover > strong {
+  color: #10B981;
+  transition: color 0.15s ease;
+}
+
+/* ============================================================
    HIDE THEME TOGGLE (moon / sun emoji button)
    ============================================================ */
 button[aria-label="Switch to light mode"],

--- a/docs/citation.md
+++ b/docs/citation.md
@@ -49,11 +49,5 @@ Published research using Semantica? [Let us know](https://github.com/semantica-a
 
 ## See Also
 
-<CardGroup cols={2}>
-  <Card title="License" icon="file-contract" href="project-license">
-    MIT License details.
-  </Card>
-  <Card title="Community" icon="users" href="community">
-    Connect with the Semantica community.
-  </Card>
-</CardGroup>
+- [License](project-license) — MIT License details.
+- [Community](community) — Connect with the Semantica community.

--- a/docs/cli-setup.md
+++ b/docs/cli-setup.md
@@ -49,23 +49,11 @@ python -c "import semantica; print(semantica.__version__)"
 
 ## When to Use Each Command
 
-<CardGroup cols={2}>
-  <Card title="semantica" icon="terminal">
-    The general-purpose CLI. Use it for one-off pipeline runs, entity extraction, and graph operations from a shell script or CI job.
-  </Card>
-  <Card title="semantica-server" icon="server">
-    Starts the REST API server. Binds to `0.0.0.0:8000`. Use this when another service or application needs programmatic access to Semantica over HTTP.
-  </Card>
-  <Card title="semantica-worker" icon="gears">
-    Background task processor. Run alongside `semantica-server` when you need async pipeline execution outside the request cycle. Start the server first, then start one or more workers pointing at the same backend.
-  </Card>
-  <Card title="semantica-explorer" icon="map">
-    Launches the browser dashboard. Requires `pip install semantica[explorer]`. Use this to explore a saved knowledge graph interactively. See [Explorer Setup](explorer-setup).
-  </Card>
-  <Card title="semantica-mcp" icon="plug">
-    Runs the MCP server over stdio. Configure it in your MCP client's settings file to expose all 12 tools and 3 resources to Claude Desktop, Cursor, Windsurf, or any MCP-aware client. See [MCP Server](reference/mcp_server).
-  </Card>
-</CardGroup>
+- **semantica** — The general-purpose CLI. Use it for one-off pipeline runs, entity extraction, and graph operations from a shell script or CI job.
+- **semantica-server** — Starts the REST API server. Binds to `0.0.0.0:8000`. Use this when another service or application needs programmatic access to Semantica over HTTP.
+- **semantica-worker** — Background task processor. Run alongside `semantica-server` when you need async pipeline execution outside the request cycle. Start the server first, then start one or more workers pointing at the same backend.
+- **semantica-explorer** — Launches the browser dashboard. Requires `pip install semantica[explorer]`. Use this to explore a saved knowledge graph interactively. See [Explorer Setup](explorer-setup).
+- **semantica-mcp** — Runs the MCP server over stdio. Configure it in your MCP client's settings file to expose all 12 tools and 3 resources to Claude Desktop, Cursor, Windsurf, or any MCP-aware client. See [MCP Server](reference/mcp_server).
 
 
 ## Usage Examples
@@ -240,17 +228,7 @@ Install the [Microsoft Visual C++ Redistributable](https://aka.ms/vs/17/release/
 
 ## Next Steps
 
-<CardGroup cols={2}>
-  <Card title="Explorer Setup" icon="map" href="explorer-setup">
-    Build a graph, save it, and launch the browser dashboard.
-  </Card>
-  <Card title="MCP Server" icon="plug" href="reference/mcp_server">
-    All 12 tools and 3 resources exposed over the MCP protocol.
-  </Card>
-  <Card title="Installation" icon="download" href="installation">
-    Virtual environments, optional extras, and platform-specific notes.
-  </Card>
-  <Card title="Quickstart" icon="rocket" href="quickstart">
-    End-to-end pipeline walkthrough with working code.
-  </Card>
-</CardGroup>
+- [Explorer Setup](explorer-setup) — Build a graph, save it, and launch the browser dashboard.
+- [MCP Server](reference/mcp_server) — All 12 tools and 3 resources exposed over the MCP protocol.
+- [Installation](installation) — Virtual environments, optional extras, and platform-specific notes.
+- [Quickstart](quickstart) — End-to-end pipeline walkthrough with working code.

--- a/docs/community-projects.md
+++ b/docs/community-projects.md
@@ -114,17 +114,7 @@ See [Architecture](architecture#extension-points) for the full extension guide.
 
 ## How to Contribute
 
-<CardGroup cols={2}>
-  <Card title="Contributing Guide" icon="code-pull-request" href="contributing-guide">
-    Submit code, documentation, tests, or cookbook notebooks.
-  </Card>
-  <Card title="GitHub Issues" icon="circle-dot" href="https://github.com/semantica-agi/semantica/issues">
-    Report bugs, request features, or propose integrations.
-  </Card>
-  <Card title="Discord" icon="discord" href="https://discord.gg/sV34vps5hH">
-    Share what you're building with the community.
-  </Card>
-  <Card title="GitHub Discussions" icon="comments" href="https://github.com/semantica-agi/semantica/discussions">
-    Long-form questions, design discussions, and ideas.
-  </Card>
-</CardGroup>
+- [Contributing Guide](contributing-guide) — Submit code, documentation, tests, or cookbook notebooks.
+- [GitHub Issues](https://github.com/semantica-agi/semantica/issues) — Report bugs, request features, or propose integrations.
+- [Discord](https://discord.gg/sV34vps5hH) — Share what you're building with the community.
+- [GitHub Discussions](https://github.com/semantica-agi/semantica/discussions) — Long-form questions, design discussions, and ideas.

--- a/docs/community.md
+++ b/docs/community.md
@@ -9,20 +9,10 @@ Semantica is built in the open, with contributions from researchers, engineers, 
 
 ## Get Help
 
-<CardGroup cols={2}>
-  <Card title="GitHub Issues" icon="circle-dot" href="https://github.com/semantica-agi/semantica/issues">
-    File bug reports and feature requests with full context.
-  </Card>
-  <Card title="GitHub Discussions" icon="comments" href="https://github.com/semantica-agi/semantica/discussions">
-    Ask questions, share ideas, and discuss design decisions.
-  </Card>
-  <Card title="Pull Requests" icon="code-pull-request" href="https://github.com/semantica-agi/semantica/pulls">
-    Browse open contributions and submit your own.
-  </Card>
-  <Card title="Security Issues" icon="shield" href="https://github.com/semantica-agi/semantica/security/advisories/new">
-    Report vulnerabilities privately: never in public issues.
-  </Card>
-</CardGroup>
+- [GitHub Issues](https://github.com/semantica-agi/semantica/issues) — File bug reports and feature requests with full context.
+- [GitHub Discussions](https://github.com/semantica-agi/semantica/discussions) — Ask questions, share ideas, and discuss design decisions.
+- [Pull Requests](https://github.com/semantica-agi/semantica/pulls) — Browse open contributions and submit your own.
+- [Security Issues](https://github.com/semantica-agi/semantica/security/advisories/new) — Report vulnerabilities privately: never in public issues.
 
 
 ## Community Guidelines
@@ -78,17 +68,7 @@ See the [Contributing Guide](contributing-guide) for the full development workfl
 
 ## See Also
 
-<CardGroup cols={2}>
-  <Card title="Contributing Guide" icon="code-pull-request" href="contributing-guide">
-    Step-by-step guide for submitting PRs and setting up your dev environment.
-  </Card>
-  <Card title="Community Projects" icon="people-group" href="community-projects">
-    Projects and integrations built by the community.
-  </Card>
-  <Card title="FAQ" icon="circle-question" href="faq">
-    Common questions answered.
-  </Card>
-  <Card title="Governance" icon="scale-balanced" href="governance">
-    How the project is run and decisions are made.
-  </Card>
-</CardGroup>
+- [Contributing Guide](contributing-guide) — Step-by-step guide for submitting PRs and setting up your dev environment.
+- [Community Projects](community-projects) — Projects and integrations built by the community.
+- [FAQ](faq) — Common questions answered.
+- [Governance](governance) — How the project is run and decisions are made.

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -12,17 +12,9 @@ Semantica transforms unstructured data: documents, web pages, reports, databases
 
 At its core, Semantica adds a **context and accountability layer** on top of your existing AI stack. It doesn't replace LangChain, LlamaIndex, or your LLM provider: it makes their outputs **grounded**, **traceable**, and **auditable**.
 
-<CardGroup cols={3}>
-  <Card title="Context Layer" icon="diagram-project">
-    Knowledge graphs, GraphRAG retrieval, semantic embeddings, and temporal intelligence ground every LLM response in structured, queryable facts.
-  </Card>
-  <Card title="Accountability Layer" icon="shield-check">
-    Provenance tracking, decision intelligence, conflict detection, and W3C PROV-O compliance make every claim in your AI stack auditable and explainable.
-  </Card>
-  <Card title="Extension Layer" icon="plug">
-    `PluginRegistry` and `MethodRegistry` let you replace or augment any component: ingestors, extractors, reasoning engines, backends: without changing framework code.
-  </Card>
-</CardGroup>
+- **Context Layer** — Knowledge graphs, GraphRAG retrieval, semantic embeddings, and temporal intelligence ground every LLM response in structured, queryable facts.
+- **Accountability Layer** — Provenance tracking, decision intelligence, conflict detection, and W3C PROV-O compliance make every claim in your AI stack auditable and explainable.
+- **Extension Layer** — `PluginRegistry` and `MethodRegistry` let you replace or augment any component: ingestors, extractors, reasoning engines, backends: without changing framework code.
 
 
 ## Knowledge Graphs
@@ -487,14 +479,6 @@ Semantica is designed for extension. Any component: ingestor, extractor, graph b
   </Accordion>
 </AccordionGroup>
 
-<CardGroup cols={2}>
-  <Card title="Quickstart Tutorial" icon="play" href="quickstart">
-    Build a full pipeline with code.
-  </Card>
-  <Card title="Modules Guide" icon="puzzle-piece" href="modules">
-    Every module explained with examples.
-  </Card>
-  <Card title="API Reference" icon="code" href="reference/context">
-    Complete technical reference.
-  </Card>
-</CardGroup>
+- [Quickstart Tutorial](quickstart) — Build a full pipeline with code.
+- [Modules Guide](modules) — Every module explained with examples.
+- [API Reference](reference/context) — Complete technical reference.

--- a/docs/contributing-guide.md
+++ b/docs/contributing-guide.md
@@ -22,20 +22,10 @@ New to the project? Start with [`good-first-issue`](https://github.com/semantica
 
 ## Ways to Contribute
 
-<CardGroup cols={2}>
-  <Card title="Code" icon="code">
-    Fix bugs, implement features, optimize performance, or add new ingestors, parsers, and exporters using the plugin registry.
-  </Card>
-  <Card title="Documentation" icon="book">
-    Fix typos, improve clarity, add missing examples, write tutorials, or keep the API reference accurate as modules evolve.
-  </Card>
-  <Card title="Testing" icon="flask">
-    Add test coverage for untested modules or edge cases, reproduce reported bugs with minimal repros, or improve cross-platform reliability.
-  </Card>
-  <Card title="Community" icon="users">
-    Answer questions in GitHub Issues and Discussions, review pull requests with constructive feedback, or share Semantica in blog posts and talks.
-  </Card>
-</CardGroup>
+- **Code** — Fix bugs, implement features, optimize performance, or add new ingestors, parsers, and exporters using the plugin registry.
+- **Documentation** — Fix typos, improve clarity, add missing examples, write tutorials, or keep the API reference accurate as modules evolve.
+- **Testing** — Add test coverage for untested modules or edge cases, reproduce reported bugs with minimal repros, or improve cross-platform reliability.
+- **Community** — Answer questions in GitHub Issues and Discussions, review pull requests with constructive feedback, or share Semantica in blog posts and talks.
 
 
 ## Development Setup
@@ -95,11 +85,5 @@ All contributors are expected to follow the [Contributor Covenant Code of Conduc
 - [GitHub Discussions](https://github.com/semantica-agi/semantica/discussions)
 - [Discord](https://discord.gg/sV34vps5hH)
 
-<CardGroup cols={2}>
-  <Card title="Community" icon="users" href="community">
-    Community guidelines and values.
-  </Card>
-  <Card title="Governance" icon="scale-balanced" href="governance">
-    How decisions are made and the project is run.
-  </Card>
-</CardGroup>
+- [Community](community) — Community guidelines and values.
+- [Governance](governance) — How decisions are made and the project is run.

--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -16,131 +16,41 @@ icon: "flask"
 </Note>
 
 
-## Featured Recipes
+## Featured Recipe
 
-<CardGroup cols={2}>
-  <Card title="Your First Knowledge Graph" icon="diagram-project" href="https://github.com/semantica-agi/semantica/blob/main/cookbook/introduction/08_Your_First_Knowledge_Graph.ipynb">
-    Go from raw text to a queryable knowledge graph in 20 minutes.
-
-    **Topics:** Extraction, Graph Construction, Visualization · **Difficulty:** Beginner
-  </Card>
-</CardGroup>
+- **[Your First Knowledge Graph](https://github.com/semantica-agi/semantica/blob/main/cookbook/introduction/08_Your_First_Knowledge_Graph.ipynb)** — Go from raw text to a queryable knowledge graph in 20 minutes. Topics: Extraction, Graph Construction, Visualization · *Beginner*
 
 
 ## Core Tutorials
 
 Essential guides to master the Semantica framework.
 
-<CardGroup cols={2}>
-  <Card title="Welcome to Semantica" icon="hands" href="https://github.com/semantica-agi/semantica/blob/main/cookbook/introduction/01_Welcome_to_Semantica.ipynb">
-    An interactive introduction to the framework's core philosophy and all modules.
-
-    **Topics:** Framework Overview, Architecture · **Difficulty:** Beginner
-  </Card>
-  <Card title="Data Ingestion" icon="database" href="https://github.com/semantica-agi/semantica/blob/main/cookbook/introduction/02_Data_Ingestion.ipynb">
-    Loading data from files, web, databases, streams, feeds, repositories, email, and MCP.
-
-    **Topics:** FileIngestor, WebIngestor, DBIngestor, Streams · **Difficulty:** Beginner
-  </Card>
-  <Card title="Document Parsing" icon="file-lines" href="https://github.com/semantica-agi/semantica/blob/main/cookbook/introduction/03_Document_Parsing.ipynb">
-    Extracting clean text from complex formats like PDF, DOCX, and HTML.
-
-    **Topics:** OCR, PDF Parsing, Text Extraction · **Difficulty:** Beginner
-  </Card>
-  <Card title="Data Normalization" icon="broom" href="https://github.com/semantica-agi/semantica/blob/main/cookbook/introduction/04_Data_Normalization.ipynb">
-    Pipelines for cleaning, normalizing, and preparing text.
-
-    **Topics:** Text Cleaning, Unicode, Formatting · **Difficulty:** Beginner
-  </Card>
-  <Card title="Entity Extraction" icon="magnifying-glass" href="https://github.com/semantica-agi/semantica/blob/main/cookbook/introduction/05_Entity_Extraction.ipynb">
-    Using NER to identify people, organizations, and custom entities.
-
-    **Topics:** NER, spaCy, LLM Extraction · **Difficulty:** Beginner
-  </Card>
-  <Card title="Relation Extraction" icon="arrows-split-up-and-left" href="https://github.com/semantica-agi/semantica/blob/main/cookbook/introduction/06_Relation_Extraction.ipynb">
-    Discovering and classifying relationships between entities.
-
-    **Topics:** Relation Classification, Dependency Parsing · **Difficulty:** Beginner
-  </Card>
-  <Card title="Embedding Generation" icon="vector-square" href="https://github.com/semantica-agi/semantica/blob/main/cookbook/introduction/12_Embedding_Generation.ipynb">
-    Creating and managing vector embeddings for semantic search.
-
-    **Topics:** Embeddings, OpenAI, HuggingFace · **Difficulty:** Intermediate
-  </Card>
-  <Card title="Vector Store" icon="database" href="https://github.com/semantica-agi/semantica/blob/main/cookbook/introduction/13_Vector_Store.ipynb">
-    Setting up vector stores for similarity search and retrieval.
-
-    **Difficulty:** Intermediate
-  </Card>
-  <Card title="Graph Store" icon="server" href="https://github.com/semantica-agi/semantica/blob/main/cookbook/introduction/09_Graph_Store.ipynb">
-    Persisting knowledge graphs in Neo4j or FalkorDB.
-
-    **Topics:** Neo4j, Cypher, Persistence · **Difficulty:** Intermediate
-  </Card>
-  <Card title="Ontology" icon="sitemap" href="https://github.com/semantica-agi/semantica/blob/main/cookbook/introduction/14_Ontology.ipynb">
-    Defining domain schemas and ontologies to structure your data.
-
-    **Topics:** OWL, RDF, Schema Design · **Difficulty:** Intermediate
-  </Card>
-</CardGroup>
+- **[Welcome to Semantica](https://github.com/semantica-agi/semantica/blob/main/cookbook/introduction/01_Welcome_to_Semantica.ipynb)** — Interactive introduction to the framework's core philosophy and all modules. Topics: Framework Overview, Architecture · *Beginner*
+- **[Data Ingestion](https://github.com/semantica-agi/semantica/blob/main/cookbook/introduction/02_Data_Ingestion.ipynb)** — Loading data from files, web, databases, streams, feeds, repositories, email, and MCP. Topics: FileIngestor, WebIngestor, DBIngestor · *Beginner*
+- **[Document Parsing](https://github.com/semantica-agi/semantica/blob/main/cookbook/introduction/03_Document_Parsing.ipynb)** — Extracting clean text from complex formats like PDF, DOCX, and HTML. Topics: OCR, PDF Parsing, Text Extraction · *Beginner*
+- **[Data Normalization](https://github.com/semantica-agi/semantica/blob/main/cookbook/introduction/04_Data_Normalization.ipynb)** — Pipelines for cleaning, normalizing, and preparing text. Topics: Text Cleaning, Unicode, Formatting · *Beginner*
+- **[Entity Extraction](https://github.com/semantica-agi/semantica/blob/main/cookbook/introduction/05_Entity_Extraction.ipynb)** — Using NER to identify people, organizations, and custom entities. Topics: NER, spaCy, LLM Extraction · *Beginner*
+- **[Relation Extraction](https://github.com/semantica-agi/semantica/blob/main/cookbook/introduction/06_Relation_Extraction.ipynb)** — Discovering and classifying relationships between entities. Topics: Relation Classification, Dependency Parsing · *Beginner*
+- **[Embedding Generation](https://github.com/semantica-agi/semantica/blob/main/cookbook/introduction/12_Embedding_Generation.ipynb)** — Creating and managing vector embeddings for semantic search. Topics: Embeddings, OpenAI, HuggingFace · *Intermediate*
+- **[Vector Store](https://github.com/semantica-agi/semantica/blob/main/cookbook/introduction/13_Vector_Store.ipynb)** — Setting up vector stores for similarity search and retrieval. *Intermediate*
+- **[Graph Store](https://github.com/semantica-agi/semantica/blob/main/cookbook/introduction/09_Graph_Store.ipynb)** — Persisting knowledge graphs in Neo4j or FalkorDB. Topics: Neo4j, Cypher, Persistence · *Intermediate*
+- **[Ontology](https://github.com/semantica-agi/semantica/blob/main/cookbook/introduction/14_Ontology.ipynb)** — Defining domain schemas and ontologies to structure your data. Topics: OWL, RDF, Schema Design · *Intermediate*
 
 
 ## Advanced Concepts
 
 Deep dive into advanced features, customization, and complex workflows.
 
-<CardGroup cols={2}>
-  <Card title="Advanced Extraction" icon="flask" href="https://github.com/semantica-agi/semantica/blob/main/cookbook/advanced/01_Advanced_Extraction.ipynb">
-    Custom extractors, LLM-based extraction, and complex pattern matching.
-
-    **Topics:** Custom Models, Regex, LLMs · **Difficulty:** Advanced
-  </Card>
-  <Card title="Advanced Graph Analytics" icon="chart-network" href="https://github.com/semantica-agi/semantica/blob/main/cookbook/advanced/02_Advanced_Graph_Analytics.ipynb">
-    Centrality, community detection, and pathfinding algorithms.
-
-    **Topics:** PageRank, Louvain, Shortest Path · **Difficulty:** Advanced
-  </Card>
-  <Card title="Advanced Context Engineering" icon="brain" href="https://github.com/semantica-agi/semantica/blob/main/cookbook/advanced/11_Advanced_Context_Engineering.ipynb">
-    Production-grade memory system for AI agents using FAISS and Neo4j.
-
-    **Topics:** Agent Memory, GraphRAG, Entity Injection · **Difficulty:** Advanced
-  </Card>
-  <Card title="Complete Visualization Suite" icon="chart-bar" href="https://github.com/semantica-agi/semantica/blob/main/cookbook/advanced/03_Complete_Visualization_Suite.ipynb">
-    Interactive, publication-ready visualizations of your graphs.
-
-    **Topics:** PyVis, NetworkX, D3.js · **Difficulty:** Intermediate
-  </Card>
-  <Card title="Conflict Resolution" icon="scale-balanced" href="https://github.com/semantica-agi/semantica/blob/main/cookbook/introduction/17_Conflict_Detection_and_Resolution.ipynb">
-    Strategies for handling contradictory information from multiple sources.
-
-    **Topics:** Truth Discovery, Voting, Confidence · **Difficulty:** Advanced
-  </Card>
-  <Card title="Multi-Format Export" icon="file-export" href="https://github.com/semantica-agi/semantica/blob/main/cookbook/advanced/05_Multi_Format_Export.ipynb">
-    Exporting to RDF, OWL, JSON-LD, and NetworkX formats.
-
-    **Topics:** Serialization, Interoperability · **Difficulty:** Intermediate
-  </Card>
-  <Card title="Multi-Source Integration" icon="code-merge" href="https://github.com/semantica-agi/semantica/blob/main/cookbook/advanced/06_Multi_Source_Data_Integration.ipynb">
-    Merging data from disparate sources into a unified graph.
-
-    **Topics:** Entity Resolution, Merging, Fusion · **Difficulty:** Advanced
-  </Card>
-  <Card title="Pipeline Orchestration" icon="gear" href="https://github.com/semantica-agi/semantica/blob/main/cookbook/advanced/07_Pipeline_Orchestration.ipynb">
-    Building robust, automated data processing pipelines.
-
-    **Topics:** Workflows, Automation, Error Handling · **Difficulty:** Advanced
-  </Card>
-  <Card title="Reasoning and Inference" icon="brain" href="https://github.com/semantica-agi/semantica/blob/main/cookbook/advanced/08_Reasoning_and_Inference.ipynb">
-    Using logical reasoning to infer new knowledge from existing facts.
-
-    **Topics:** Logic Rules, Inference Engines · **Difficulty:** Advanced
-  </Card>
-  <Card title="Temporal Knowledge Graphs" icon="clock" href="https://github.com/semantica-agi/semantica/blob/main/cookbook/advanced/10_Temporal_Knowledge_Graphs.ipynb">
-    Modeling and querying data that changes over time.
-
-    **Topics:** Time Series, Temporal Logic, Allen Algebra · **Difficulty:** Advanced
-  </Card>
-</CardGroup>
+- **[Advanced Extraction](https://github.com/semantica-agi/semantica/blob/main/cookbook/advanced/01_Advanced_Extraction.ipynb)** — Custom extractors, LLM-based extraction, and complex pattern matching. Topics: Custom Models, Regex, LLMs · *Advanced*
+- **[Advanced Graph Analytics](https://github.com/semantica-agi/semantica/blob/main/cookbook/advanced/02_Advanced_Graph_Analytics.ipynb)** — Centrality, community detection, and pathfinding algorithms. Topics: PageRank, Louvain, Shortest Path · *Advanced*
+- **[Advanced Context Engineering](https://github.com/semantica-agi/semantica/blob/main/cookbook/advanced/11_Advanced_Context_Engineering.ipynb)** — Production-grade memory system for AI agents using FAISS and Neo4j. Topics: Agent Memory, GraphRAG, Entity Injection · *Advanced*
+- **[Complete Visualization Suite](https://github.com/semantica-agi/semantica/blob/main/cookbook/advanced/03_Complete_Visualization_Suite.ipynb)** — Interactive, publication-ready visualizations of your graphs. Topics: PyVis, NetworkX, D3.js · *Intermediate*
+- **[Conflict Resolution](https://github.com/semantica-agi/semantica/blob/main/cookbook/introduction/17_Conflict_Detection_and_Resolution.ipynb)** — Strategies for handling contradictory information from multiple sources. Topics: Truth Discovery, Voting, Confidence · *Advanced*
+- **[Multi-Format Export](https://github.com/semantica-agi/semantica/blob/main/cookbook/advanced/05_Multi_Format_Export.ipynb)** — Exporting to RDF, OWL, JSON-LD, and NetworkX formats. Topics: Serialization, Interoperability · *Intermediate*
+- **[Multi-Source Integration](https://github.com/semantica-agi/semantica/blob/main/cookbook/advanced/06_Multi_Source_Data_Integration.ipynb)** — Merging data from disparate sources into a unified graph. Topics: Entity Resolution, Merging, Fusion · *Advanced*
+- **[Pipeline Orchestration](https://github.com/semantica-agi/semantica/blob/main/cookbook/advanced/07_Pipeline_Orchestration.ipynb)** — Building robust, automated data processing pipelines. Topics: Workflows, Automation, Error Handling · *Advanced*
+- **[Reasoning and Inference](https://github.com/semantica-agi/semantica/blob/main/cookbook/advanced/08_Reasoning_and_Inference.ipynb)** — Using logical reasoning to infer new knowledge from existing facts. Topics: Logic Rules, Inference Engines · *Advanced*
+- **[Temporal Knowledge Graphs](https://github.com/semantica-agi/semantica/blob/main/cookbook/advanced/10_Temporal_Knowledge_Graphs.ipynb)** — Modeling and querying data that changes over time. Topics: Time Series, Temporal Logic, Allen Algebra · *Advanced*
 
 
 ## How to Run

--- a/docs/explorer-setup.md
+++ b/docs/explorer-setup.md
@@ -264,17 +264,7 @@ Once running, Explorer exposes a REST API and dashboard for:
 
 The full endpoint catalogue is documented in the Swagger UI at `/docs` and in the reference page below.
 
-<CardGroup cols={2}>
-  <Card title="Explorer Reference" icon="book-open" href="reference/explorer">
-    Every REST endpoint, WebSocket events, analytics, and all supported flags.
-  </Card>
-  <Card title="CLI Setup" icon="terminal" href="cli-setup">
-    All five Semantica executables and when to use each one.
-  </Card>
-  <Card title="Context Module" icon="brain" href="reference/context">
-    Full documentation for ContextGraph: build, query, save, and load.
-  </Card>
-  <Card title="Quickstart" icon="rocket" href="quickstart">
-    End-to-end pipeline: ingest → extract → build graph → export.
-  </Card>
-</CardGroup>
+- [Explorer Reference](reference/explorer) — Every REST endpoint, WebSocket events, analytics, and all supported flags.
+- [CLI Setup](cli-setup) — All five Semantica executables and when to use each one.
+- [Context Module](reference/context) — Full documentation for ContextGraph: build, query, save, and load.
+- [Quickstart](quickstart) — End-to-end pipeline: ingest → extract → build graph → export.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -338,14 +338,6 @@ set PYTHONIOENCODING=utf-8
 
 ## Support
 
-<CardGroup cols={3}>
-  <Card title="Discord" icon="discord" href="https://discord.gg/sV34vps5hH">
-    Community chat and live support.
-  </Card>
-  <Card title="GitHub Issues" icon="github" href="https://github.com/semantica-agi/semantica/issues">
-    Bug reports and feature requests.
-  </Card>
-  <Card title="Contributing" icon="code-pull-request" href="contributing-guide">
-    Help improve Semantica.
-  </Card>
-</CardGroup>
+- [Discord](https://discord.gg/sV34vps5hH) — Community chat and live support.
+- [GitHub Issues](https://github.com/semantica-agi/semantica/issues) — Bug reports and feature requests.
+- [Contributing](contributing-guide) — Help improve Semantica.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -10,20 +10,10 @@ icon: "rocket"
 
 ## What You Can Build
 
-<CardGroup cols={2}>
-  <Card title="GraphRAG Systems" icon="diagram-project">
-    Ground LLM responses in traceable, structured knowledge. Every claim links back to a source node.
-  </Card>
-  <Card title="Accountable AI Agents" icon="robot">
-    Agents with structured decision history, causal chains, and precedent search. Every choice is recorded and auditable.
-  </Card>
-  <Card title="Production Knowledge Graphs" icon="sitemap">
-    Build, validate, and maintain enterprise-grade semantic knowledge bases from multi-source data.
-  </Card>
-  <Card title="Compliance-Ready AI" icon="shield-check">
-    W3C PROV-O provenance on every fact. HIPAA, SOX, GDPR, FDA 21 CFR Part 11 infrastructure built in.
-  </Card>
-</CardGroup>
+- **GraphRAG Systems** — Ground LLM responses in traceable, structured knowledge. Every claim links back to a source node.
+- **Accountable AI Agents** — Agents with structured decision history, causal chains, and precedent search. Every choice is recorded and auditable.
+- **Production Knowledge Graphs** — Build, validate, and maintain enterprise-grade semantic knowledge bases from multi-source data.
+- **Compliance-Ready AI** — W3C PROV-O provenance on every fact. HIPAA, SOX, GDPR, FDA 21 CFR Part 11 infrastructure built in.
 
 
 ## Setup in 3 Steps
@@ -204,32 +194,12 @@ icon: "rocket"
 
 Semantica uses a modular, layered architecture: import only what you need.
 
-<CardGroup cols={3}>
-  <Card title="Input Layer" icon="database" href="reference/ingest">
-    Load and prepare data from any source.
-    **Modules:** `ingest`, `parse`, `split`, `normalize`
-  </Card>
-  <Card title="Semantic Layer" icon="microchip" href="reference/semantic_extract">
-    Extract meaning from raw text.
-    **Modules:** `semantic_extract`, `kg`, `ontology`, `reasoning`
-  </Card>
-  <Card title="Storage Layer" icon="hard-drive" href="reference/vector_store">
-    Persist knowledge for retrieval.
-    **Modules:** `embeddings`, `vector_store`, `graph_store`, `triplet_store`
-  </Card>
-  <Card title="Quality Layer" icon="check-circle" href="reference/deduplication">
-    Validate and deduplicate.
-    **Modules:** `deduplication`, `conflicts`
-  </Card>
-  <Card title="Context Layer" icon="brain" href="reference/context">
-    Track decisions and lineage.
-    **Modules:** `context`, `provenance`, `change_management`
-  </Card>
-  <Card title="Output Layer" icon="share-nodes" href="reference/export">
-    Deliver results downstream.
-    **Modules:** `export`, `visualization`, `pipeline`, `explorer`
-  </Card>
-</CardGroup>
+- **[Input Layer](reference/ingest)** — Load and prepare data from any source. Modules: `ingest`, `parse`, `split`, `normalize`
+- **[Semantic Layer](reference/semantic_extract)** — Extract meaning from raw text. Modules: `semantic_extract`, `kg`, `ontology`, `reasoning`
+- **[Storage Layer](reference/vector_store)** — Persist knowledge for retrieval. Modules: `embeddings`, `vector_store`, `graph_store`, `triplet_store`
+- **[Quality Layer](reference/deduplication)** — Validate and deduplicate. Modules: `deduplication`, `conflicts`
+- **[Context Layer](reference/context)** — Track decisions and lineage. Modules: `context`, `provenance`, `change_management`
+- **[Output Layer](reference/export)** — Deliver results downstream. Modules: `export`, `visualization`, `pipeline`, `explorer`
 
 
 ## "Which module do I need?" Quick Reference
@@ -252,32 +222,14 @@ Semantica uses a modular, layered architecture: import only what you need.
 
 ## Next Steps
 
-<CardGroup cols={2}>
-  <Card title="Core Concepts" icon="book-open" href="concepts">
-    Knowledge graphs, ontologies, and reasoning explained in depth.
-  </Card>
-  <Card title="Quickstart Tutorial" icon="play" href="quickstart">
-    Full 6-step pipeline walkthrough with working code.
-  </Card>
-  <Card title="Module Reference" icon="puzzle-piece" href="modules">
-    Every module, class, and common chain explained.
-  </Card>
-  <Card title="API Reference" icon="code" href="reference/context">
-    Complete module documentation for every class and method.
-  </Card>
-</CardGroup>
+- [Core Concepts](concepts) — Knowledge graphs, ontologies, and reasoning explained in depth.
+- [Quickstart Tutorial](quickstart) — Full 6-step pipeline walkthrough with working code.
+- [Module Reference](modules) — Every module, class, and common chain explained.
+- [API Reference](reference/context) — Complete module documentation for every class and method.
 
 
 ## Help
 
-<CardGroup cols={3}>
-  <Card title="Discord" icon="discord" href="https://discord.gg/sV34vps5hH">
-    Ask questions, share projects, get community support.
-  </Card>
-  <Card title="GitHub Issues" icon="github" href="https://github.com/semantica-agi/semantica/issues">
-    Report bugs or request features.
-  </Card>
-  <Card title="FAQ" icon="circle-question" href="faq">
-    Common questions answered.
-  </Card>
-</CardGroup>
+- [Discord](https://discord.gg/sV34vps5hH) — Ask questions, share projects, get community support.
+- [GitHub Issues](https://github.com/semantica-agi/semantica/issues) — Report bugs or request features.
+- [FAQ](faq) — Common questions answered.

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -214,17 +214,7 @@ A vulnerability in XML parsers that allows attackers to read arbitrary files or 
 
 ## See Also
 
-<CardGroup cols={2}>
-  <Card title="Core Concepts" icon="lightbulb" href="concepts">
-    Deeper explanation of key ideas with code examples.
-  </Card>
-  <Card title="Getting Started" icon="play" href="getting-started">
-    First working examples: no prior graph experience required.
-  </Card>
-  <Card title="Modules Guide" icon="cubes" href="modules">
-    All 27 modules explained with code and pipeline chains.
-  </Card>
-  <Card title="API Reference" icon="code" href="reference/context">
-    Complete technical reference for every class and method.
-  </Card>
-</CardGroup>
+- [Core Concepts](concepts) — Deeper explanation of key ideas with code examples.
+- [Getting Started](getting-started) — First working examples: no prior graph experience required.
+- [Modules Guide](modules) — All 27 modules explained with code and pipeline chains.
+- [API Reference](reference/context) — Complete technical reference for every class and method.

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -9,17 +9,9 @@ icon: "scale-balanced"
 
 ## Roles
 
-<CardGroup cols={3}>
-  <Card title="Maintainers" icon="shield-halved">
-    Hawksight AI team: review and merge PRs, manage releases and code quality, set project direction and community standards.
-  </Card>
-  <Card title="Contributors" icon="code-pull-request">
-    Submit code, documentation, and bug reports. Help with issues and reviews. Recognized in [CONTRIBUTORS.md](https://github.com/semantica-agi/semantica/blob/main/CONTRIBUTORS.md).
-  </Card>
-  <Card title="Community Members" icon="users">
-    Use Semantica, provide feedback, share use cases, and participate in GitHub Discussions and Discord.
-  </Card>
-</CardGroup>
+- **Maintainers** — Hawksight AI team: review and merge PRs, manage releases and code quality, set project direction and community standards.
+- **Contributors** — Submit code, documentation, and bug reports. Help with issues and reviews. Recognized in [CONTRIBUTORS.md](https://github.com/semantica-agi/semantica/blob/main/CONTRIBUTORS.md).
+- **Community Members** — Use Semantica, provide feedback, share use cases, and participate in GitHub Discussions and Discord.
 
 
 ## Decision Process
@@ -73,23 +65,11 @@ Semantica follows **Semantic Versioning** (`MAJOR.MINOR.PATCH`):
 
 ## Project Goals
 
-<CardGroup cols={3}>
-  <Card title="Usability" icon="hand-pointer">
-    Easy to use and understand: sensible defaults, clear documentation, minimal ceremony.
-  </Card>
-  <Card title="Reliability" icon="circle-check">
-    Production-ready quality: tested across Python versions, platforms, and real-world workloads.
-  </Card>
-  <Card title="Performance" icon="bolt">
-    Efficient and scalable: from single-machine notebooks to enterprise graph databases.
-  </Card>
-  <Card title="Extensibility" icon="puzzle-piece">
-    Easy to extend with plugins and custom modules via the `PluginRegistry` pattern.
-  </Card>
-  <Card title="Community" icon="heart">
-    Welcoming and inclusive: all backgrounds and experience levels contribute and are recognized.
-  </Card>
-</CardGroup>
+- **Usability** — Easy to use and understand: sensible defaults, clear documentation, minimal ceremony.
+- **Reliability** — Production-ready quality: tested across Python versions, platforms, and real-world workloads.
+- **Performance** — Efficient and scalable: from single-machine notebooks to enterprise graph databases.
+- **Extensibility** — Easy to extend with plugins and custom modules via the `PluginRegistry` pattern.
+- **Community** — Welcoming and inclusive: all backgrounds and experience levels contribute and are recognized.
 
 
 ## License
@@ -99,11 +79,5 @@ MIT License: see [LICENSE](https://github.com/semantica-agi/semantica/blob/main/
 
 ## See Also
 
-<CardGroup cols={2}>
-  <Card title="Contributing" icon="code-pull-request" href="contributing-guide">
-    How to submit changes.
-  </Card>
-  <Card title="Community" icon="users" href="community">
-    Community guidelines and channels.
-  </Card>
-</CardGroup>
+- [Contributing](contributing-guide) — How to submit changes.
+- [Community](community) — Community guidelines and channels.

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@ description: "The Accountability and Context Layer for AI: Context Graphs · Dec
 ---
 
 <Info>
-  **v0.5.0 is live**: Ontology Hub, Distance Intelligence, SHACL Studio, Parquet & XML ingestion, 12 security fixes. [What's new →](#whats-new)
+  **v0.5.0 is live** — Ontology Hub, Distance Intelligence, SHACL Studio, Parquet & XML ingestion, 12 security fixes. <a href="#whats-new" style={{color:"#10B981",fontWeight:600,textDecoration:"none"}}>What's new →</a>
 </Info>
 
 Your AI agent just made a decision. Now someone needs to explain it.
@@ -15,58 +15,42 @@ If your stack can't answer those questions with a traceable record, you have a g
 
 **Semantica closes that gap.** It's the context and accountability layer that sits beneath your existing agent framework: not a replacement for LangChain or LlamaIndex, but the infrastructure that makes their outputs trustworthy.
 
-<CardGroup cols={4}>
-  <Card title="1,000+ Tests" icon="circle-check">
-    Production-hardened with a full regression suite
-  </Card>
-  <Card title="25+ Modules" icon="puzzle-piece">
-    Every capability independently importable
-  </Card>
-  <Card title="12 LLM Providers" icon="microchip">
-    OpenAI, Anthropic, Ollama, Groq, and more
-  </Card>
-  <Card title="MIT Licensed" icon="code-branch">
-    Open source, no vendor lock-in, fully forkable
-  </Card>
-</CardGroup>
+<div style={{display:"flex",flexWrap:"wrap",gap:"3rem",margin:"2rem 0",padding:"1.5rem 2rem",borderRadius:"10px",border:"1px solid rgba(16,185,129,0.2)",background:"rgba(16,185,129,0.03)"}}>
+  <div><div style={{fontSize:"1.75rem",fontWeight:700,color:"#10B981",lineHeight:1.1}}>1,000+</div><div style={{fontSize:"0.8rem",color:"rgba(255,255,255,0.5)",marginTop:"4px"}}>passing tests</div></div>
+  <div><div style={{fontSize:"1.75rem",fontWeight:700,color:"#10B981",lineHeight:1.1}}>25+</div><div style={{fontSize:"0.8rem",color:"rgba(255,255,255,0.5)",marginTop:"4px"}}>modules</div></div>
+  <div><div style={{fontSize:"1.75rem",fontWeight:700,color:"#10B981",lineHeight:1.1}}>12</div><div style={{fontSize:"0.8rem",color:"rgba(255,255,255,0.5)",marginTop:"4px"}}>LLM providers</div></div>
+  <div><div style={{fontSize:"1.75rem",fontWeight:700,color:"#10B981",lineHeight:1.1}}>MIT</div><div style={{fontSize:"0.8rem",color:"rgba(255,255,255,0.5)",marginTop:"4px"}}>open source</div></div>
+</div>
 
 
 ## The Problem Every Production AI Team Hits
 
 Powerful agents aren't automatically trustworthy ones. Five structural blind spots make modern AI systems impossible to deploy in regulated environments:
 
-<CardGroup cols={2}>
-  <Card title="No memory structure" icon="brain">
-    Agents store embeddings, not meaning.
-    - No way to ask *why* a fact was recalled
-    - No link from a recalled fact back to its source document
-    - Context is a black box that resets on every run
-  </Card>
-  <Card title="No decision trail" icon="clock-rotate-left">
-    Agents act continuously but record nothing.
-    - No history to hand to a regulator or auditor
-    - No way to replay or reproduce a past decision
-    - Debugging means re-running, not reviewing
-  </Card>
-  <Card title="No provenance" icon="link-slash">
-    Outputs can't be traced to source facts.
-    - In healthcare, finance, and legal: this is a hard compliance blocker
-    - No lineage from inference back to the original document
-    - Impossible to demonstrate what the agent actually relied on
-  </Card>
-  <Card title="No reasoning transparency" icon="eye-slash">
-    Black-box answers with no explanation.
-    - Impossible to validate the reasoning path
-    - Impossible to contest a specific conclusion
-    - No basis for improving or correcting future behavior
-  </Card>
-  <Card title="No conflict detection" icon="triangle-exclamation">
-    Contradictory facts silently coexist in vector stores.
-    - No detection when two sources disagree
-    - Outputs become inconsistent and unpredictable over time
-    - Silent failures compound as the knowledge base grows
-  </Card>
-</CardGroup>
+**No memory structure** — agents store embeddings, not meaning
+- No way to ask *why* a fact was recalled
+- No link from a recalled fact back to its source document
+- Context is a black box that resets on every run
+
+**No decision trail** — agents act continuously but record nothing
+- No history to hand to a regulator or auditor
+- No way to replay or reproduce a past decision
+- Debugging means re-running, not reviewing
+
+**No provenance** — outputs can't be traced to source facts
+- In healthcare, finance, and legal: this is a hard compliance blocker
+- No lineage from inference back to the original document
+- Impossible to demonstrate what the agent actually relied on
+
+**No reasoning transparency** — black-box answers with no explanation
+- Impossible to validate the reasoning path
+- Impossible to contest a specific conclusion
+- No basis for improving or correcting future behavior
+
+**No conflict detection** — contradictory facts silently coexist in vector stores
+- No detection when two sources disagree
+- Outputs become inconsistent and unpredictable over time
+- Silent failures compound as the knowledge base grows
 
 <Note>
   These aren't edge cases. They're why enterprise AI pilots stall: and why your compliance team keeps saying *not yet*.
@@ -77,50 +61,41 @@ Powerful agents aren't automatically trustworthy ones. Five structural blind spo
 
 Semantica gives every agent the infrastructure it needs to be accountable. Drop it into your existing setup in minutes:
 
-<CardGroup cols={2}>
-  <Card title="Context Graphs" icon="diagram-project">
-    A structured, queryable graph of everything your agent knows, decides, and reasons about.
-    - Persistent across agent runs: no context loss between sessions
-    - Queryable with SPARQL and full graph algorithms
-    - Temporal model with `valid_from` / `valid_until` on nodes and edges
-    - Point-in-time snapshots of the full knowledge state
-  </Card>
-  <Card title="Decision Intelligence" icon="check-circle">
-    Every decision is a first-class object in your system.
-    - `record_decision()` captures full lifecycle and causal chain
-    - Hybrid precedent search over past decisions for consistency
-    - `analyze_decision_impact()` shows downstream consequences
-    - Causal chain visualization from trigger to outcome
-  </Card>
-  <Card title="Full Provenance" icon="shield-check">
-    Every fact links to its source document and ingestion event.
-    - W3C PROV-O compliant lineage across all modules
-    - Full traceability from raw input to final inference
-    - `recorded_at` stamping with OWL-Time export
-    - Audit-ready for HIPAA, SOX, GDPR, FDA 21 CFR Part 11
-  </Card>
-  <Card title="Reasoning Engines" icon="microchip">
-    Explainable reasoning paths: not black boxes.
-    - Forward chaining, Rete, deductive, abductive
-    - SPARQL query-based inference over RDF graphs
-    - Datalog with recursive Horn clause rules
-    - Every conclusion backed by a traceable derivation path
-  </Card>
-  <Card title="Temporal Intelligence" icon="clock">
-    Your graph knows not just *what*: but *when*.
-    - Allen interval algebra: all 13 temporal relations
-    - Point-in-time queries over historical graph states
-    - Temporal provenance stamping on every fact
-    - OWL-Time export for standards-compliant archiving
-  </Card>
-  <Card title="Ontology Hub" icon="sitemap">
-    Full ontology lifecycle in the browser.
-    - Visual editor for schema design and editing
-    - SHACL Studio for constraint authoring and validation
-    - Alignment authoring across multiple ontologies
-    - Health dashboard and version control built in
-  </Card>
-</CardGroup>
+**Context Graphs** — a structured, queryable graph of everything your agent knows, decides, and reasons about
+- Persistent across agent runs: no context loss between sessions
+- Queryable with SPARQL and full graph algorithms
+- Temporal model with `valid_from` / `valid_until` on nodes and edges
+- Point-in-time snapshots of the full knowledge state
+
+**Decision Intelligence** — every decision is a first-class object in your system
+- `record_decision()` captures full lifecycle and causal chain
+- Hybrid precedent search over past decisions for consistency
+- `analyze_decision_impact()` shows downstream consequences
+- Causal chain visualization from trigger to outcome
+
+**Full Provenance** — every fact links to its source document and ingestion event
+- W3C PROV-O compliant lineage across all modules
+- Full traceability from raw input to final inference
+- `recorded_at` stamping with OWL-Time export
+- Audit-ready for HIPAA, SOX, GDPR, FDA 21 CFR Part 11
+
+**Reasoning Engines** — explainable reasoning paths, not black boxes
+- Forward chaining, Rete, deductive, abductive
+- SPARQL query-based inference over RDF graphs
+- Datalog with recursive Horn clause rules
+- Every conclusion backed by a traceable derivation path
+
+**Temporal Intelligence** — your graph knows not just *what*, but *when*
+- Allen interval algebra: all 13 temporal relations
+- Point-in-time queries over historical graph states
+- Temporal provenance stamping on every fact
+- OWL-Time export for standards-compliant archiving
+
+**Ontology Hub** — full ontology lifecycle in the browser
+- Visual editor for schema design and editing
+- SHACL Studio for constraint authoring and validation
+- Alignment authoring across multiple ontologies
+- Health dashboard and version control built in
 
 <Tip>
   Works alongside any LLM provider and any agent framework: add it to an existing stack without changing your architecture.
@@ -217,61 +192,50 @@ decision_id = context.record_decision(
 
 </CodeGroup>
 
-<CardGroup cols={3}>
-  <Card title="Full Quickstart" icon="rocket" href="quickstart">
-    Step-by-step pipeline walkthrough
-  </Card>
-  <Card title="Cookbook" icon="flask" href="cookbook">
-    40+ real-world Jupyter notebooks
-  </Card>
-  <Card title="Join Discord" icon="discord" href="https://discord.gg/sV34vps5hH">
-    Community chat and support
-  </Card>
-</CardGroup>
+- [Full Quickstart](quickstart) — Step-by-step pipeline walkthrough
+- [Cookbook](cookbook) — 40+ real-world Jupyter notebooks
+- [Join Discord](https://discord.gg/sV34vps5hH) — Community chat and support
 
 
 ## Built for Where Mistakes Have Consequences
 
 Semantica was designed for domains where every decision must be explainable and every fact must be traceable:
 
-<CardGroup cols={2}>
-  <Card title="Healthcare & Life Sciences" icon="heart-pulse">
-    - Clinical decision support with full audit trails
-    - Drug interaction and contraindication graphs
-    - Patient safety event tracking and root-cause analysis
-    - HIPAA-compliant provenance chains out of the box
-  </Card>
-  <Card title="Finance & Risk" icon="chart-line">
-    - Fraud detection knowledge graphs
-    - Risk assessment trails built to survive an audit
-    - SOX, GDPR, and MiFID II compliance infrastructure
-    - Model decision lineage for regulatory reporting
-  </Card>
-  <Card title="Legal & Compliance" icon="scale-balanced">
-    - Evidence-backed research with every cited fact provenance-linked
-    - Contract analysis with traceable clause extraction
-    - Regulatory change tracking across jurisdictions
-    - Full reasoning paths ready for court-admissible documentation
-  </Card>
-  <Card title="Cybersecurity" icon="shield">
-    - Threat attribution graphs linking actors, TTPs, and indicators
-    - Incident response timelines with full event provenance
-    - Security audit trails across the complete kill chain
-    - MITRE ATT&CK-aligned knowledge graph integration
-  </Card>
-  <Card title="Government & Defense" icon="building-columns">
-    - Policy decision trails from brief to outcome
-    - Classified information handling with provenance chains
-    - Chain-of-custody scrutiny for intelligence reporting
-    - Air-gapped deployment with local LLM support
-  </Card>
-  <Card title="Critical Infrastructure" icon="bolt">
-    - Power grid state tracking with temporal intelligence
-    - Transportation safety event graphs
-    - Emergency response coordination with decision audit trails
-    - Consequence modeling for high-stakes operational decisions
-  </Card>
-</CardGroup>
+**Healthcare & Life Sciences**
+- Clinical decision support with full audit trails
+- Drug interaction and contraindication graphs
+- Patient safety event tracking and root-cause analysis
+- HIPAA-compliant provenance chains out of the box
+
+**Finance & Risk**
+- Fraud detection knowledge graphs
+- Risk assessment trails built to survive an audit
+- SOX, GDPR, and MiFID II compliance infrastructure
+- Model decision lineage for regulatory reporting
+
+**Legal & Compliance**
+- Evidence-backed research with every cited fact provenance-linked
+- Contract analysis with traceable clause extraction
+- Regulatory change tracking across jurisdictions
+- Full reasoning paths ready for court-admissible documentation
+
+**Cybersecurity**
+- Threat attribution graphs linking actors, TTPs, and indicators
+- Incident response timelines with full event provenance
+- Security audit trails across the complete kill chain
+- MITRE ATT&CK-aligned knowledge graph integration
+
+**Government & Defense**
+- Policy decision trails from brief to outcome
+- Classified information handling with provenance chains
+- Chain-of-custody scrutiny for intelligence reporting
+- Air-gapped deployment with local LLM support
+
+**Critical Infrastructure**
+- Power grid state tracking with temporal intelligence
+- Transportation safety event graphs
+- Emergency response coordination with decision audit trails
+- Consequence modeling for high-stakes operational decisions
 
 
 ## Start Here
@@ -305,23 +269,11 @@ Semantica was designed for domains where every decision must be explainable and 
   </Step>
 </Steps>
 
-<CardGroup cols={2}>
-  <Card title="Installation" icon="download" href="installation">
-    Get Semantica installed in under a minute
-  </Card>
-  <Card title="Quickstart" icon="rocket" href="quickstart">
-    Build a complete knowledge graph pipeline in 5 minutes
-  </Card>
-  <Card title="Core Concepts" icon="book-open" href="concepts">
-    The mental model behind the API
-  </Card>
-  <Card title="API Reference" icon="rectangle-terminal" href="reference/context">
-    Exact module, class, and method details
-  </Card>
-  <Card title="Cookbook" icon="flask" href="cookbook">
-    Domain notebooks for real-world use cases
-  </Card>
-</CardGroup>
+- [Installation](installation) — Get Semantica installed in under a minute
+- [Quickstart](quickstart) — Build a complete knowledge graph pipeline in 5 minutes
+- [Core Concepts](concepts) — The mental model behind the API
+- [API Reference](reference/context) — Exact module, class, and method details
+- [Cookbook](cookbook) — Domain notebooks for real-world use cases
 
 
 ## What's New
@@ -332,15 +284,13 @@ Semantica was designed for domains where every decision must be explainable and 
 
 Released **May 11, 2026**
 
-| Area | Highlights |
-| :------ | :------------ |
-| **Ontology Hub** | Visual editor, SHACL Studio, alignment authoring, health dashboard, version control: full ontology lifecycle in the browser |
-| **Distance Intelligence** | Semantic neighborhoods, N×N distance matrices, ego-mode visualization, distance band classification, embedding cache optimization |
-| **Parquet Ingestion** | `ParquetIngestor` with PyArrow: single file, partitioned directories, Hive-style discovery, selective column reading |
-| **XML Ingestion** | `XMLIngestor` with XXE-safe lxml backend, XSD/DTD validation, namespace handling, directory scanning |
-| **Graph Explorer** | Landing page redesign, bidirectional path finding, indexed search (0.004ms on 118k nodes) |
-| **Security** | 12 vulnerability fixes: eval injection, pickle deserialization, SQL injection, XXE, SSRF, ReDoS, path traversal |
-| **Bug Fixes** | NER LLM silent fallback on enterprise gateways, ConflictDetector duplicate definition, Windows `[all]` install, cp1252 crash |
+- **Ontology Hub** — Visual editor, SHACL Studio, alignment authoring, health dashboard, version control: full ontology lifecycle in the browser
+- **Distance Intelligence** — Semantic neighborhoods, N×N distance matrices, ego-mode visualization, distance band classification, embedding cache optimization
+- **Parquet Ingestion** — `ParquetIngestor` with PyArrow: single file, partitioned directories, Hive-style discovery, selective column reading
+- **XML Ingestion** — `XMLIngestor` with XXE-safe lxml backend, XSD/DTD validation, namespace handling, directory scanning
+- **Graph Explorer** — Landing page redesign, bidirectional path finding, indexed search (0.004ms on 118k nodes)
+- **Security** — 12 vulnerability fixes: eval injection, pickle deserialization, SQL injection, XXE, SSRF, ReDoS, path traversal
+- **Bug Fixes** — NER LLM silent fallback on enterprise gateways, ConflictDetector duplicate definition, Windows `[all]` install, cp1252 crash
 
 ```bash
 pip install semantica==0.5.0
@@ -350,13 +300,11 @@ pip install semantica==0.5.0
 
 <Accordion title="v0.4.0: Temporal Intelligence & Knowledge Explorer" icon="clock">
 
-| Area | Highlights |
-| :------ | :------------ |
-| **Temporal Intelligence** | 6-PR system: temporal data model, point-in-time queries, Allen interval algebra (all 13 relations), OWL-Time export |
-| **Knowledge Explorer API** | Full FastAPI backend: 99 tests, 12 export formats, WebSocket progress, thread-safe sessions, audit trail |
-| **Ontology Foundations** | SHACL generation/validation, SKOS vocabulary, ontology alignment API, diff & migration tooling |
-| **Datalog Reasoning** | Pure-Python bottom-up semi-naive fixpoint, recursive Horn clause rules, guaranteed termination |
-| **Agno Integration** | 5 components: graph-backed memory, multi-hop GraphRAG, decision toolkit, KG toolkit, shared team context; 110 tests |
+- **Temporal Intelligence** — 6-PR system: temporal data model, point-in-time queries, Allen interval algebra (all 13 relations), OWL-Time export
+- **Knowledge Explorer API** — Full FastAPI backend: 99 tests, 12 export formats, WebSocket progress, thread-safe sessions, audit trail
+- **Ontology Foundations** — SHACL generation/validation, SKOS vocabulary, ontology alignment API, diff & migration tooling
+- **Datalog Reasoning** — Pure-Python bottom-up semi-naive fixpoint, recursive Horn clause rules, guaranteed termination
+- **Agno Integration** — 5 components: graph-backed memory, multi-hop GraphRAG, decision toolkit, KG toolkit, shared team context; 110 tests
 
 </Accordion>
 
@@ -483,26 +431,20 @@ pip install semantica==0.5.0
 
 ## Why Semantica?
 
-<CardGroup cols={3}>
-  <Card title="Open Source, MIT" icon="code-branch">
-    No vendor lock-in. No paywalled features.
-    - Full source available on GitHub
-    - Every line auditable by your security team
-    - Fork, extend, and self-host with no restrictions
-    - No telemetry, no usage reporting
-  </Card>
-  <Card title="Production Ready" icon="circle-check">
-    Built for teams that can't afford surprises.
-    - 1,000+ passing tests with full regression coverage
-    - `PipelineValidator` catches configuration errors at startup
-    - `FailureHandler` with exponential backoff and dead-letter queues
-    - 12 security vulnerabilities fixed in v0.5.0
-  </Card>
-  <Card title="Modular by Design" icon="puzzle-piece">
-    Import only what you need.
-    - Use `NERExtractor` without a graph store
-    - Use `ContextGraph` without vector storage
-    - Every component independently swappable and testable
-    - No framework lock-in: works with any agent stack
-  </Card>
-</CardGroup>
+**Open Source, MIT** — No vendor lock-in. No paywalled features.
+- Full source available on GitHub
+- Every line auditable by your security team
+- Fork, extend, and self-host with no restrictions
+- No telemetry, no usage reporting
+
+**Production Ready** — Built for teams that can't afford surprises.
+- 1,000+ passing tests with full regression coverage
+- `PipelineValidator` catches configuration errors at startup
+- `FailureHandler` with exponential backoff and dead-letter queues
+- 12 security vulnerabilities fixed in v0.5.0
+
+**Modular by Design** — Import only what you need.
+- Use `NERExtractor` without a graph store
+- Use `ContextGraph` without vector storage
+- Every component independently swappable and testable
+- No framework lock-in: works with any agent stack

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -183,14 +183,6 @@ Install the [Microsoft Visual C++ Redistributable](https://aka.ms/vs/17/release/
 
 ## Next Steps
 
-<CardGroup cols={3}>
-  <Card title="Getting Started" icon="rocket" href="getting-started">
-    Understand what Semantica does before you build.
-  </Card>
-  <Card title="Build the Pipeline" icon="play" href="quickstart">
-    Follow the end-to-end workflow with code.
-  </Card>
-  <Card title="Browse Examples" icon="flask" href="cookbook">
-    See notebook examples organized by use case.
-  </Card>
-</CardGroup>
+- [Getting Started](getting-started) — Understand what Semantica does before you build.
+- [Build the Pipeline](quickstart) — Follow the end-to-end workflow with code.
+- [Browse Examples](cookbook) — See notebook examples organized by use case.

--- a/docs/integrations/agno.md
+++ b/docs/integrations/agno.md
@@ -24,23 +24,11 @@ pip install "semantica[agno,graph-neo4j,vectorstore-pgvector]"
 
 ## Components at a Glance
 
-<CardGroup cols={2}>
-  <Card title="AgnoContextStore" icon="database">
-    `AgentMemory(db=…)`: Replaces Agno's flat storage with hybrid vector + context graph memory. Adds decision tracking and precedent search to any agent.
-  </Card>
-  <Card title="AgnoKnowledgeGraph" icon="diagram-project">
-    `Agent(knowledge=…)`: Documents flow through the full Semantica extraction pipeline into a queryable `ContextGraph` with multi-hop GraphRAG.
-  </Card>
-  <Card title="AgnoDecisionKit" icon="list-check">
-    `Agent(tools=[…])`: 6 decision intelligence tools: record decisions, find precedents, trace causal chains, analyze impact, check policies, summarize history.
-  </Card>
-  <Card title="AgnoKGToolkit" icon="wrench">
-    `Agent(tools=[…])`: 7 KG construction tools: extract entities, extract relations, add to graph, query graph, find related, infer facts, export subgraph.
-  </Card>
-  <Card title="AgnoSharedContext" icon="users">
-    Team-level: A single `ContextGraph` shared across all agents. Each agent gets a role-scoped view via `bind_agent()`. Writes are tagged by role.
-  </Card>
-</CardGroup>
+- **AgnoContextStore** — `AgentMemory(db=…)`: Replaces Agno's flat storage with hybrid vector + context graph memory. Adds decision tracking and precedent search to any agent.
+- **AgnoKnowledgeGraph** — `Agent(knowledge=…)`: Documents flow through the full Semantica extraction pipeline into a queryable `ContextGraph` with multi-hop GraphRAG.
+- **AgnoDecisionKit** — `Agent(tools=[…])`: 6 decision intelligence tools: record decisions, find precedents, trace causal chains, analyze impact, check policies, summarize history.
+- **AgnoKGToolkit** — `Agent(tools=[…])`: 7 KG construction tools: extract entities, extract relations, add to graph, query graph, find related, infer facts, export subgraph.
+- **AgnoSharedContext** — Team-level: A single `ContextGraph` shared across all agents. Each agent gets a role-scoped view via `bind_agent()`. Writes are tagged by role.
 
 
 ## Component Details
@@ -233,17 +221,7 @@ All five classes are usable without `agno` installed: they carry the full Semant
 
 ## See Also
 
-<CardGroup cols={2}>
-  <Card title="Context Module" icon="brain" href="../reference/context">
-    AgentContext and ContextGraph backing the integration.
-  </Card>
-  <Card title="Knowledge Graph" icon="diagram-project" href="../reference/kg">
-    KG construction used by AgnoKnowledgeGraph.
-  </Card>
-  <Card title="LLMs" icon="microchip" href="../reference/llms">
-    Configure LLM providers for Agno agents.
-  </Card>
-  <Card title="Vector Store" icon="vector-square" href="../reference/vector_store">
-    Vector backend for AgnoContextStore.
-  </Card>
-</CardGroup>
+- [Context Module](../reference/context) — AgentContext and ContextGraph backing the integration.
+- [Knowledge Graph](../reference/kg) — KG construction used by AgnoKnowledgeGraph.
+- [LLMs](../reference/llms) — Configure LLM providers for Agno agents.
+- [Vector Store](../reference/vector_store) — Vector backend for AgnoContextStore.

--- a/docs/integrations/docling.md
+++ b/docs/integrations/docling.md
@@ -11,20 +11,10 @@ icon: "file-lines"
 
 Docling is integrated into Semantica's `parse` module via the **`DoclingParser`**. Documents pass through Docling's **layout engine**, then feed directly into Semantica's extraction and KG pipeline.
 
-<CardGroup cols={2}>
-  <Card title="Multi-format" icon="file">
-    PDF, DOCX, PPTX, HTML, and more.
-  </Card>
-  <Card title="Table Extraction" icon="table">
-    High-fidelity table parsing with header detection.
-  </Card>
-  <Card title="OCR Support" icon="eye">
-    Built-in OCR for scanned documents.
-  </Card>
-  <Card title="Markdown Export" icon="markdown">
-    Clean Markdown output optimized for LLM consumption.
-  </Card>
-</CardGroup>
+- **Multi-format** — PDF, DOCX, PPTX, HTML, and more.
+- **Table Extraction** — High-fidelity table parsing with header detection.
+- **OCR Support** — Built-in OCR for scanned documents.
+- **Markdown Export** — Clean Markdown output optimized for LLM consumption.
 
 
 ## Installation
@@ -100,17 +90,7 @@ print(f"Pages: {result.get('total_pages')}")
 
 ## See Also
 
-<CardGroup cols={2}>
-  <Card title="Parse Module" icon="file-lines" href="../reference/parse">
-    Full DocumentParser and DoclingParser reference.
-  </Card>
-  <Card title="Ingest Module" icon="file-import" href="../reference/ingest">
-    Loading documents before parsing.
-  </Card>
-  <Card title="Semantic Extract" icon="magnifying-glass" href="../reference/semantic_extract">
-    NER and relation extraction on parsed text.
-  </Card>
-  <Card title="Pipeline" icon="gear" href="../reference/pipeline">
-    Using DoclingParser in a full pipeline.
-  </Card>
-</CardGroup>
+- [Parse Module](../reference/parse) — Full DocumentParser and DoclingParser reference.
+- [Ingest Module](../reference/ingest) — Loading documents before parsing.
+- [Semantic Extract](../reference/semantic_extract) — NER and relation extraction on parsed text.
+- [Pipeline](../reference/pipeline) — Using DoclingParser in a full pipeline.

--- a/docs/integrations/snowflake.md
+++ b/docs/integrations/snowflake.md
@@ -171,17 +171,7 @@ if not connector.test_connection():
 
 ## See Also
 
-<CardGroup cols={2}>
-  <Card title="Ingest Module" icon="database" href="../reference/ingest">
-    Full SnowflakeIngestor and all other ingestors.
-  </Card>
-  <Card title="Pipeline" icon="gear" href="../reference/pipeline">
-    Use Snowflake ingestion as a pipeline step.
-  </Card>
-  <Card title="Installation" icon="download" href="../installation">
-    All optional dependency extras.
-  </Card>
-  <Card title="Knowledge Graph" icon="diagram-project" href="../reference/kg">
-    Build a KG from ingested Snowflake data.
-  </Card>
-</CardGroup>
+- [Ingest Module](../reference/ingest) — Full SnowflakeIngestor and all other ingestors.
+- [Pipeline](../reference/pipeline) — Use Snowflake ingestion as a pipeline step.
+- [Installation](../installation) — All optional dependency extras.
+- [Knowledge Graph](../reference/kg) — Build a KG from ingested Snowflake data.

--- a/docs/learning-more.md
+++ b/docs/learning-more.md
@@ -9,20 +9,9 @@ Whether you're running your first pipeline or deploying Semantica in production,
 
 ## Learning Paths
 
-<CardGroup cols={3}>
-  <Card title="Beginner (1–2 hrs)" icon="seedling">
-    New to Semantica and knowledge graphs.
-    [Start with Installation →](installation)
-  </Card>
-  <Card title="Intermediate (4–6 hrs)" icon="compass">
-    Comfortable with basics, building real applications.
-    [Start with Modules →](modules)
-  </Card>
-  <Card title="Advanced (8+ hrs)" icon="rocket">
-    Enterprise deployments, customization, and extension.
-    [Start with Architecture →](architecture)
-  </Card>
-</CardGroup>
+- **Beginner (1–2 hrs)** — New to Semantica and knowledge graphs. [Start with Installation →](installation)
+- **Intermediate (4–6 hrs)** — Comfortable with basics, building real applications. [Start with Modules →](modules)
+- **Advanced (8+ hrs)** — Enterprise deployments, customization, and extension. [Start with Architecture →](architecture)
 
 <Tabs>
   <Tab title="Beginner (1–2 hrs)">
@@ -247,14 +236,6 @@ The `blocking_v2`, `hybrid_v2`, and `semantic_v2` strategies reduce O(n²) compa
 - **Graph exports**: encrypt sensitive exports at rest; use the v0.5.0 SSRF-safe `base_url` validation when configuring custom LLM gateways
 - **XML ingestion**: always use `XMLIngestor` (v0.5.0), which uses the XXE-safe lxml backend; never parse untrusted XML with the standard library parser
 
-<CardGroup cols={2}>
-  <Card title="Cookbook" icon="flask" href="cookbook">
-    Interactive Jupyter notebooks from beginner to advanced.
-  </Card>
-  <Card title="FAQ" icon="circle-question" href="faq">
-    Common questions answered.
-  </Card>
-  <Card title="API Reference" icon="code" href="reference/core">
-    Complete technical documentation.
-  </Card>
-</CardGroup>
+- [Cookbook](cookbook) — Interactive Jupyter notebooks from beginner to advanced.
+- [FAQ](faq) — Common questions answered.
+- [API Reference](reference/core) — Complete technical documentation.

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -12,26 +12,12 @@ Semantica is organized into **27 modules** across six logical layers. Each modul
 
 ## Architecture Overview
 
-<CardGroup cols={3}>
-  <Card title="Input Layer" icon="database">
-    Data ingestion and preparation. **Modules:** Ingest, Parse, Split, Normalize
-  </Card>
-  <Card title="Core Processing" icon="microchip">
-    Intelligence and understanding. **Modules:** Semantic Extract, KG, Ontology, Reasoning
-  </Card>
-  <Card title="Storage" icon="hard-drive">
-    Persistent data storage. **Modules:** Embeddings, Vector Store, Graph Store, Triplet Store
-  </Card>
-  <Card title="Quality Assurance" icon="check-circle">
-    Data quality and consistency. **Modules:** Deduplication, Conflicts
-  </Card>
-  <Card title="Context & Memory" icon="brain">
-    Agent memory and decision tracking. **Modules:** Context, Provenance, Change Management
-  </Card>
-  <Card title="Output & Orchestration" icon="share-nodes">
-    Export, visualization, and workflows. **Modules:** Export, Visualization, Pipeline, Explorer
-  </Card>
-</CardGroup>
+- **Input Layer** — Data ingestion and preparation. Modules: `ingest`, `parse`, `split`, `normalize`
+- **Core Processing** — Intelligence and understanding. Modules: `semantic_extract`, `kg`, `ontology`, `reasoning`
+- **Storage** — Persistent data storage. Modules: `embeddings`, `vector_store`, `graph_store`, `triplet_store`
+- **Quality Assurance** — Data quality and consistency. Modules: `deduplication`, `conflicts`
+- **Context & Memory** — Agent memory and decision tracking. Modules: `context`, `provenance`, `change_management`
+- **Output & Orchestration** — Export, visualization, and workflows. Modules: `export`, `visualization`, `pipeline`, `explorer`
 
 
 ## Input Layer
@@ -712,14 +698,6 @@ versioner.create_snapshot(kg, "2024-Q1", author="user@example.com", description=
 | [core](reference/core) | Base classes & registry | `Semantica`, `ConfigManager`, `PluginRegistry`, `LifecycleManager` |
 | [utils](reference/utils) | Shared utilities | `helpers`, `validators` |
 
-<CardGroup cols={2}>
-  <Card title="Getting Started" icon="rocket" href="getting-started">
-    Your first knowledge graph in 5 minutes.
-  </Card>
-  <Card title="Cookbook" icon="flask" href="cookbook">
-    40+ domain notebooks with real-world examples.
-  </Card>
-  <Card title="API Reference" icon="code" href="reference/context">
-    Full technical documentation.
-  </Card>
-</CardGroup>
+- [Getting Started](getting-started) — Your first knowledge graph in 5 minutes.
+- [Cookbook](cookbook) — 40+ domain notebooks with real-world examples.
+- [API Reference](reference/context) — Full technical documentation.

--- a/docs/project-license.md
+++ b/docs/project-license.md
@@ -76,11 +76,5 @@ By contributing to Semantica, you agree that your contributions will be licensed
 
 ## See Also
 
-<CardGroup cols={2}>
-  <Card title="Contributing" icon="code-pull-request" href="contributing-guide">
-    How to contribute to the project.
-  </Card>
-  <Card title="Citation" icon="quote-left" href="citation">
-    How to cite Semantica in research.
-  </Card>
-</CardGroup>
+- [Contributing](contributing-guide) — How to contribute to the project.
+- [Citation](citation) — How to cite Semantica in research.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -5,7 +5,7 @@ icon: "rocket"
 ---
 
 <Info>
-  **v0.5.0**: Ontology Hub, Distance Intelligence, Parquet & XML ingestion, 12 security fixes. [What's new →](index#whats-new)
+  **v0.5.0** — Ontology Hub, Distance Intelligence, Parquet & XML ingestion, 12 security fixes. <a href="index#whats-new" style={{color:"#10B981",fontWeight:600,textDecoration:"none"}}>What's new →</a>
 </Info>
 
 This guide walks you through the end-to-end pipeline for building your first knowledge graph. Start here after installation. An LLM API key is optional: pattern-based extraction works out of the box.
@@ -420,17 +420,7 @@ pip install --upgrade semantica
 
 ## Next Steps
 
-<CardGroup cols={2}>
-  <Card title="Core Concepts" icon="book-open" href="concepts">
-    Knowledge graphs, ontologies, reasoning engines: the mental model behind Semantica.
-  </Card>
-  <Card title="Module Reference" icon="puzzle-piece" href="modules">
-    Every module explained with key classes and common chains.
-  </Card>
-  <Card title="API Reference" icon="rectangle-terminal" href="reference/context">
-    Complete documentation for every module, class, and parameter.
-  </Card>
-  <Card title="Cookbook" icon="flask" href="cookbook">
-    40+ interactive Jupyter notebooks with real-world datasets.
-  </Card>
-</CardGroup>
+- [Core Concepts](concepts) — Knowledge graphs, ontologies, reasoning engines: the mental model behind Semantica.
+- [Module Reference](modules) — Every module explained with key classes and common chains.
+- [API Reference](reference/context) — Complete documentation for every module, class, and parameter.
+- [Cookbook](cookbook) — 40+ interactive Jupyter notebooks with real-world datasets.

--- a/docs/reference/change_management.md
+++ b/docs/reference/change_management.md
@@ -30,26 +30,12 @@ icon: "clock-rotate-left"
 
 ## What You Get
 
-<CardGroup cols={2}>
-  <Card title="TemporalVersionManager" icon="code-branch">
-    Snapshot, diff, rollback, and per-entity audit trail for knowledge graphs.
-  </Card>
-  <Card title="OntologyVersionManager" icon="sitemap">
-    Version control for OWL ontologies with diff and schema migration support.
-  </Card>
-  <Card title="VersionStorage" icon="database">
-    Pluggable backends: `InMemoryVersionStorage` for tests, `SQLiteVersionStorage` for production.
-  </Card>
-  <Card title="Integrity Verification" icon="shield-check">
-    SHA-256 checksums on every snapshot to detect any unauthorised modification.
-  </Card>
-  <Card title="ChangeLogEntry" icon="list-check">
-    Internal metadata validated on every snapshot: ISO 8601 timestamp, email author, and description (max 500 chars).
-  </Card>
-  <Card title="Version History" icon="file-shield">
-    Full tamper-evident version history via `list_versions()` and `diff()` for regulatory review.
-  </Card>
-</CardGroup>
+- **TemporalVersionManager** — Snapshot, diff, rollback, and per-entity audit trail for knowledge graphs.
+- **OntologyVersionManager** — Version control for OWL ontologies with diff and schema migration support.
+- **VersionStorage** — Pluggable backends: `InMemoryVersionStorage` for tests, `SQLiteVersionStorage` for production.
+- **Integrity Verification** — SHA-256 checksums on every snapshot to detect any unauthorised modification.
+- **ChangeLogEntry** — Internal metadata validated on every snapshot: ISO 8601 timestamp, email author, and description (max 500 chars).
+- **Version History** — Full tamper-evident version history via `list_versions()` and `diff()` for regulatory review.
 
 ## Typical Workflow
 
@@ -364,17 +350,7 @@ for record in history:
   </Accordion>
 </AccordionGroup>
 
-<CardGroup cols={2}>
-  <Card title="Provenance" icon="link" href="provenance">
-    W3C PROV-O lineage tracking.
-  </Card>
-  <Card title="Knowledge Graph" icon="diagram-project" href="kg">
-    The graph being versioned.
-  </Card>
-  <Card title="Export" icon="file-export" href="export">
-    Export versioned snapshots.
-  </Card>
-  <Card title="Conflicts" icon="triangle-exclamation" href="conflicts">
-    Detect conflicts introduced between versions.
-  </Card>
-</CardGroup>
+- [Provenance](provenance) — W3C PROV-O lineage tracking.
+- [Knowledge Graph](kg) — The graph being versioned.
+- [Export](export) — Export versioned snapshots.
+- [Conflicts](conflicts) — Detect conflicts introduced between versions.

--- a/docs/reference/conflicts.md
+++ b/docs/reference/conflicts.md
@@ -45,26 +45,12 @@ Semantica's conflict detection makes disagreements explicit and actionable:
 
 ## What You Get
 
-<CardGroup cols={2}>
-  <Card title="ConflictDetector" icon="magnifying-glass">
-    Value, type, and relationship conflict detection across entity and relationship lists.
-  </Card>
-  <Card title="ConflictResolver" icon="check">
-    7 resolution strategies including voting, credibility-weighted, and temporal preference.
-  </Card>
-  <Card title="SourceTracker" icon="link">
-    Track which source each conflicting fact came from, with per-source credibility scores.
-  </Card>
-  <Card title="ConflictAnalyzer" icon="chart-line">
-    Pattern analysis, severity grouping, source-level statistics, and trend identification.
-  </Card>
-  <Card title="InvestigationGuideGenerator" icon="list-check">
-    Auto-generate step-by-step investigation checklists for human and expert review.
-  </Card>
-  <Card title="Convenience Functions" icon="bolt">
-    `detect_conflicts()` and `resolve_conflicts()` for one-call workflows.
-  </Card>
-</CardGroup>
+- **ConflictDetector** — Value, type, and relationship conflict detection across entity and relationship lists.
+- **ConflictResolver** — 7 resolution strategies including voting, credibility-weighted, and temporal preference.
+- **SourceTracker** — Track which source each conflicting fact came from, with per-source credibility scores.
+- **ConflictAnalyzer** — Pattern analysis, severity grouping, source-level statistics, and trend identification.
+- **InvestigationGuideGenerator** — Auto-generate step-by-step investigation checklists for human and expert review.
+- **Convenience Functions** — `detect_conflicts()` and `resolve_conflicts()` for one-call workflows.
 
 ## Quick Start
 
@@ -464,17 +450,7 @@ class InvestigationStep:
   </Accordion>
 </AccordionGroup>
 
-<CardGroup cols={2}>
-  <Card title="Deduplication" icon="copy" href="deduplication">
-    Resolve duplicate entities before conflict detection.
-  </Card>
-  <Card title="Ontology" icon="sitemap" href="ontology">
-    Logical conflicts use SHACL shapes and ontology axioms.
-  </Card>
-  <Card title="Provenance" icon="link" href="provenance">
-    Track which source each conflicting fact came from.
-  </Card>
-  <Card title="Knowledge Graph" icon="diagram-project" href="kg">
-    The graph being checked for conflicts.
-  </Card>
-</CardGroup>
+- [Deduplication](deduplication) — Resolve duplicate entities before conflict detection.
+- [Ontology](ontology) — Logical conflicts use SHACL shapes and ontology axioms.
+- [Provenance](provenance) — Track which source each conflicting fact came from.
+- [Knowledge Graph](kg) — The graph being checked for conflicts.

--- a/docs/reference/context.md
+++ b/docs/reference/context.md
@@ -29,48 +29,30 @@ icon: "brain"
 
 ## What You Get
 
-<CardGroup cols={2}>
-  <Card title="AgentContext" icon="brain">
-    - Memory, decision tracking, and graph-backed retrieval behind one API
-    - Conversation history and checkpoint diffing
-    - Persist and restore full context state to disk
-  </Card>
-  <Card title="ContextGraph" icon="diagram-project">
-    - Thread-safe in-memory knowledge graph
-    - PageRank, centrality, community detection, temporal validity
-    - Cross-graph navigation and link traversal
-  </Card>
-  <Card title="AgentMemory" icon="database">
-    - Embedding-backed memory with retention policy
-    - LRU eviction at configurable `max_memory_size`
-    - Per-conversation history isolation
-  </Card>
-  <Card title="DecisionRecorder" icon="list-check">
-    - Records decisions with causal chains and confidence scores
-    - Temporal validity windows (`valid_from` / `valid_until`)
-    - Cross-system context capture on every decision
-  </Card>
-  <Card title="PolicyEngine" icon="shield-check">
-    - Versioned policy storage in the knowledge graph
-    - Compliance checking against recorded decisions
-    - Policy exception tracking with approver audit trail
-  </Card>
-  <Card title="EntityLinker" icon="link">
-    - Maps entity text to stable URIs
-    - Creates typed links between entity IDs
-    - Prevents "Apple", "Apple Inc.", "AAPL" becoming separate nodes
-  </Card>
-  <Card title="ContextRetriever" icon="magnifying-glass">
-    - Fuses vector similarity, graph traversal, and agent memory
-    - Richer context than pure vector search
-    - Configurable `hybrid_alpha` and expansion hops
-  </Card>
-  <Card title="CausalChainAnalyzer" icon="arrow-trend-up">
-    - Traces upstream causes and downstream effects of any decision
-    - Explainability paths with relationship types
-    - Configurable depth and direction
-  </Card>
-</CardGroup>
+- **AgentContext** — Memory, decision tracking, and graph-backed retrieval behind one API
+  - Conversation history and checkpoint diffing
+  - Persist and restore full context state to disk
+- **ContextGraph** — Thread-safe in-memory knowledge graph
+  - PageRank, centrality, community detection, temporal validity
+  - Cross-graph navigation and link traversal
+- **AgentMemory** — Embedding-backed memory with retention policy
+  - LRU eviction at configurable `max_memory_size`
+  - Per-conversation history isolation
+- **DecisionRecorder** — Records decisions with causal chains and confidence scores
+  - Temporal validity windows (`valid_from` / `valid_until`)
+  - Cross-system context capture on every decision
+- **PolicyEngine** — Versioned policy storage in the knowledge graph
+  - Compliance checking against recorded decisions
+  - Policy exception tracking with approver audit trail
+- **EntityLinker** — Maps entity text to stable URIs
+  - Creates typed links between entity IDs
+  - Prevents "Apple", "Apple Inc.", "AAPL" becoming separate nodes
+- **ContextRetriever** — Fuses vector similarity, graph traversal, and agent memory
+  - Richer context than pure vector search
+  - Configurable `hybrid_alpha` and expansion hops
+- **CausalChainAnalyzer** — Traces upstream causes and downstream effects of any decision
+  - Explainability paths with relationship types
+  - Configurable depth and direction
 
 
 ## Quick Start
@@ -889,26 +871,10 @@ class EntityLink:
   </Tab>
 </Tabs>
 
-<CardGroup cols={2}>
-  <Card title="Vector Store" icon="database" href="vector_store">
-    Embedding storage backend for memory retrieval.
-  </Card>
-  <Card title="Knowledge Graph" icon="diagram-project" href="kg">
-    Graph algorithms and analytics used inside ContextGraph.
-  </Card>
-  <Card title="Reasoning" icon="microchip" href="reasoning">
-    Logical inference layered on top of context.
-  </Card>
-  <Card title="Provenance" icon="link" href="provenance">
-    W3C PROV-O lineage for every stored fact.
-  </Card>
-</CardGroup>
+- [Vector Store](vector_store) — Embedding storage backend for memory retrieval.
+- [Knowledge Graph](kg) — Graph algorithms and analytics used inside ContextGraph.
+- [Reasoning](reasoning) — Logical inference layered on top of context.
+- [Provenance](provenance) — W3C PROV-O lineage for every stored fact.
 
-<CardGroup cols={2}>
-  <Card title="Context Module" icon="book-open" href="https://github.com/semantica-agi/semantica/blob/main/cookbook/introduction/19_Context_Module.ipynb">
-    Memory and decision tracking · Intermediate
-  </Card>
-  <Card title="Advanced Context Engineering" icon="flask" href="https://github.com/semantica-agi/semantica/blob/main/cookbook/advanced/11_Advanced_Context_Engineering.ipynb">
-    Production FAISS + Neo4j setup · Advanced
-  </Card>
-</CardGroup>
+- [Context Module](https://github.com/semantica-agi/semantica/blob/main/cookbook/introduction/19_Context_Module.ipynb) — Memory and decision tracking · Intermediate
+- [Advanced Context Engineering](https://github.com/semantica-agi/semantica/blob/main/cookbook/advanced/11_Advanced_Context_Engineering.ipynb) — Production FAISS + Neo4j setup · Advanced

--- a/docs/reference/core.md
+++ b/docs/reference/core.md
@@ -18,20 +18,10 @@ icon: "gear"
 
 ## What You Get
 
-<CardGroup cols={2}>
-  <Card title="Semantica" icon="arrows-turn-to-dots">
-    High-level orchestrator: coordinates the full KG construction pipeline from a single `config.yaml`. Entry point for application-level deployments.
-  </Card>
-  <Card title="ConfigManager" icon="sliders">
-    YAML config with deep-merge, `SEMANTICA_` env var overrides, and dot-notation nested key access. Keeps secrets out of source files.
-  </Card>
-  <Card title="LifecycleManager" icon="circle-play">
-    Ordered startup/shutdown hooks, health monitoring, and a 6-state machine. Essential for long-running services like FastAPI apps.
-  </Card>
-  <Card title="PluginRegistry" icon="plug">
-    Register custom ingestors, parsers, exporters, or any component. Load them by name at runtime: no imports required.
-  </Card>
-</CardGroup>
+- **Semantica** — High-level orchestrator: coordinates the full KG construction pipeline from a single `config.yaml`. Entry point for application-level deployments.
+- **ConfigManager** — YAML config with deep-merge, `SEMANTICA_` env var overrides, and dot-notation nested key access. Keeps secrets out of source files.
+- **LifecycleManager** — Ordered startup/shutdown hooks, health monitoring, and a 6-state machine. Essential for long-running services like FastAPI apps.
+- **PluginRegistry** — Register custom ingestors, parsers, exporters, or any component. Load them by name at runtime: no imports required.
 
 ## Exported Classes
 
@@ -236,17 +226,7 @@ result = build_knowledge_base(sources=["doc.pdf"], method="fast")
   Use `Semantica` and `LifecycleManager` only when building a long-running application (e.g. a FastAPI service) that needs ordered startup, health checks, and graceful shutdown. For scripts and notebooks, use individual modules directly.
 </Tip>
 
-<CardGroup cols={2}>
-  <Card title="Pipeline" icon="arrows-turn-to-dots" href="pipeline">
-    Pipeline execution and step orchestration.
-  </Card>
-  <Card title="Utils" icon="wrench" href="utils">
-    Shared utilities used by Core internally.
-  </Card>
-  <Card title="Getting Started" icon="play" href="../getting-started">
-    Learn the basics before using Core.
-  </Card>
-  <Card title="LLMs" icon="microchip" href="llms">
-    Configure LLM providers via ConfigManager.
-  </Card>
-</CardGroup>
+- [Pipeline](pipeline) — Pipeline execution and step orchestration.
+- [Utils](utils) — Shared utilities used by Core internally.
+- [Getting Started](../getting-started) — Learn the basics before using Core.
+- [LLMs](llms) — Configure LLM providers via ConfigManager.

--- a/docs/reference/deduplication.md
+++ b/docs/reference/deduplication.md
@@ -30,26 +30,12 @@ icon: "copy"
 
 ## What You Get
 
-<CardGroup cols={2}>
-  <Card title="DuplicateDetector" icon="copy">
-    Pairwise, batch, incremental, and group detection modes. Returns scored candidates with reasons.
-  </Card>
-  <Card title="EntityMerger" icon="code-merge">
-    Five merge strategies: keep first, last, most complete, highest confidence, or merge all fields.
-  </Card>
-  <Card title="SimilarityCalculator" icon="equals">
-    Multi-factor scoring across string edit distance, property overlap, relationship overlap, and embeddings.
-  </Card>
-  <Card title="ClusterBuilder" icon="diagram-project">
-    Union-Find and hierarchical clustering for batch deduplication at scale: handles 100k+ entity sets.
-  </Card>
-  <Card title="MergeStrategyManager" icon="sliders">
-    Per-property merge rules with conflict resolution priorities. Apply different strategies to different fields.
-  </Card>
-  <Card title="v2 Strategies" icon="bolt">
-    `blocking_v2`, `hybrid_v2`, `semantic_v2`: up to 7× faster than v1 for large entity sets.
-  </Card>
-</CardGroup>
+- **DuplicateDetector** — Pairwise, batch, incremental, and group detection modes. Returns scored candidates with reasons.
+- **EntityMerger** — Five merge strategies: keep first, last, most complete, highest confidence, or merge all fields.
+- **SimilarityCalculator** — Multi-factor scoring across string edit distance, property overlap, relationship overlap, and embeddings.
+- **ClusterBuilder** — Union-Find and hierarchical clustering for batch deduplication at scale: handles 100k+ entity sets.
+- **MergeStrategyManager** — Per-property merge rules with conflict resolution priorities. Apply different strategies to different fields.
+- **v2 Strategies** — `blocking_v2`, `hybrid_v2`, `semantic_v2`: up to 7× faster than v1 for large entity sets.
 
 
 ## Getting Started
@@ -451,17 +437,7 @@ result = calculate_similarity(entity_a, entity_b, method="drug_name")
   </Tab>
 </Tabs>
 
-<CardGroup cols={2}>
-  <Card title="Conflicts" icon="triangle-exclamation" href="conflicts">
-    Detect value conflicts between non-duplicate entities.
-  </Card>
-  <Card title="Knowledge Graph" icon="diagram-project" href="kg">
-    GraphBuilder uses deduplication during construction.
-  </Card>
-  <Card title="Normalize" icon="broom" href="normalize">
-    Normalize entity names before deduplication.
-  </Card>
-  <Card title="Provenance" icon="link" href="provenance">
-    Track merged entity lineage.
-  </Card>
-</CardGroup>
+- [Conflicts](conflicts) — Detect value conflicts between non-duplicate entities.
+- [Knowledge Graph](kg) — GraphBuilder uses deduplication during construction.
+- [Normalize](normalize) — Normalize entity names before deduplication.
+- [Provenance](provenance) — Track merged entity lineage.

--- a/docs/reference/embeddings.md
+++ b/docs/reference/embeddings.md
@@ -41,26 +41,12 @@ Semantica uses embeddings for:
 
 ## What You Get
 
-<CardGroup cols={2}>
-  <Card title="EmbeddingGenerator" icon="vector-square">
-    Main entry point: provider-agnostic, handles batching automatically across all backends.
-  </Card>
-  <Card title="TextEmbedder" icon="text-size">
-    Text-specific with automatic batching and progress tracking. Default method is FastEmbed.
-  </Card>
-  <Card title="GraphEmbeddingManager" icon="diagram-project">
-    Node and edge embeddings for graph databases: Neo4j, NetworkX, FalkorDB.
-  </Card>
-  <Card title="VectorEmbeddingManager" icon="database">
-    Prepare, normalize, and format embeddings for FAISS, Weaviate, Qdrant, and Milvus.
-  </Card>
-  <Card title="Provider Stores" icon="plug">
-    `OpenAIStore`, `BGEStore`, `FastEmbedStore`, and `ProviderStoreFactory`.
-  </Card>
-  <Card title="Pooling Strategies" icon="layer-group">
-    Mean, Max, CLS, Attention, and Hierarchical: control token-to-vector aggregation.
-  </Card>
-</CardGroup>
+- **EmbeddingGenerator** — Main entry point: provider-agnostic, handles batching automatically across all backends.
+- **TextEmbedder** — Text-specific with automatic batching and progress tracking. Default method is FastEmbed.
+- **GraphEmbeddingManager** — Node and edge embeddings for graph databases: Neo4j, NetworkX, FalkorDB.
+- **VectorEmbeddingManager** — Prepare, normalize, and format embeddings for FAISS, Weaviate, Qdrant, and Milvus.
+- **Provider Stores** — `OpenAIStore`, `BGEStore`, `FastEmbedStore`, and `ProviderStoreFactory`.
+- **Pooling Strategies** — Mean, Max, CLS, Attention, and Hierarchical: control token-to-vector aggregation.
 
 ## Provider Setup
 
@@ -633,17 +619,7 @@ providers = check_available_providers()
 # → {"sentence_transformers": True, "fastembed": True, "openai": False}
 ```
 
-<CardGroup cols={2}>
-  <Card title="Vector Store" icon="database" href="vector_store">
-    Store and search the generated embeddings.
-  </Card>
-  <Card title="Split" icon="scissors" href="split">
-    Chunk text before embedding for better retrieval quality.
-  </Card>
-  <Card title="KG Module" icon="diagram-project" href="kg">
-    Distance Intelligence uses graph embeddings for semantic neighbourhoods.
-  </Card>
-  <Card title="Deduplication" icon="copy" href="deduplication">
-    Semantic deduplication uses embedding distance for entity resolution.
-  </Card>
-</CardGroup>
+- [Vector Store](vector_store) — Store and search the generated embeddings.
+- [Split](split) — Chunk text before embedding for better retrieval quality.
+- [KG Module](kg) — Distance Intelligence uses graph embeddings for semantic neighbourhoods.
+- [Deduplication](deduplication) — Semantic deduplication uses embedding distance for entity resolution.

--- a/docs/reference/evals.md
+++ b/docs/reference/evals.md
@@ -58,17 +58,7 @@ print("Relation coverage: ", report["relation_completeness"]["relation_coverage"
 | `suggestions` | `List[str]` | Improvement suggestions |
 | `metrics` | `dict` | Detailed sub-metrics |
 
-<CardGroup cols={2}>
-  <Card title="Semantic Extract" icon="magnifying-glass" href="semantic_extract">
-    Extraction module.
-  </Card>
-  <Card title="Knowledge Graph" icon="diagram-project" href="kg">
-    Graph quality assessment.
-  </Card>
-  <Card title="Pipeline" icon="gear" href="pipeline">
-    Pipeline performance metrics.
-  </Card>
-  <Card title="Ontology Evaluator" icon="sitemap" href="ontology">
-    Available now for ontology quality metrics.
-  </Card>
-</CardGroup>
+- [Semantic Extract](semantic_extract) — Extraction module.
+- [Knowledge Graph](kg) — Graph quality assessment.
+- [Pipeline](pipeline) — Pipeline performance metrics.
+- [Ontology Evaluator](ontology) — Available now for ontology quality metrics.

--- a/docs/reference/explorer.md
+++ b/docs/reference/explorer.md
@@ -115,26 +115,12 @@ EXPLORER_CORS_ORIGINS="http://myapp.example.com" \
 
 ## What You Get
 
-<CardGroup cols={2}>
-  <Card title="Graph Explorer" icon="diagram-project">
-    Interactive node/edge search, path finding, and neighborhood expansion. Indexed search at 0.004ms on 118k-node graphs.
-  </Card>
-  <Card title="Ontology Hub" icon="sitemap">
-    SKOS vocabulary management, SHACL shape generation and validation, ontology alignment, health dashboard, and versioning.
-  </Card>
-  <Card title="Analytics" icon="chart-line">
-    Degree centrality, community detection, connectivity analysis, graph validation, and distance matrices.
-  </Card>
-  <Card title="REST API" icon="code">
-    All features available as a REST API: fully documented at `/docs`.
-  </Card>
-  <Card title="WebSocket Updates" icon="bolt">
-    Real-time graph mutation events streamed over WebSocket at `/ws/graph-updates`.
-  </Card>
-  <Card title="CLI Launcher" icon="terminal">
-    `semantica-explorer --graph my_graph.json` for instant local startup.
-  </Card>
-</CardGroup>
+- **Graph Explorer** — Interactive node/edge search, path finding, and neighborhood expansion. Indexed search at 0.004ms on 118k-node graphs.
+- **Ontology Hub** — SKOS vocabulary management, SHACL shape generation and validation, ontology alignment, health dashboard, and versioning.
+- **Analytics** — Degree centrality, community detection, connectivity analysis, graph validation, and distance matrices.
+- **REST API** — All features available as a REST API: fully documented at `/docs`.
+- **WebSocket Updates** — Real-time graph mutation events streamed over WebSocket at `/ws/graph-updates`.
+- **CLI Launcher** — `semantica-explorer --graph my_graph.json` for instant local startup.
 
 ## Features
 
@@ -412,17 +398,7 @@ Semantic neighborhood requires node embeddings stored in node properties (keys `
 **Session state lost after restart**
 Session state is in-memory only. Use `POST /api/export` to save a JSON snapshot before shutting down.
 
-<CardGroup cols={2}>
-  <Card title="Context" icon="brain" href="context">
-    Build and save the ContextGraph that Explorer loads.
-  </Card>
-  <Card title="Ontology" icon="sitemap" href="ontology">
-    Programmatic ontology management and SHACL generation.
-  </Card>
-  <Card title="Visualization" icon="chart-bar" href="visualization">
-    Programmatic graph rendering without the Explorer server.
-  </Card>
-  <Card title="Export" icon="file-export" href="export">
-    Export to RDF, Parquet, and other formats without launching a server.
-  </Card>
-</CardGroup>
+- [Context](context) — Build and save the ContextGraph that Explorer loads.
+- [Ontology](ontology) — Programmatic ontology management and SHACL generation.
+- [Visualization](visualization) — Programmatic graph rendering without the Explorer server.
+- [Export](export) — Export to RDF, Parquet, and other formats without launching a server.

--- a/docs/reference/export.md
+++ b/docs/reference/export.md
@@ -381,17 +381,7 @@ The `export_csv` convenience function delegates to `CSVExporter.export()`. For p
   **Match your export format to your consumer.** Neo4j → `cypher`; ArangoDB → `aql`; Gephi/yEd → `graphml` or `gexf`; semantic web tools → `turtle` or `json-ld`; analytics pipelines → `parquet`; zero-copy IPC → `arrow`.
 </Tip>
 
-<CardGroup cols={2}>
-  <Card title="Triplet Store" icon="table" href="triplet_store">
-    Store RDF exports in a SPARQL-queryable backend.
-  </Card>
-  <Card title="Ontology" icon="sitemap" href="ontology">
-    Export OWL ontologies.
-  </Card>
-  <Card title="Provenance" icon="link" href="provenance">
-    Include provenance metadata in RDF exports.
-  </Card>
-  <Card title="Pipeline" icon="gear" href="pipeline">
-    Add export as a final pipeline step.
-  </Card>
-</CardGroup>
+- [Triplet Store](triplet_store) — Store RDF exports in a SPARQL-queryable backend.
+- [Ontology](ontology) — Export OWL ontologies.
+- [Provenance](provenance) — Include provenance metadata in RDF exports.
+- [Pipeline](pipeline) — Add export as a final pipeline step.

--- a/docs/reference/graph_store.md
+++ b/docs/reference/graph_store.md
@@ -28,38 +28,24 @@ icon: "server"
 
 ## What You Get
 
-<CardGroup cols={2}>
-  <Card title="GraphStore" icon="server">
-    - Unified API across Neo4j, FalkorDB, Apache AGE, Amazon Neptune
-    - Context manager support for automatic connection cleanup
-    - `create_nodes()` for bulk loading: faster than individual calls
-  </Card>
-  <Card title="QueryEngine" icon="magnifying-glass">
-    - Parameterized Cypher construction prevents injection attacks
-    - Optional in-process result caching with `use_cache=True`
-    - `clear_cache()` on writes, toggle with `enable_cache()` / `disable_cache()`
-  </Card>
-  <Card title="GraphAnalytics" icon="chart-line">
-    - Degree centrality ordered by degree DESC
-    - Connected component assignment
-    - Shortest path between nodes, neighbor traversal up to N hops
-  </Card>
-  <Card title="Bulk Operations" icon="layer-group">
-    - `create_nodes(list)`: one round-trip for many nodes
-    - `create_relationship()` with typed properties
-    - `delete_node(detach=True)` removes all connected relationships
-  </Card>
-  <Card title="Schema Management" icon="table">
-    - `create_index(label, property_name=)`: makes MATCH queries orders-of-magnitude faster
-    - `get_stats()`: node counts, edge counts, type breakdown
-    - Create indexes before bulk loading for best performance
-  </Card>
-  <Card title="Path Traversal" icon="route">
-    - `shortest_path()` returns `length`, `nodes`, `relationships`
-    - `get_neighbors()` with direction and depth control
-    - Cross-backend path traversal via the unified API
-  </Card>
-</CardGroup>
+- **GraphStore** — Unified API across Neo4j, FalkorDB, Apache AGE, Amazon Neptune
+  - Context manager support for automatic connection cleanup
+  - `create_nodes()` for bulk loading: faster than individual calls
+- **QueryEngine** — Parameterized Cypher construction prevents injection attacks
+  - Optional in-process result caching with `use_cache=True`
+  - `clear_cache()` on writes, toggle with `enable_cache()` / `disable_cache()`
+- **GraphAnalytics** — Degree centrality ordered by degree DESC
+  - Connected component assignment
+  - Shortest path between nodes, neighbor traversal up to N hops
+- **Bulk Operations** — `create_nodes(list)`: one round-trip for many nodes
+  - `create_relationship()` with typed properties
+  - `delete_node(detach=True)` removes all connected relationships
+- **Schema Management** — `create_index(label, property_name=)`: makes MATCH queries orders-of-magnitude faster
+  - `get_stats()`: node counts, edge counts, type breakdown
+  - Create indexes before bulk loading for best performance
+- **Path Traversal** — `shortest_path()` returns `length`, `nodes`, `relationships`
+  - `get_neighbors()` with direction and depth control
+  - Cross-backend path traversal via the unified API
 
 
 ## Getting Started
@@ -517,17 +503,7 @@ stats = store.get_stats()
   </Tab>
 </Tabs>
 
-<CardGroup cols={2}>
-  <Card title="KG Module" icon="diagram-project" href="kg">
-    Build the graph before persisting it.
-  </Card>
-  <Card title="Triplet Store" icon="table" href="triplet_store">
-    RDF triple store for semantic web and SPARQL queries.
-  </Card>
-  <Card title="Visualization" icon="chart-bar" href="visualization">
-    Visualize graphs stored in any backend.
-  </Card>
-  <Card title="Context" icon="brain" href="context">
-    AgentContext uses GraphStore for memory retrieval.
-  </Card>
-</CardGroup>
+- [KG Module](kg) — Build the graph before persisting it.
+- [Triplet Store](triplet_store) — RDF triple store for semantic web and SPARQL queries.
+- [Visualization](visualization) — Visualize graphs stored in any backend.
+- [Context](context) — AgentContext uses GraphStore for memory retrieval.

--- a/docs/reference/ingest.md
+++ b/docs/reference/ingest.md
@@ -625,17 +625,7 @@ from semantica.ingest import ingest_file
 result = ingest_file("source_path", method="my_format")
 ```
 
-<CardGroup cols={2}>
-  <Card title="Parse" icon="file-lines" href="parse">
-    Parse raw sources into structured text and tables.
-  </Card>
-  <Card title="Pipeline" icon="gear" href="pipeline">
-    Orchestrate ingest as the first pipeline step.
-  </Card>
-  <Card title="Snowflake Integration" icon="snowflake" href="../integrations/snowflake">
-    Snowflake-specific setup and authentication guide.
-  </Card>
-  <Card title="Provenance" icon="link" href="provenance">
-    Track lineage from ingest through to inference.
-  </Card>
-</CardGroup>
+- [Parse](parse) — Parse raw sources into structured text and tables.
+- [Pipeline](pipeline) — Orchestrate ingest as the first pipeline step.
+- [Snowflake Integration](../integrations/snowflake) — Snowflake-specific setup and authentication guide.
+- [Provenance](provenance) — Track lineage from ingest through to inference.

--- a/docs/reference/kg.md
+++ b/docs/reference/kg.md
@@ -316,20 +316,10 @@ kg:
     default_validity: infinite
 ```
 
-<CardGroup cols={2}>
-  <Card title="Graph Store" icon="server" href="graph_store">
-    Persist graphs in Neo4j, FalkorDB, or Apache AGE.
-  </Card>
-  <Card title="Semantic Extract" icon="magnifying-glass" href="semantic_extract">
-    Source of entities and relationships fed to GraphBuilder.
-  </Card>
-  <Card title="Visualization" icon="chart-bar" href="visualization">
-    Visualize knowledge graphs interactively.
-  </Card>
-  <Card title="Conflicts" icon="triangle-exclamation" href="conflicts">
-    Conflict detection and resolution.
-  </Card>
-</CardGroup>
+- [Graph Store](graph_store) — Persist graphs in Neo4j, FalkorDB, or Apache AGE.
+- [Semantic Extract](semantic_extract) — Source of entities and relationships fed to GraphBuilder.
+- [Visualization](visualization) — Visualize knowledge graphs interactively.
+- [Conflicts](conflicts) — Conflict detection and resolution.
 
 ### Cookbooks
 

--- a/docs/reference/llms.md
+++ b/docs/reference/llms.md
@@ -439,17 +439,7 @@ extractor = NERExtractor(
 )
 ```
 
-<CardGroup cols={2}>
-  <Card title="Semantic Extract" icon="magnifying-glass" href="semantic_extract">
-    Use LLMs for NER and relation extraction.
-  </Card>
-  <Card title="Agno Integration" icon="robot" href="../integrations/agno">
-    LLM providers in Agno multi-agent teams.
-  </Card>
-  <Card title="Reasoning" icon="brain" href="reasoning">
-    LLM-backed deductive and abductive reasoning.
-  </Card>
-  <Card title="Context" icon="diagram-project" href="context">
-    GraphRAG uses LLMs for reasoning over knowledge graphs.
-  </Card>
-</CardGroup>
+- [Semantic Extract](semantic_extract) — Use LLMs for NER and relation extraction.
+- [Agno Integration](../integrations/agno) — LLM providers in Agno multi-agent teams.
+- [Reasoning](reasoning) — LLM-backed deductive and abductive reasoning.
+- [Context](context) — GraphRAG uses LLMs for reasoning over knowledge graphs.

--- a/docs/reference/mcp_server.md
+++ b/docs/reference/mcp_server.md
@@ -40,26 +40,12 @@ python -m semantica.mcp_server
 
 ## What You Get
 
-<CardGroup cols={2}>
-  <Card title="12 MCP Tools" icon="wrench">
-    Extract entities, extract relations, record decisions, query decisions, find precedents, trace causal chains, add entities, add relationships, run analytics, summarise graph, run reasoning, export graph.
-  </Card>
-  <Card title="3 Readable Resources" icon="book-open">
-    Live graph JSON (`semantica://graph/summary`), decision list, and schema/version info: readable by any MCP client.
-  </Card>
-  <Card title="Zero Infrastructure" icon="bolt">
-    Runs over stdio: no server, no port, no Docker required. One config block to activate in any MCP client.
-  </Card>
-  <Card title="Persistent Graphs" icon="database">
-    Point `SEMANTICA_KG_PATH` at a saved graph file to reload it automatically on every server startup.
-  </Card>
-  <Card title="Decision Intelligence" icon="brain">
-    Record decisions, find precedents via hybrid similarity search, and trace causal chains across agent runs.
-  </Card>
-  <Card title="REST Alternative" icon="globe">
-    The [Explorer](explorer) module offers a full HTTP API and browser dashboard if you prefer programmatic access.
-  </Card>
-</CardGroup>
+- **12 MCP Tools** — Extract entities, extract relations, record decisions, query decisions, find precedents, trace causal chains, add entities, add relationships, run analytics, summarise graph, run reasoning, export graph.
+- **3 Readable Resources** — Live graph JSON (`semantica://graph/summary`), decision list, and schema/version info: readable by any MCP client.
+- **Zero Infrastructure** — Runs over stdio: no server, no port, no Docker required. One config block to activate in any MCP client.
+- **Persistent Graphs** — Point `SEMANTICA_KG_PATH` at a saved graph file to reload it automatically on every server startup.
+- **Decision Intelligence** — Record decisions, find precedents via hybrid similarity search, and trace causal chains across agent runs.
+- **REST Alternative** — The [Explorer](explorer) module offers a full HTTP API and browser dashboard if you prefer programmatic access.
 
 ## Installation
 
@@ -459,17 +445,7 @@ The MCP server exposes three readable resources:
 | `semantica://decisions/list` | All recorded decisions (up to 50) |
 | `semantica://schema/info` | Server version and available tools |
 
-<CardGroup cols={2}>
-  <Card title="Context" icon="brain" href="context">
-    The ContextGraph that the MCP server operates on.
-  </Card>
-  <Card title="Semantic Extract" icon="magnifying-glass" href="semantic_extract">
-    NER and relation extraction powering the MCP tools.
-  </Card>
-  <Card title="Reasoning" icon="microchip" href="reasoning">
-    Forward-chaining engine behind run_reasoning.
-  </Card>
-  <Card title="Agno Integration" icon="robot" href="../integrations/agno">
-    Use Semantica inside Agno multi-agent teams.
-  </Card>
-</CardGroup>
+- [Context](context) — The ContextGraph that the MCP server operates on.
+- [Semantic Extract](semantic_extract) — NER and relation extraction powering the MCP tools.
+- [Reasoning](reasoning) — Forward-chaining engine behind run_reasoning.
+- [Agno Integration](../integrations/agno) — Use Semantica inside Agno multi-agent teams.

--- a/docs/reference/normalize.md
+++ b/docs/reference/normalize.md
@@ -584,17 +584,7 @@ normalized = normalize_text("Apple Inc.", method="expand_suffixes")
 # → "Apple Incorporated"
 ```
 
-<CardGroup cols={2}>
-  <Card title="Parse" icon="file-lines" href="parse">
-    Parse documents before normalization.
-  </Card>
-  <Card title="Split" icon="scissors" href="split">
-    Chunk normalized text for embedding.
-  </Card>
-  <Card title="Deduplication" icon="copy" href="deduplication">
-    Resolve duplicate entities after normalization.
-  </Card>
-  <Card title="Pipeline" icon="gear" href="pipeline">
-    Include normalization as a named pipeline step.
-  </Card>
-</CardGroup>
+- [Parse](parse) — Parse documents before normalization.
+- [Split](split) — Chunk normalized text for embedding.
+- [Deduplication](deduplication) — Resolve duplicate entities after normalization.
+- [Pipeline](pipeline) — Include normalization as a named pipeline step.

--- a/docs/reference/ontology.md
+++ b/docs/reference/ontology.md
@@ -286,17 +286,7 @@ ontology_data = ingest_ontology("schema.jsonld")  # JSON-LD
   Ontology versioning (`VersionManager`, `OntologyVersion`) has moved to `semantica.change_management`. Import from there: `from semantica.change_management import VersionManager`.
 </Note>
 
-<CardGroup cols={2}>
-  <Card title="Reasoning" icon="microchip" href="reasoning">
-    Apply inference rules over ontology axioms.
-  </Card>
-  <Card title="Knowledge Graph" icon="diagram-project" href="kg">
-    The graph being modeled by the ontology.
-  </Card>
-  <Card title="Export" icon="file-export" href="export">
-    Export ontologies as RDF, OWL, or JSON-LD.
-  </Card>
-  <Card title="Conflicts" icon="triangle-exclamation" href="conflicts">
-    Detect ontology constraint violations.
-  </Card>
-</CardGroup>
+- [Reasoning](reasoning) — Apply inference rules over ontology axioms.
+- [Knowledge Graph](kg) — The graph being modeled by the ontology.
+- [Export](export) — Export ontologies as RDF, OWL, or JSON-LD.
+- [Conflicts](conflicts) — Detect ontology constraint violations.

--- a/docs/reference/parse.md
+++ b/docs/reference/parse.md
@@ -297,17 +297,7 @@ for source in sources:
   Docling is an optional dependency. If `docling` is not installed, `DoclingParser` raises an `ImportError` with installation instructions: `pip install docling`. `DocumentParser` is always available and requires no extras.
 </Note>
 
-<CardGroup cols={2}>
-  <Card title="Ingest" icon="database" href="ingest">
-    Load files before parsing.
-  </Card>
-  <Card title="Split" icon="scissors" href="split">
-    Chunk parsed text for embedding and extraction.
-  </Card>
-  <Card title="Docling Integration" icon="file-pdf" href="../integrations/docling">
-    Full Docling integration setup guide.
-  </Card>
-  <Card title="Semantic Extract" icon="magnifying-glass" href="semantic_extract">
-    Extract entities and relations from parsed text.
-  </Card>
-</CardGroup>
+- [Ingest](ingest) — Load files before parsing.
+- [Split](split) — Chunk parsed text for embedding and extraction.
+- [Docling Integration](../integrations/docling) — Full Docling integration setup guide.
+- [Semantic Extract](semantic_extract) — Extract entities and relations from parsed text.

--- a/docs/reference/pipeline.md
+++ b/docs/reference/pipeline.md
@@ -29,26 +29,12 @@ icon: "gear"
 
 You could wire Semantica modules together with plain Python code. Pipelines add:
 
-<CardGroup cols={2}>
-  <Card title="Retry and failure handling" icon="arrow-rotate-right">
-    A single bad document doesn't crash a 10,000-document run.
-  </Card>
-  <Card title="Parallelism" icon="bolt">
-    Run extraction across multiple workers with one parameter.
-  </Card>
-  <Card title="Progress tracking" icon="chart-line">
-    tqdm console bar or WebSocket streaming to Explorer.
-  </Card>
-  <Card title="Reproducibility" icon="floppy-disk">
-    Save the exact pipeline configuration to YAML and replay on any machine.
-  </Card>
-  <Card title="Delta mode" icon="code-compare">
-    On re-runs, only process documents that changed since the last run.
-  </Card>
-  <Card title="Validation" icon="shield-check">
-    Catch misconfigured steps and dependency cycles before they fail mid-run.
-  </Card>
-</CardGroup>
+- **Retry and failure handling** — A single bad document doesn't crash a 10,000-document run.
+- **Parallelism** — Run extraction across multiple workers with one parameter.
+- **Progress tracking** — tqdm console bar or WebSocket streaming to Explorer.
+- **Reproducibility** — Save the exact pipeline configuration to YAML and replay on any machine.
+- **Delta mode** — On re-runs, only process documents that changed since the last run.
+- **Validation** — Catch misconfigured steps and dependency cycles before they fail mid-run.
 
 <Note>
   Use plain module calls for quick scripts and notebooks. Use pipelines for anything you run repeatedly, at scale, or in production.
@@ -322,48 +308,33 @@ manager = PipelineTemplateManager()
 
 The `create_pipeline_from_template(name)` method returns a configured `PipelineBuilder`. Call `.build(pipeline_name)` on it to produce a runnable `Pipeline`.
 
-<CardGroup cols={2}>
-  <Card title="document_processing" icon="diagram-project">
-    **Ingest → Parse → Normalize → Extract → Embed → Build KG**
+- **document_processing** — **Ingest → Parse → Normalize → Extract → Embed → Build KG** — Complete document processing from ingestion to knowledge graph.
 
-    Complete document processing from ingestion to knowledge graph.
+  ```python
+  builder  = manager.create_pipeline_from_template("document_processing")
+  pipeline = builder.build("doc_pipeline")
+  ```
 
-    ```python
-    builder  = manager.create_pipeline_from_template("document_processing")
-    pipeline = builder.build("doc_pipeline")
-    ```
-  </Card>
-  <Card title="rag_pipeline" icon="magnifying-glass">
-    **Ingest → Chunk → Embed → Store Vectors**
+- **rag_pipeline** — **Ingest → Chunk → Embed → Store Vectors** — RAG pipeline for question answering: builds a vector-indexed store.
 
-    RAG pipeline for question answering: builds a vector-indexed store.
+  ```python
+  builder  = manager.create_pipeline_from_template("rag_pipeline")
+  pipeline = builder.build("rag_pipeline")
+  ```
 
-    ```python
-    builder  = manager.create_pipeline_from_template("rag_pipeline")
-    pipeline = builder.build("rag_pipeline")
-    ```
-  </Card>
-  <Card title="kg_construction" icon="chart-bar">
-    **Ingest → Extract Entities → Extract Relations → Dedup → Resolve → Build Graph**
+- **kg_construction** — **Ingest → Extract Entities → Extract Relations → Dedup → Resolve → Build Graph** — Knowledge graph construction from multiple sources.
 
-    Knowledge graph construction from multiple sources.
+  ```python
+  builder  = manager.create_pipeline_from_template("kg_construction")
+  pipeline = builder.build("kg_pipeline")
+  ```
 
-    ```python
-    builder  = manager.create_pipeline_from_template("kg_construction")
-    pipeline = builder.build("kg_pipeline")
-    ```
-  </Card>
-  <Card title="ontology_generation" icon="shield-check">
-    **Extract Concepts → Infer Classes → Infer Properties → Generate OWL → Validate**
+- **ontology_generation** — **Extract Concepts → Infer Classes → Infer Properties → Generate OWL → Validate** — Ontology generation from extracted data.
 
-    Ontology generation from extracted data.
-
-    ```python
-    builder  = manager.create_pipeline_from_template("ontology_generation")
-    pipeline = builder.build("ontology_pipeline")
-    ```
-  </Card>
-</CardGroup>
+  ```python
+  builder  = manager.create_pipeline_from_template("ontology_generation")
+  pipeline = builder.build("ontology_pipeline")
+  ```
 
 <Tip>
   **Use templates from `PipelineTemplateManager` for common patterns.** `create_pipeline_from_template("kg_construction")` wires normalization, deduplication, conflict detection, and graph construction in the correct order: saving you from common mistakes like deduplicating before normalizing.
@@ -583,17 +554,7 @@ StepStatus.SKIPPED    # Skipped due to FailureHandler "skip" strategy
   </Accordion>
 </AccordionGroup>
 
-<CardGroup cols={2}>
-  <Card title="Ingest" icon="database" href="ingest">
-    First step in most pipelines.
-  </Card>
-  <Card title="Semantic Extract" icon="magnifying-glass" href="semantic_extract">
-    Core extraction step.
-  </Card>
-  <Card title="Knowledge Graph" icon="diagram-project" href="kg">
-    Graph construction step.
-  </Card>
-  <Card title="Export" icon="file-export" href="export">
-    Final output step.
-  </Card>
-</CardGroup>
+- [Ingest](ingest) — First step in most pipelines.
+- [Semantic Extract](semantic_extract) — Core extraction step.
+- [Knowledge Graph](kg) — Graph construction step.
+- [Export](export) — Final output step.

--- a/docs/reference/provenance.md
+++ b/docs/reference/provenance.md
@@ -517,17 +517,7 @@ Provenance tracking in Semantica produces the following audit artifacts:
   `ProvenanceManager` does not include built-in Turtle or JSON-LD serialization. Use `entry.to_dict()` and `get_lineage()` to retrieve provenance data, then serialize with your preferred RDF library if W3C PROV-O RDF output is required.
 </Note>
 
-<CardGroup cols={2}>
-  <Card title="Change Management" icon="clock-rotate-left" href="change_management">
-    Version control and snapshot audit trails.
-  </Card>
-  <Card title="Ingest" icon="database" href="ingest">
-    Provenance begins at the ingestion stage.
-  </Card>
-  <Card title="Export" icon="file-export" href="export">
-    Include provenance metadata in RDF exports.
-  </Card>
-  <Card title="Context" icon="brain" href="context">
-    Decision provenance via AgentContext.
-  </Card>
-</CardGroup>
+- [Change Management](change_management) — Version control and snapshot audit trails.
+- [Ingest](ingest) — Provenance begins at the ingestion stage.
+- [Export](export) — Include provenance metadata in RDF exports.
+- [Context](context) — Decision provenance via AgentContext.

--- a/docs/reference/reasoning.md
+++ b/docs/reference/reasoning.md
@@ -31,26 +31,12 @@ icon: "microchip"
 
 ## Which Engine Should I Use?
 
-<CardGroup cols={2}>
-  <Card title="Reasoner" icon="arrow-right-arrow-left" href="#reasoner-forwardbackward-chaining">
-    IF/THEN rules, forward and backward chaining. **Start here**: covers 90% of use cases. No query language required.
-  </Card>
-  <Card title="GraphReasoner" icon="robot" href="#graphreasoner">
-    Natural language queries over a knowledge graph via LLM. No SPARQL or rules: just ask a question.
-  </Card>
-  <Card title="DatalogReasoner" icon="code" href="#datalogreasoner">
-    Recursive Horn clause rules with guaranteed termination. Use for complex multi-hop transitive rules.
-  </Card>
-  <Card title="ReteEngine" icon="bolt" href="#reteengine">
-    Rete pattern matching for high-frequency inference. Use when you need to match many facts against many rules simultaneously.
-  </Card>
-  <Card title="SPARQLReasoner" icon="database" href="#sparqlreasoner">
-    SPARQL query expansion and rule-based inference. Use when you're working with RDF/OWL data.
-  </Card>
-  <Card title="TemporalReasoningEngine" icon="clock" href="#temporalreasoningengine">
-    All 13 Allen interval algebra relations. Use for time-aware reasoning: overlaps, before/after, during, contains.
-  </Card>
-</CardGroup>
+- [Reasoner](#reasoner-forwardbackward-chaining) — IF/THEN rules, forward and backward chaining. **Start here**: covers 90% of use cases. No query language required.
+- [GraphReasoner](#graphreasoner) — Natural language queries over a knowledge graph via LLM. No SPARQL or rules: just ask a question.
+- [DatalogReasoner](#datalogreasoner) — Recursive Horn clause rules with guaranteed termination. Use for complex multi-hop transitive rules.
+- [ReteEngine](#reteengine) — Rete pattern matching for high-frequency inference. Use when you need to match many facts against many rules simultaneously.
+- [SPARQLReasoner](#sparqlreasoner) — SPARQL query expansion and rule-based inference. Use when you're working with RDF/OWL data.
+- [TemporalReasoningEngine](#temporalreasoningengine) — All 13 Allen interval algebra relations. Use for time-aware reasoning: overlaps, before/after, during, contains.
 
 
 ## Getting Started
@@ -479,17 +465,7 @@ step.confidence     # float
   `GraphReasoner` requires a configured LLM provider. If the provider fails to initialize, `reason()` returns an error string instead of raising. Check `reasoner.provider is not None` before calling if you need to surface failures explicitly.
 </Warning>
 
-<CardGroup cols={2}>
-  <Card title="Knowledge Graph" icon="diagram-project" href="kg">
-    The knowledge graph being reasoned over.
-  </Card>
-  <Card title="Ontology" icon="sitemap" href="ontology">
-    Ontology axioms and SHACL constraints for logical reasoning.
-  </Card>
-  <Card title="Triplet Store" icon="table" href="triplet_store">
-    RDF backend for SPARQL-based reasoning.
-  </Card>
-  <Card title="Context" icon="brain" href="context">
-    Reasoning integrated into agent decision intelligence.
-  </Card>
-</CardGroup>
+- [Knowledge Graph](kg) — The knowledge graph being reasoned over.
+- [Ontology](ontology) — Ontology axioms and SHACL constraints for logical reasoning.
+- [Triplet Store](triplet_store) — RDF backend for SPARQL-based reasoning.
+- [Context](context) — Reasoning integrated into agent decision intelligence.

--- a/docs/reference/seed.md
+++ b/docs/reference/seed.md
@@ -23,26 +23,12 @@ icon: "database"
 
 ## What You Get
 
-<CardGroup cols={2}>
-  <Card title="SeedDataManager" icon="database">
-    Register sources, build a foundation graph, validate quality, and merge with extracted data.
-  </Card>
-  <Card title="SeedDataSource" icon="file-code">
-    Typed source definition supporting CSV, JSON, SQL, and API with format-specific config.
-  </Card>
-  <Card title="Foundation Graph" icon="circle-plus">
-    Build a foundation graph from all registered sources in one pass, ready to merge with extracted data.
-  </Card>
-  <Card title="Merge Strategies" icon="arrows-merge">
-    `seed_first`, `extracted_first`, and `merge` with property-level conflict detection.
-  </Card>
-  <Card title="Validation" icon="shield-check">
-    Required field checks, ID uniqueness, type consistency, reference integrity, and encoding validation before loading.
-  </Card>
-  <Card title="Versioning" icon="clock-rotate-left">
-    Track seed data versions across pipeline runs and diff changes between versions.
-  </Card>
-</CardGroup>
+- **SeedDataManager** — Register sources, build a foundation graph, validate quality, and merge with extracted data.
+- **SeedDataSource** — Typed source definition supporting CSV, JSON, SQL, and API with format-specific config.
+- **Foundation Graph** — Build a foundation graph from all registered sources in one pass, ready to merge with extracted data.
+- **Merge Strategies** — `seed_first`, `extracted_first`, and `merge` with property-level conflict detection.
+- **Validation** — Required field checks, ID uniqueness, type consistency, reference integrity, and encoding validation before loading.
+- **Versioning** — Track seed data versions across pipeline runs and diff changes between versions.
 
 <Tip>
   **When to use the Seed Module:** Bootstrapping with structured reference data (taxonomies, user lists, product catalogs), loading immutable facts (ISO country codes, standard ontology terms) that extracted data should not override, ensuring test reproducibility with deterministic datasets, and anchoring entity disambiguation with canonical forms.
@@ -335,17 +321,7 @@ export SEMANTICA_SEED_MERGE_STRATEGY=seed_first
   **Use YAML configuration for production deployments.** Hard-coding source paths in Python scripts makes environment-switching (dev → staging → prod) fragile. Declare sources in `config.yaml` under the `seed:` key and override paths with `SEMANTICA_SEED_DATA_DIR`. This way, the same code runs in every environment.
 </Tip>
 
-<CardGroup cols={2}>
-  <Card title="Ingest" icon="file-import" href="ingest">
-    Load unstructured data alongside seed data.
-  </Card>
-  <Card title="Knowledge Graph" icon="diagram-project" href="kg">
-    The target graph that seed data populates.
-  </Card>
-  <Card title="Deduplication" icon="copy" href="deduplication">
-    Handle duplicates during seed-extracted merge.
-  </Card>
-  <Card title="Pipeline" icon="gear" href="pipeline">
-    Incorporate seed loading as a named pipeline step.
-  </Card>
-</CardGroup>
+- [Ingest](ingest) — Load unstructured data alongside seed data.
+- [Knowledge Graph](kg) — The target graph that seed data populates.
+- [Deduplication](deduplication) — Handle duplicates during seed-extracted merge.
+- [Pipeline](pipeline) — Incorporate seed loading as a named pipeline step.

--- a/docs/reference/semantic_extract.md
+++ b/docs/reference/semantic_extract.md
@@ -410,17 +410,7 @@ triplets      = trip.extract(text)
 | `ml` | Fast | Free | High | Limited |
 | `llm` | Medium | API cost | Highest | Yes (schema) |
 
-<CardGroup cols={2}>
-  <Card title="LLM Providers" icon="microchip" href="llms">
-    Configure which LLM is used for extraction.
-  </Card>
-  <Card title="Knowledge Graph" icon="diagram-project" href="kg">
-    Build graphs from extracted entities and relationships.
-  </Card>
-  <Card title="Parse Module" icon="file-lines" href="parse">
-    Parse documents before extraction.
-  </Card>
-  <Card title="Deduplication" icon="copy" href="deduplication">
-    Resolve duplicate entities after extraction.
-  </Card>
-</CardGroup>
+- [LLM Providers](llms) — Configure which LLM is used for extraction.
+- [Knowledge Graph](kg) — Build graphs from extracted entities and relationships.
+- [Parse Module](parse) — Parse documents before extraction.
+- [Deduplication](deduplication) — Resolve duplicate entities after extraction.

--- a/docs/reference/split.md
+++ b/docs/reference/split.md
@@ -51,23 +51,11 @@ Semantica's chunking methods are designed to avoid these failure modes.
 
 ## What You Get
 
-<CardGroup cols={2}>
-  <Card title="TextSplitter" icon="scissors">
-    Unified interface for 11 chunking strategies: swap methods without changing downstream code.
-  </Card>
-  <Card title="Semantic Chunking" icon="brain">
-    Embedding-based topic shift detection: splits only when the topic actually changes.
-  </Card>
-  <Card title="Entity-Aware Chunking" icon="user">
-    Entity spans never cross chunk boundaries: guaranteed by boundary adjustment.
-  </Card>
-  <Card title="Relation-Aware Chunking" icon="arrows-left-right">
-    Subject–predicate–object triplets kept within a single chunk for KG pipelines.
-  </Card>
-  <Card title="Chunk Object" icon="box">
-    Output dataclass with text, character offsets, optional id, and method-specific metadata.
-  </Card>
-</CardGroup>
+- **TextSplitter** — Unified interface for 11 chunking strategies: swap methods without changing downstream code.
+- **Semantic Chunking** — Embedding-based topic shift detection: splits only when the topic actually changes.
+- **Entity-Aware Chunking** — Entity spans never cross chunk boundaries: guaranteed by boundary adjustment.
+- **Relation-Aware Chunking** — Subject–predicate–object triplets kept within a single chunk for KG pipelines.
+- **Chunk Object** — Output dataclass with text, character offsets, optional id, and method-specific metadata.
 
 ## Quick Start
 
@@ -385,17 +373,7 @@ for chunk in chunks:
 
 For the full pipeline orchestration API, see the [Pipeline reference](pipeline).
 
-<CardGroup cols={2}>
-  <Card title="Parse" icon="file-lines" href="parse">
-    Parse documents before chunking: produces sections and metadata.
-  </Card>
-  <Card title="Embeddings" icon="vector-square" href="embeddings">
-    Embed chunks for vector search and semantic chunking.
-  </Card>
-  <Card title="Semantic Extract" icon="magnifying-glass" href="semantic_extract">
-    Extract entities and relations from individual chunks.
-  </Card>
-  <Card title="Pipeline" icon="gear" href="pipeline">
-    Integrate splitting as a named pipeline step.
-  </Card>
-</CardGroup>
+- [Parse](parse) — Parse documents before chunking: produces sections and metadata.
+- [Embeddings](embeddings) — Embed chunks for vector search and semantic chunking.
+- [Semantic Extract](semantic_extract) — Extract entities and relations from individual chunks.
+- [Pipeline](pipeline) — Integrate splitting as a named pipeline step.

--- a/docs/reference/triplet_store.md
+++ b/docs/reference/triplet_store.md
@@ -19,26 +19,12 @@ icon: "table"
 
 ## What You Get
 
-<CardGroup cols={2}>
-  <Card title="TripletStore" icon="server">
-    Unified interface across Blazegraph, Apache Jena, and RDF4J: swap backends with one parameter.
-  </Card>
-  <Card title="SPARQL" icon="magnifying-glass">
-    Full SPARQL SELECT, ASK, CONSTRUCT, and UPDATE query support via `execute_query()`.
-  </Card>
-  <Card title="Bulk Loading" icon="layer-group">
-    `add_triplets()` batches writes with configurable batch size, retry logic, and progress tracking.
-  </Card>
-  <Card title="SKOS Vocabulary" icon="diagram-project">
-    Built-in helpers: `add_skos_concept()` and `get_skos_concepts()` for controlled vocabulary management.
-  </Card>
-  <Card title="Named Graphs" icon="folder-tree">
-    Blazegraph and RDF4J support named graph scoping via `graph=` on `execute_query()`.
-  </Card>
-  <Card title="Delta Computation" icon="code-compare">
-    `compute_delta(old_graph_uri, new_graph_uri)` returns added and removed triples between two named graph snapshots.
-  </Card>
-</CardGroup>
+- **TripletStore** — Unified interface across Blazegraph, Apache Jena, and RDF4J: swap backends with one parameter.
+- **SPARQL** — Full SPARQL SELECT, ASK, CONSTRUCT, and UPDATE query support via `execute_query()`.
+- **Bulk Loading** — `add_triplets()` batches writes with configurable batch size, retry logic, and progress tracking.
+- **SKOS Vocabulary** — Built-in helpers: `add_skos_concept()` and `get_skos_concepts()` for controlled vocabulary management.
+- **Named Graphs** — Blazegraph and RDF4J support named graph scoping via `graph=` on `execute_query()`.
+- **Delta Computation** — `compute_delta(old_graph_uri, new_graph_uri)` returns added and removed triples between two named graph snapshots.
 
 ## Getting Started
 
@@ -490,17 +476,7 @@ for row in result.bindings:
     print(row)
 ```
 
-<CardGroup cols={2}>
-  <Card title="Export" icon="file-export" href="export">
-    Export knowledge graphs to RDF formats.
-  </Card>
-  <Card title="Ontology" icon="sitemap" href="ontology">
-    Load OWL ontologies and store as RDF triples.
-  </Card>
-  <Card title="Reasoning" icon="microchip" href="reasoning">
-    SPARQL-based property chain inference.
-  </Card>
-  <Card title="Graph Store" icon="server" href="graph_store">
-    Property graph alternative for Cypher queries.
-  </Card>
-</CardGroup>
+- [Export](export) — Export knowledge graphs to RDF formats.
+- [Ontology](ontology) — Load OWL ontologies and store as RDF triples.
+- [Reasoning](reasoning) — SPARQL-based property chain inference.
+- [Graph Store](graph_store) — Property graph alternative for Cypher queries.

--- a/docs/reference/utils.md
+++ b/docs/reference/utils.md
@@ -36,26 +36,12 @@ Most users won't call utils directly: it's the **shared foundation** for all mod
 
 ## What You Get
 
-<CardGroup cols={2}>
-  <Card title="Logging" icon="scroll">
-    Structured logging with `@log_execution_time` decorator and quality metrics via environment variables.
-  </Card>
-  <Card title="Validation" icon="shield-check">
-    `validate_entity` and `validate_config` with a typed `ValidationError` carrying field and value context.
-  </Card>
-  <Card title="Progress Tracking" icon="bars-progress">
-    `track_progress` wraps any iterable: auto-detects console vs Jupyter for the right renderer.
-  </Card>
-  <Card title="Helper Functions" icon="wrench">
-    `clean_text`, `hash_data`, `safe_filename`, and nested dict utilities used throughout the framework.
-  </Card>
-  <Card title="Exception Hierarchy" icon="triangle-exclamation">
-    `SemanticaError` → `ValidationError`, `ProcessingError`: typed exceptions for targeted recovery.
-  </Card>
-  <Card title="File Utilities" icon="file">
-    `read_json_file` raises `FileNotFoundError` or `json.JSONDecodeError` on failure: no boilerplate try/except around JSON I/O.
-  </Card>
-</CardGroup>
+- **Logging** — Structured logging with `@log_execution_time` decorator and quality metrics via environment variables.
+- **Validation** — `validate_entity` and `validate_config` with a typed `ValidationError` carrying field and value context.
+- **Progress Tracking** — `track_progress` wraps any iterable: auto-detects console vs Jupyter for the right renderer.
+- **Helper Functions** — `clean_text`, `hash_data`, `safe_filename`, and nested dict utilities used throughout the framework.
+- **Exception Hierarchy** — `SemanticaError` → `ValidationError`, `ProcessingError`: typed exceptions for targeted recovery.
+- **File Utilities** — `read_json_file` raises `FileNotFoundError` or `json.JSONDecodeError` on failure: no boilerplate try/except around JSON I/O.
 
 ## Logging
 
@@ -226,11 +212,5 @@ from semantica.utils import read_json_file
 config = read_json_file("config.json")
 ```
 
-<CardGroup cols={2}>
-  <Card title="Core" icon="gear" href="core">
-    Framework orchestration that uses Utils internally.
-  </Card>
-  <Card title="Pipeline" icon="arrows-turn-to-dots" href="pipeline">
-    Uses ProgressTracker for per-step tracking.
-  </Card>
-</CardGroup>
+- [Core](core) — Framework orchestration that uses Utils internally.
+- [Pipeline](pipeline) — Uses ProgressTracker for per-step tracking.

--- a/docs/reference/vector_store.md
+++ b/docs/reference/vector_store.md
@@ -32,38 +32,24 @@ icon: "database"
 
 ## What You Get
 
-<CardGroup cols={2}>
-  <Card title="VectorStore" icon="database">
-    - Unified interface across FAISS, Pinecone, Weaviate, Qdrant, Milvus, PgVector
-    - One-line backend swap: no application code changes
-    - `add_documents()` auto-embeds; `store_vectors()` for pre-computed embeddings
-  </Card>
-  <Card title="HybridSearch" icon="magnifying-glass">
-    - Dense vector similarity with metadata filtering
-    - RRF or weighted-average fusion strategies
-    - Multi-source fusion across separate collections
-  </Card>
-  <Card title="MetadataStore" icon="table">
-    - Rich metadata indexing by field values
-    - Update metadata fields without re-embedding
-    - OR and AND query operators
-  </Card>
-  <Card title="NamespaceManager" icon="folder-tree">
-    - Structural per-tenant namespace isolation
-    - Faster queries (smaller search space per tenant)
-    - Safer than metadata-filter-only separation
-  </Card>
-  <Card title="Batch Operations" icon="layer-group">
-    - Bulk add, delete, and metadata updates
-    - Parallel embedding with configurable `batch_size` and `workers`
-    - In-place vector updates without full re-indexing
-  </Card>
-  <Card title="FAISS Index Types" icon="chart-scatter">
-    - flat, ivf, hnsw, and pq index types
-    - Full configuration control via `FAISSStore.create_index()`
-    - `save()` / `load()` for disk persistence
-  </Card>
-</CardGroup>
+- **VectorStore** — Unified interface across FAISS, Pinecone, Weaviate, Qdrant, Milvus, PgVector
+  - One-line backend swap: no application code changes
+  - `add_documents()` auto-embeds; `store_vectors()` for pre-computed embeddings
+- **HybridSearch** — Dense vector similarity with metadata filtering
+  - RRF or weighted-average fusion strategies
+  - Multi-source fusion across separate collections
+- **MetadataStore** — Rich metadata indexing by field values
+  - Update metadata fields without re-embedding
+  - OR and AND query operators
+- **NamespaceManager** — Structural per-tenant namespace isolation
+  - Faster queries (smaller search space per tenant)
+  - Safer than metadata-filter-only separation
+- **Batch Operations** — Bulk add, delete, and metadata updates
+  - Parallel embedding with configurable `batch_size` and `workers`
+  - In-place vector updates without full re-indexing
+- **FAISS Index Types** — flat, ivf, hnsw, and pq index types
+  - Full configuration control via `FAISSStore.create_index()`
+  - `save()` / `load()` for disk persistence
 
 
 ## Getting Started
@@ -602,17 +588,7 @@ store.create_index(index_type="pq", metric="L2", m=8)
   </Tab>
 </Tabs>
 
-<CardGroup cols={2}>
-  <Card title="Embeddings" icon="vector-square" href="embeddings">
-    Generate the vectors stored here.
-  </Card>
-  <Card title="Context" icon="brain" href="context">
-    AgentContext uses VectorStore for memory retrieval.
-  </Card>
-  <Card title="Split" icon="scissors" href="split">
-    Chunk documents before embedding and storing.
-  </Card>
-  <Card title="Ingest" icon="download" href="ingest">
-    Ingest documents before embedding and storing.
-  </Card>
-</CardGroup>
+- [Embeddings](embeddings) — Generate the vectors stored here.
+- [Context](context) — AgentContext uses VectorStore for memory retrieval.
+- [Split](split) — Chunk documents before embedding and storing.
+- [Ingest](ingest) — Ingest documents before embedding and storing.

--- a/docs/reference/visualization.md
+++ b/docs/reference/visualization.md
@@ -290,17 +290,7 @@ semantica-explorer --graph my_graph.json
 
 See the [Explorer reference](explorer) for the full feature set and REST API.
 
-<CardGroup cols={2}>
-  <Card title="Knowledge Graph" icon="diagram-project" href="kg">
-    The graph being visualized.
-  </Card>
-  <Card title="Ontology" icon="sitemap" href="ontology">
-    Visualize ontology class structure.
-  </Card>
-  <Card title="Embeddings" icon="vector-square" href="embeddings">
-    Generate the embeddings visualized here.
-  </Card>
-  <Card title="Explorer" icon="globe" href="explorer">
-    Full interactive Knowledge Explorer UI.
-  </Card>
-</CardGroup>
+- [Knowledge Graph](kg) — The graph being visualized.
+- [Ontology](ontology) — Visualize ontology class structure.
+- [Embeddings](embeddings) — Generate the embeddings visualized here.
+- [Explorer](explorer) — Full interactive Knowledge Explorer UI.


### PR DESCRIPTION
## Summary

- **Fix broken link** — `What's new →` in the homepage `<Info>` banner now uses a proper `<a>` tag so it's always clickable
- **Premium stats row** — replaced the 4-stat `<CardGroup>` on the homepage with an inline number display (1,000+ · 25+ · 12 · MIT) with large green numerals
- **Site-wide card → bullet conversion** — every `<CardGroup>/<Card>` block across all 50 docs pages replaced with clean markdown bullet lists:
  - Content sections: `**Title** — description` with sub-bullets
  - Navigation links: `[Title](href) — description`
- **CSS hover animations** — added to `custom.css`: green inset left border slides in on hover, subtle background tint, bullet marker turns green — smooth `0.18s` transitions throughout

## Files changed

- `docs/index.md` — homepage overhaul (stats row, all section cards → bullets, link fix)
- `docs/getting-started.md`, `quickstart.md`, `concepts.md`, `modules.md`, `faq.md`, `architecture.md`, `installation.md`, `cookbook.md`, `glossary.md`, `learning-more.md`, `explorer-setup.md`, `cli-setup.md`
- `docs/community.md`, `community-projects.md`, `contributing-guide.md`, `governance.md`, `citation.md`, `project-license.md`
- `docs/integrations/agno.md`, `docling.md`, `snowflake.md`
- All 20+ `docs/reference/` module pages
- `docs/assets/custom.css` — bullet point hover animation added

## Test plan

- [ ] Verify `What's new →` link navigates to the changelog section on the homepage
- [ ] Check bullet hover animations render in the Mintlify preview
- [ ] Confirm no content was lost — every card title and description is preserved as a bullet
- [ ] Spot-check reference pages to confirm navigation links still work