### PR TITLE
docs: align onboarding examples with current APIs

### DIFF
--- a/docs/modules.md
+++ b/docs/modules.md
@@ -348,16 +348,16 @@ diff     = manager.diff("v1.0", "v1.1")
 Serializes graphs to downstream formats for analytics, semantic web, or graph databases.
 
 ```python
-from semantica.export import RDFExporter, ParquetExporter, ArangoDBExporter
+from semantica.export import RDFExporter, ParquetExporter, ArangoAQLExporter
 
 # RDF formats
-RDFExporter().export_to_rdf(graph, format="turtle", output="graph.ttl")
+RDFExporter().export(graph, file_path="graph.ttl", format="turtle")
 
 # Analytics
-ParquetExporter().export(graph, output_dir="output/")
+ParquetExporter().export(graph, file_path="output/graph.parquet")
 
 # ArangoDB
-aql = ArangoDBExporter().export(graph)
+aql = ArangoAQLExporter().export(graph)
 ```
 
 **Export formats:** RDF (Turtle, JSON-LD, N-Triples, XML), Parquet, ArangoDB AQL, CSV, OWL, Arrow, LPG, YAML, distance matrices
@@ -367,13 +367,13 @@ aql = ArangoDBExporter().export(graph)
 Renders interactive and static knowledge graph visualizations.
 
 ```python
-from semantica.visualization import GraphVisualizer
+from semantica.visualization import KGVisualizer
 
-viz = GraphVisualizer()
-viz.visualize(graph, output="graph.html")
+viz = KGVisualizer()
+viz.visualize_network(graph, output="html", file_path="graph.html")
 ```
 
-**Visualizers:** `GraphVisualizer`, `OntologyVisualizer`, `EmbeddingVisualizer`, `SemanticNetworkVisualizer`, `TemporalVisualizer`, `AnalyticsVisualizer`
+**Visualizers:** `KGVisualizer`, `OntologyVisualizer`, `EmbeddingVisualizer`, `SemanticNetworkVisualizer`, `TemporalVisualizer`, `AnalyticsVisualizer`
 
 **Layout algorithms:** force-directed, hierarchical, circular
 
@@ -609,7 +609,7 @@ graph    = GraphBuilder(merge_entities=True).build(entities=entities, relationsh
 prov     = ProvenanceManager()
 lineage  = prov.get_entity_lineage("entity_id")
 
-RDFExporter(include_provenance=True).export_to_rdf(graph, format="turtle", output="audit.ttl")
+RDFExporter(include_provenance=True).export(graph, file_path="audit.ttl", format="turtle")
 ```
 
     **Best for:** HIPAA, SOX, GDPR, FDA 21 CFR Part 11 deployments
@@ -690,7 +690,7 @@ versioner.create_snapshot(kg, "2024-Q1", author="user@example.com", description=
 | [provenance](reference/provenance) | W3C PROV-O lineage | `ProvenanceManager` |
 | [change_management](reference/change_management) | Version control | `TemporalVersionManager` |
 | [export](reference/export) | Data export | `RDFExporter`, `ParquetExporter` |
-| [visualization](reference/visualization) | Graph visualization | `GraphVisualizer` |
+| [visualization](reference/visualization) | Graph visualization | `KGVisualizer` |
 | [pipeline](reference/pipeline) | Workflow orchestration | `Pipeline`, `PipelineBuilder` |
 | [explorer](reference/explorer) | Knowledge Explorer UI | `semantica-explorer --graph <file>` |
 | [llms](reference/llms) | LLM providers | `Groq`, `OpenAI`, `create_provider` |

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -167,14 +167,12 @@ print(f"Graph: {len(graph['entities'])} nodes, {len(graph['relationships'])} edg
 Render an interactive, zoomable knowledge graph in the browser.
 
 ```python
-from semantica.visualization import GraphVisualizer
+from semantica.visualization import KGVisualizer
 
-viz = GraphVisualizer(
+viz = KGVisualizer(
     layout="force",        # "force" | "hierarchical" | "circular"
-    node_color_by="type",  # color nodes by entity type
-    show_confidence=True,
 )
-viz.visualize(graph, output="graph.html")
+viz.visualize_network(graph, output="html", file_path="graph.html", node_color_by="type")
 ```
 
 Open `graph.html` in any browser: pan, zoom, click nodes for details, filter by entity type.
@@ -191,23 +189,23 @@ Export to any downstream format.
 from semantica.export import RDFExporter
 
 exporter = RDFExporter()
-exporter.export_to_rdf(graph, format="turtle",  output="graph.ttl")
-exporter.export_to_rdf(graph, format="json-ld", output="graph.jsonld")
-exporter.export_to_rdf(graph, format="nt",      output="graph.nt")
+exporter.export(graph, file_path="graph.ttl",    format="turtle")
+exporter.export(graph, file_path="graph.jsonld", format="json-ld")
+exporter.export(graph, file_path="graph.nt",     format="nt")
 ```
 
 ```python Parquet / Analytics
 from semantica.export import ParquetExporter
 
 exporter = ParquetExporter()
-exporter.export(graph, output_dir="output/")
+exporter.export(graph, file_path="output/graph.parquet")
 # Writes nodes.parquet + edges.parquet: ready for Spark, BigQuery, Databricks
 ```
 
 ```python ArangoDB
-from semantica.export import ArangoDBExporter
+from semantica.export import ArangoAQLExporter
 
-exporter = ArangoDBExporter()
+exporter = ArangoAQLExporter()
 aql      = exporter.export(graph)
 # Returns ready-to-run AQL INSERT statements
 ```


### PR DESCRIPTION
## Summary

Fix onboarding documentation examples that reference outdated visualization and export APIs.

## Changes

### Visualization

* Replace `GraphVisualizer` with `KGVisualizer`
* Replace `visualize()` with `visualize_network()`
* Update visualization module references to match exported APIs

### Export

* Replace `ArangoDBExporter` with `ArangoAQLExporter`
* Update RDF export examples to use the current `export()` API
* Update Parquet export examples to use `file_path` instead of `output_dir`
* Update remaining RDF export examples in module workflow chains

## Verification

All changes were verified against the current implementation and exported public APIs:

* `KGVisualizer`
* `KGVisualizer.visualize_network()`
* `RDFExporter.export()`
* `ParquetExporter.export()`
* `ArangoAQLExporter.export()`

## Files Changed

* `docs/quickstart.md`
* `docs/modules.md`
