### PR TITLE
docs: fix onboarding examples for GraphBuilder and temporal queries

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -94,9 +94,9 @@ icon: "rocket"
 
     # 4. Build
     graph = GraphBuilder(merge_entities=True).build(
-        entities=entities, relationships=relationships
+        {"entities": entities, "relationships": relationships}
     )
-    print(f"{len(graph['nodes'])} nodes, {len(graph['relationships'])} edges")
+    print(f"{len(graph['entities'])} nodes, {len(graph['relationships'])} edges")
     ```
 
     **Next:** [Full pipeline walkthrough →](quickstart)

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -348,20 +348,19 @@ graph   = builder.build({"entities": entities, "relationships": relationships})
 <Accordion title="Full provenance pipeline: W3C PROV-O" icon="link">
 
 ```python
-from semantica.kg import GraphBuilder, ProvenanceTracker
+from semantica.provenance import ProvenanceManager
+from semantica.kg import GraphBuilder
 
-tracker = ProvenanceTracker()
-
-# Record where each entity came from before or after extraction
-tracker.track_entity("Apple Inc.", "data/report.pdf", metadata={"confidence": 0.98})
+prov    = ProvenanceManager()
+prov.track_entity("Apple Inc.", "data/report.pdf", metadata={"confidence": 0.98})
 
 builder = GraphBuilder(merge_entities=True)
 graph   = builder.build({"entities": entities, "relationships": relationships})
 
 # Retrieve full lineage for any entity
-sources = tracker.get_all_sources("Apple Inc.")
+sources = prov.get_all_sources("Apple Inc.")
 print(sources[0])
-# {"source": "data/report.pdf", "recorded_at": "2026-05-22T10:30:00Z", "confidence": 0.98}
+# {"source": "data/report.pdf", "location": None, "timestamp": "...", "confidence": 0.98}
 ```
 
 </Accordion>

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -316,7 +316,8 @@ kg = builder.build({
 
 tq = TemporalGraphQuery(temporal_granularity="day")
 
-result_2020 = tq.query_at_time(kg, query="", at_time="2020-06-15")
+result_2020 = tq.query_at_time(kg, query="",  # query reserved for future use
+                               at_time="2020-06-15")
 result_2023 = tq.query_at_time(kg, query="", at_time="2023-01-01")
 
 print(f"Relationships active in 2020: {result_2020['num_relationships']}")
@@ -347,12 +348,20 @@ graph   = builder.build({"entities": entities, "relationships": relationships})
 <Accordion title="Full provenance pipeline: W3C PROV-O" icon="link">
 
 ```python
-from semantica.provenance import ProvenanceTracker
-from semantica.kg import GraphBuilder
+from semantica.kg import GraphBuilder, ProvenanceTracker
 
 tracker = ProvenanceTracker()
-builder = GraphBuilder(merge_entities=True, provenance=tracker)
+
+# Record where each entity came from before or after extraction
+tracker.track_entity("Apple Inc.", "data/report.pdf", metadata={"confidence": 0.98})
+
+builder = GraphBuilder(merge_entities=True)
 graph   = builder.build({"entities": entities, "relationships": relationships})
+
+# Retrieve full lineage for any entity
+sources = tracker.get_all_sources("Apple Inc.")
+print(sources[0])
+# {"source": "data/report.pdf", "recorded_at": "2026-05-22T10:30:00Z", "confidence": 0.98}
 ```
 
 </Accordion>

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -151,13 +151,9 @@ Assemble extracted entities and relationships into a queryable knowledge graph.
 from semantica.kg import GraphBuilder
 
 builder = GraphBuilder(merge_entities=True)
-graph   = builder.build(entities=entities, relationships=relationships)
+graph   = builder.build({"entities": entities, "relationships": relationships})
 
-print(f"Graph: {len(graph.nodes)} nodes, {len(graph.edges)} edges")
-
-# Query the graph
-apple    = graph.get_node("Apple Inc.")
-founders = graph.get_neighbors("Apple Inc.", predicate="founded_by")
+print(f"Graph: {len(graph['entities'])} nodes, {len(graph['relationships'])} edges")
 ```
 
 <Note>
@@ -289,7 +285,7 @@ for doc in parsed_docs:
     all_entities.extend(entities)
     all_rels.extend(rels)
 
-graph = builder.build(entities=all_entities, relationships=all_rels)
+graph = builder.build({"entities": all_entities, "relationships": all_rels})
 ```
 
 </Accordion>
@@ -297,18 +293,34 @@ graph = builder.build(entities=all_entities, relationships=all_rels)
 <Accordion title="Temporal knowledge graph with point-in-time queries" icon="clock">
 
 ```python
-from semantica.kg import TemporalKnowledgeGraph
-from datetime import datetime
+from semantica.kg import GraphBuilder, TemporalGraphQuery
 
-tkg = TemporalKnowledgeGraph()
+builder = GraphBuilder()
+kg = builder.build({
+    "entities": [
+        {"id": "alice",     "type": "Person"},
+        {"id": "acme_corp", "type": "Organization"},
+        {"id": "beta_ltd",  "type": "Organization"},
+    ],
+    "relationships": [
+        {
+            "source": "alice", "target": "acme_corp", "type": "ceo_of",
+            "valid_from": "2018-01-01", "valid_until": "2022-06-01",
+        },
+        {
+            "source": "alice", "target": "beta_ltd", "type": "ceo_of",
+            "valid_from": "2022-06-01",
+        },
+    ],
+})
 
-tkg.add_node("Tim Cook",   role="CEO", valid_from=datetime(2011, 8, 24))
-tkg.add_node("Steve Jobs", role="CEO", valid_from=datetime(1997, 9, 16),
-             valid_until=datetime(2011, 8, 24))
+tq = TemporalGraphQuery(temporal_granularity="day")
 
-# What did the graph look like on Jan 1, 2005?
-snapshot = tkg.at(datetime(2005, 1, 1))
-print(snapshot.get_node("Steve Jobs"))  # role: CEO
+result_2020 = tq.query_at_time(kg, query="", at_time="2020-06-15")
+result_2023 = tq.query_at_time(kg, query="", at_time="2023-01-01")
+
+print(f"Relationships active in 2020: {result_2020['num_relationships']}")
+print(f"Relationships active in 2023: {result_2023['num_relationships']}")
 ```
 
 </Accordion>
@@ -326,7 +338,7 @@ store = Neo4jStore(
 )
 
 builder = GraphBuilder(merge_entities=True, graph_store=store)
-graph   = builder.build(entities=entities, relationships=relationships)
+graph   = builder.build({"entities": entities, "relationships": relationships})
 # Graph persisted to Neo4j: survives process restarts
 ```
 
@@ -340,17 +352,7 @@ from semantica.kg import GraphBuilder
 
 tracker = ProvenanceTracker()
 builder = GraphBuilder(merge_entities=True, provenance=tracker)
-graph   = builder.build(entities=entities, relationships=relationships)
-
-# Every node and edge has full lineage
-node = graph.get_node("Apple Inc.")
-print(node.provenance)
-# {
-#   "source_document": "data/report.pdf",
-#   "extraction_method": "NERExtractor:llm",
-#   "extracted_at": "2026-05-22T10:30:00Z",
-#   "confidence": 0.98
-# }
+graph   = builder.build({"entities": entities, "relationships": relationships})
 ```
 
 </Accordion>


### PR DESCRIPTION
## Summary

Fix onboarding examples that did not match the current implementation.

### Changes

* Corrected `GraphBuilder.build()` usage in Quickstart and Getting Started guides.
* Updated examples to use the actual graph structure returned by `GraphBuilder`.
* Removed references to non-existent graph query methods.
* Replaced an outdated temporal knowledge graph example with a verified `TemporalGraphQuery` workflow.

### Validation

Verified against:

* `semantica/kg/graph_builder.py`
* `semantica/kg/temporal_query.py`
* `semantica/kg/__init__.py`

All examples were updated to match current APIs, method signatures, and return structures.
