### PR TITLE
docs: align Explorer module references with actual CLI usage

### DIFF
--- a/docs/modules.md
+++ b/docs/modules.md
@@ -397,10 +397,8 @@ result = pipeline.run("data/")
 
 FastAPI Knowledge Explorer with Ontology Hub, WebSocket progress, bidirectional path finding, and indexed search (0.004ms on 118k nodes).
 
-```python
-# Launch via CLI
-# semantica explore --port 8080
-# Opens at http://localhost:8080
+```bash
+semantica-explorer --graph my_graph.json
 ```
 
 **Routes:** graph, ontology, provenance, decisions, analytics, SPARQL, temporal, annotations, export/import, vocabulary
@@ -694,7 +692,7 @@ versioner.create_snapshot(kg, "2024-Q1", author="user@example.com", description=
 | [export](reference/export) | Data export | `RDFExporter`, `ParquetExporter` |
 | [visualization](reference/visualization) | Graph visualization | `GraphVisualizer` |
 | [pipeline](reference/pipeline) | Workflow orchestration | `Pipeline`, `PipelineBuilder` |
-| [explorer](reference/explorer) | Knowledge Explorer UI | `start_explorer` |
+| [explorer](reference/explorer) | Knowledge Explorer UI | `semantica-explorer --graph <file>` |
 | [llms](reference/llms) | LLM providers | `Groq`, `OpenAI`, `create_provider` |
 | [mcp_server](reference/mcp_server) | MCP stdio server | `python -m semantica.mcp_server` |
 | [seed](reference/seed) | KG bootstrapping from structured sources | `SeedManager` |


### PR DESCRIPTION
## Summary

Align Explorer documentation with the actual implementation and existing Explorer setup documentation.

### Changes

* Replaced the invalid Explorer CLI example in `docs/modules.md` with the documented Explorer entry point:

  * `semantica-explorer --graph my_graph.json`
* Replaced the non-existent `start_explorer` reference in the Module Index with:

  * `semantica-explorer --graph <file>`

### Validation

The changes were verified against the implementation and existing documentation:

* Confirmed `start_explorer` does not exist anywhere in the codebase.
* Confirmed `semantica-explorer` is the registered Explorer entry point.
* Verified the command matches the usage documented in `docs/explorer-setup.md`.
* Verified the previous example (`semantica explore --port 8080`) was not a valid runnable command.
* Confirmed no files other than `docs/modules.md` were modified.

### Impact

This removes incorrect Explorer references and ensures the Modules reference page is consistent with the actual CLI and the dedicated Explorer documentation.
