### PR TITLE
docs: lighten code block hover animation

### DIFF
--- a/docs/assets/custom.css
+++ b/docs/assets/custom.css
@@ -148,18 +148,21 @@ pre,
 [class*="CodeBlock"],
 [data-rehype-pretty-code-fragment] {
   transition:
-    box-shadow   0.22s ease,
-    border-color 0.22s ease !important;
+    box-shadow   0.25s cubic-bezier(0.4, 0, 0.2, 1),
+    border-color 0.25s cubic-bezier(0.4, 0, 0.2, 1),
+    transform    0.25s cubic-bezier(0.4, 0, 0.2, 1) !important;
 }
 
 pre:hover,
 [class*="codeblock"]:hover,
 [class*="CodeBlock"]:hover,
 [data-rehype-pretty-code-fragment]:hover {
+  transform: translateY(-1px) !important;
   box-shadow:
-    0 0 0 1px rgba(16, 185, 129, 0.28),
-    0 4px 24px rgba(16, 185, 129, 0.09) !important;
-  border-color: rgba(16, 185, 129, 0.28) !important;
+    0 0 0 1px rgba(16, 185, 129, 0.18),
+    0 2px 12px rgba(16, 185, 129, 0.06),
+    0 8px 32px rgba(0, 0, 0, 0.2) !important;
+  border-color: rgba(16, 185, 129, 0.2) !important;
 }
 
 /* ── CARDS ───────────────────────────────────────────────────── */


### PR DESCRIPTION
## Summary

Refines the code block hover effect to be lighter and more premium — a barely-there 1px lift with a faint emerald ring and soft depth shadow, instead of the more visible 1px ring + flat glow from the previous pass.

## Changes

| Property | Before | After |
|---|---|---|
| Ring | `1px rgba(16,185,129, 0.28)` | `1px rgba(16,185,129, 0.18)` |
| Glow spread | `0 4px 24px rgba(green, 0.09)` | `0 2px 12px rgba(green, 0.06)` |
| Depth shadow | none | `0 8px 32px rgba(0,0,0, 0.2)` |
| Lift | none | `translateY(-1px)` |
| Easing | `ease` | `cubic-bezier(0.4, 0, 0.2, 1)` |

The depth shadow (`rgba(0,0,0, 0.2)`) lifts the block visually off the page without adding green — keeping the effect premium but not distracting.

## Test plan
- [ ] Hover over a code block — should feel like it gently lifts off the page
- [ ] Ring and glow should be barely visible, not neon