### PR TITLE
docs: improve conflict resolution guide onboarding and workflow guidance

### DIFF
--- a/docs/guides/conflict-resolution.md
+++ b/docs/guides/conflict-resolution.md
@@ -10,9 +10,152 @@ icon: "code-merge"
 Run conflict detection after deduplication and before SHACL validation. Deduplication removes duplicate nodes; conflict resolution reconciles disagreeing property values on the same canonical entity. Running them out of order — detecting conflicts before deduplication — will produce spurious conflicts between entities that should have been merged first.
 </Info>
 
-## Detecting the disagreement
+## What Is Conflict Resolution?
 
-Start by loading your multi-source records for the same entity. `ConflictDetector` groups them by entity ID, then compares the values each source reports for a given property. Any entity where two or more sources report different values for the same property produces a `Conflict` object.
+When you merge data from multiple sources, the same real-world entity — a customer, a product, a threat actor, a drug compound — often appears with contradictory property values. One database says a customer's email is `alice@example.com`; another says `alice.smith@example.com`. One security feed rates a CVE at 10.0; two others rate it 9.1 and 9.5.
+
+**Conflict resolution** is the systematic process of deciding which value is most trustworthy and recording that decision with evidence, so the canonical entity ends up with one defensible, auditable value per property.
+
+### Key Concepts
+
+**Canonical entity** — The single authoritative record for a real-world thing. After deduplication, each entity has exactly one canonical node in your graph. Conflict resolution determines which property values belong on that node.
+
+**Conflicting values** — Two or more different values asserted for the same property on the same canonical entity, each reported by a different source.
+
+**Credibility score** — A number between 0.0 and 1.0 you attach to each source record, indicating how reliable that source is. A government registry might carry 0.99; a scraped blog might carry 0.30. You supply these; Semantica uses them during `CREDIBILITY_WEIGHTED` resolution.
+
+**Confidence score** — A number between 0.0 and 1.0 the resolver *computes* after resolution, reflecting how certain the outcome is. A unanimous vote produces high confidence; a close split among equally credible sources produces lower confidence. This appears on `ResolutionResult.confidence` and should be read as a signal, not a guarantee that the resolved value is correct.
+
+**Resolution strategy** — The rule for picking the winning value: majority vote, credibility-weighted average, latest timestamp, and so on. See [Resolution strategies at a glance](#resolution-strategies-at-a-glance) for the full list.
+
+**Audit trail** — The complete record of every resolution decision: conflict ID, strategy used, resolved value, sources consulted, and confidence score. Returned by `resolver.get_resolution_history()`.
+
+**Provenance-aware resolution** — Resolution that records not just the winning value but which source it came from. Every `ResolutionResult` carries a `sources_used` field, so you can always trace a canonical value back to its origin — critical in regulated environments.
+
+## Why Use Conflict Resolution?
+
+- **Multi-source pipelines always produce disagreements.** Differences in update cadence, data-entry conventions, and source reliability are unavoidable. Without an explicit resolution step, you silently favor one source over another with no record of the choice.
+- **You get a defensible, auditable decision log.** Compliance teams, auditors, and domain experts need to know which source won and why. The audit trail provides exactly that.
+- **Easy cases are automated; hard cases are escalated.** Routine disagreements — slightly different name spellings, stale timestamps — are resolved algorithmically. Genuinely ambiguous cases — competing legal classifications, different clinical endpoints — are flagged for expert review without blocking the rest of the pipeline.
+
+## When To Use / When Not To Use
+
+**Use conflict resolution when:**
+- You are merging two or more independent sources for the same entity.
+- Sources disagree on property values and you need a single canonical value.
+- You need an auditable record of every resolution decision.
+- Some conflicts require domain-expert review before they can be resolved.
+
+**Skip conflict resolution when:**
+- **A single authoritative source already exists.** If one system is always correct for a given property, read from it directly. Adding resolution machinery around a single source creates complexity without benefit.
+- **All sources are always in agreement.** Verify this empirically before skipping; silent disagreements are common in practice.
+- **You want to preserve all conflicting values.** If retaining every source's assertion matters more than picking one, model provenance directly in your graph schema instead of resolving to one winner.
+
+## Typical Workflow
+
+```mermaid
+flowchart TD
+    A[Raw Sources] --> B[Deduplication]
+    B --> C[Conflict Detection]
+    C --> D{Auto-resolvable?}
+    D -- Yes --> E[Apply Resolution Strategy]
+    D -- No --> F[Expert Review Queue]
+    E --> G[Persist Canonical Values]
+    F --> G
+    G --> H[SHACL Validation]
+```
+
+1. **Deduplication** — Merge duplicate nodes so each entity has exactly one canonical record. Conflict resolution operates on a single canonical entity; you must identify it before comparing what different sources say about it. See [Deduplication](deduplication).
+2. **Conflict Detection** — Call `detect_entity_conflicts()` to surface all property disagreements at once, or `detect_value_conflicts()` to target a specific property.
+3. **Resolution** — For each conflict, apply a strategy (`CREDIBILITY_WEIGHTED`, `MOST_RECENT`, `VOTING`, etc.) or route it for expert review (`EXPERT_REVIEW`).
+4. **Persist Canonical Values** — Write resolved values back to your canonical entities or graph store. See [Persisting resolved values](#persisting-resolved-values).
+5. **SHACL Validation** — Enforce structural constraints on the resolved graph to confirm it satisfies your ontology. See [SHACL Validation](shacl-validation).
+
+## Quick Start: A Beginner Example
+
+Before diving into domain-specific scenarios, here is the shortest path through the API. Three systems — a CRM, an ERP, and an LDAP directory — hold slightly different contact details for the same customer. Two of the three agree that the canonical email is `alice.smith@example.com`; the CRM has an older value.
+
+```python
+from semantica.conflicts import ConflictDetector, ConflictResolver, ResolutionStrategy
+
+# Same customer, three sources — only email disagrees
+customer_records = [
+    {"id": "cust-001", "source": "crm",  "email": "alice@example.com",       "phone": "+1-555-0100"},
+    {"id": "cust-001", "source": "erp",  "email": "alice.smith@example.com", "phone": "+1-555-0100"},
+    {"id": "cust-001", "source": "ldap", "email": "alice.smith@example.com", "phone": "+1-555-0100"},
+]
+
+# Step 1: Detect all property conflicts at once — no need to name each property
+detector = ConflictDetector()
+conflicts = detector.detect_entity_conflicts(customer_records)
+
+print(f"Conflicts found: {len(conflicts)}")
+for c in conflicts:
+    print(f"  Property : {c.property_name}")
+    print(f"  Values   : {c.conflicting_values}")
+    print(f"  Severity : {c.severity}")
+
+# Step 2: Resolve — two out of three sources agree, so majority vote wins
+resolver = ConflictResolver()
+results = resolver.resolve_conflicts(conflicts, strategy=ResolutionStrategy.VOTING)
+
+for r in results:
+    print(f"\n[{'RESOLVED' if r.resolved else 'REVIEW'}] {r.conflict_id}")
+    print(f"  Resolved value : {r.resolved_value}")
+    print(f"  Strategy       : {r.resolution_strategy}")
+    print(f"  Confidence     : {r.confidence:.0%}")
+    print(f"  Sources used   : {r.sources_used}")
+```
+
+```text
+Conflicts found: 1
+  Property : email
+  Values   : ['alice@example.com', 'alice.smith@example.com']
+  Severity : low
+
+[RESOLVED] cust-001_email_conflict
+  Resolved value : alice.smith@example.com
+  Strategy       : voting
+  Confidence     : 67%
+  Sources used   : ['erp', 'ldap']
+```
+
+`detect_entity_conflicts()` scanned both `email` and `phone` automatically — you did not name them. Because `phone` is identical across all three records, no conflict was detected for it. The email disagreement resolves to `alice.smith@example.com` because two of three sources agree on that value.
+
+When every conflict in a batch should use the same strategy, pass `strategy=` directly to `resolve_conflicts()`. Use `set_resolution_rule()` when different entity-property pairs need different strategies — explained in [Setting per-property resolution rules](#setting-per-property-resolution-rules).
+
+## Detecting Conflicts
+
+`ConflictDetector` provides three methods. Choose the one that fits your situation:
+
+| Method | What it scans | When to use |
+| :--- | :--- | :--- |
+| `detect_entity_conflicts(entities)` | Every property on each entity at once | First pass; you do not know in advance which properties conflict |
+| `detect_value_conflicts(entities, property_name)` | One named property across all entities | Targeted check for a known hot-spot property |
+| `detect_relationship_conflicts(relationships)` | Edge types between the same node pair | Structural disagreements in graph edges |
+
+### Scanning All Properties at Once — `detect_entity_conflicts`
+
+`detect_entity_conflicts()` is the recommended starting point for a new pipeline. It inspects every property found on your entity records and returns a single flat list of all conflicts — without you having to enumerate properties in advance.
+
+```python
+detector = ConflictDetector()
+all_conflicts = detector.detect_entity_conflicts(records)
+# Returns every conflict across every property in one call
+```
+
+If you have registered conflict fields for a specific entity type, pass `entity_type` to limit detection to those fields:
+
+```python
+# Limit detection to fields registered for this entity type
+all_conflicts = detector.detect_entity_conflicts(records, entity_type="vulnerability")
+```
+
+Without `entity_type`, the detector checks every key found on your entity dicts (excluding bookkeeping fields such as `id`, `source`, and `metadata`). Start here to get a complete picture, then decide which conflicts need which resolution strategy.
+
+### Scanning a Specific Property — `detect_value_conflicts`
+
+Use `detect_value_conflicts()` when you already know which property to check, or when you want to apply different detection logic to each property. `ConflictDetector` groups the records by entity ID, then compares each source's value for that property. Any entity where two or more sources report different values produces a `Conflict` object.
 
 ```python
 from semantica.conflicts import ConflictDetector, ConflictResolver, ResolutionStrategy
@@ -79,9 +222,24 @@ Conflict: cve-2024-3400_cvss_score_conflict
 
 Each `Conflict` captures the full picture: which entity, which property, every disagreeing value, and which source reported each. This is already enough to build a review queue — but the goal is to resolve these automatically according to rules you set.
 
-## Setting per-property resolution rules
+## Setting Per-Property Resolution Rules
 
-The key method is `set_resolution_rule(entity_id, property_name, strategy)`. It takes three arguments: which entity, which property, and which `ResolutionStrategy` to apply when that combination appears in a conflict. Rules are stored in the resolver and automatically applied when you call `resolve_conflicts()` without passing an explicit strategy.
+`set_resolution_rule(entity_id, property_name, strategy)` registers a strategy for a specific entity-property combination. The resolver stores the rule under the key `entity_id.property_name` and applies it automatically when you call `resolve_conflicts()`.
+
+Because rules are keyed by both entity ID and property name, `set_resolution_rule()` is entity-specific. There is no wildcard that applies a rule to all entities or all properties at once.
+
+**When to use `set_resolution_rule()`:** Use it when different entity-property combinations need different strategies. For example, an entity's `legal_name` might use `CREDIBILITY_WEIGHTED` while its `last_updated` uses `MOST_RECENT`. Registering a rule per combination lets the single `resolve_conflicts()` call handle all of them correctly in one pass.
+
+**When to pass `strategy=` directly to `resolve_conflicts()`:** If every conflict in a batch should use the same strategy, pass it directly to `resolve_conflicts()` instead of registering a rule for each entity-property pair:
+
+```python
+# Same strategy for every conflict — no per-property rules needed
+results = resolver.resolve_conflicts(all_conflicts, strategy=ResolutionStrategy.CREDIBILITY_WEIGHTED)
+```
+
+This is cleaner than calling `set_resolution_rule()` in a loop over every entity just to apply the same strategy everywhere.
+
+**Per-property rules for the CVE example:**
 
 ```python
 resolver = ConflictResolver()
@@ -108,9 +266,9 @@ resolver.set_resolution_rule(
 
 You can set rules before or after detection — the resolver applies them lazily when `resolve_conflicts()` is called.
 
-## Resolving the batch
+## Resolving the Batch
 
-Pass all detected conflicts to `resolve_conflicts()`. For each conflict, the resolver looks up whether a property-specific rule is set for that entity and property combination. If one is found, it applies that strategy. If none is set, it falls back to the default strategy (voting, unless you override it in the constructor).
+Pass all detected conflicts to `resolve_conflicts()`. For each conflict, the resolver looks up whether a rule is registered for that entity-property combination. If one is found, it applies that strategy. If none is set, it falls back to the default strategy (voting, unless you override it in the constructor).
 
 ```python
 all_conflicts = score_conflicts + exploit_conflicts
@@ -146,7 +304,7 @@ for r in results:
 
 NVD wins the CVSS score — its credibility weight (0.98) edges out the commercial feed (0.91) and the vendor (0.87), so 10.0 becomes the canonical score. The exploitation status resolves to `in_wild` — the commercial feed and vendor advisory are both more recent than NVD's initial triage, and both report active exploitation.
 
-## Handling conflicts that need human judgment
+## Handling Conflicts That Need Human Judgment
 
 Not every conflict can be auto-resolved. A disagreement about the legal classification of a financial instrument, or about a patient's current medication list, is too consequential to resolve by algorithm. Flag these for review without blocking the rest of the batch:
 
@@ -214,7 +372,38 @@ Expert review : 1   # primary_endpoint — EXPERT_REVIEW means resolved=False
 
 `EXPERT_REVIEW` sets `resolved=False` on the result. The conflict stays in the graph unresolved, the metadata field carries `requires_expert_review: True`, and the review queue JSON gives your clinical team exactly what they need to make the call.
 
-## Reviewing the full audit trail
+## Persisting Resolved Values
+
+`resolve_conflicts()` returns `ResolutionResult` objects — it does not automatically write resolved values back to your graph or entity store. That step is yours to implement using whatever storage layer your pipeline uses.
+
+The most direct approach is to pair each `ResolutionResult` with its original `Conflict` object — the two lists are returned in the same order — and write the winning value onto your canonical entity:
+
+```python
+# canonical_entity is your authoritative record — a dict, graph node, database row, etc.
+canonical_entity = {"id": "cve-2024-3400", "cvss_score": None, "exploit_status": None}
+
+for conflict, result in zip(all_conflicts, results):
+    if result.resolved:
+        canonical_entity[conflict.property_name] = result.resolved_value
+        # Log provenance: record which source this value came from
+        print(f"  {conflict.property_name} = {result.resolved_value} "
+              f"(from {result.sources_used}, confidence {result.confidence:.0%})")
+
+# Persist canonical_entity to your graph store, database, or downstream system.
+```
+
+```text
+  cvss_score = 10.0 (from ['nvd'], confidence 72%)
+  exploit_status = in_wild (from ['commercial_feed'], confidence 80%)
+```
+
+A few things to keep in mind:
+
+- **Conflicts with `resolved=False`** — flagged for expert or manual review — should not be written to the canonical record until a human has made the call. Keep them in the review queue.
+- **Confidence is a signal, not a guarantee.** A 72% confidence score means the resolver had reasonable but not unanimous evidence for its decision. Treat low-confidence results with additional scrutiny before writing them to production.
+- **Track provenance.** `result.sources_used` tells you which source's value won. Store this alongside the canonical value if your compliance requirements demand a full evidence chain.
+
+## Reviewing the Full Audit Trail
 
 After a resolution run, `get_resolution_history()` returns every decision made since the resolver was instantiated. This is your compliance log:
 
@@ -245,7 +434,7 @@ print(f"By severity               : {report['by_severity']}")
 
 The report aggregates every conflict the detector has seen across its lifetime — useful for pipeline monitoring and for identifying which entity types or data sources generate the most disagreements.
 
-## Detecting relationship conflicts
+## Detecting Relationship Conflicts
 
 Value conflicts live on properties. Relationship conflicts live on edges — two sources asserting contradictory connections between the same node pair:
 
@@ -267,7 +456,7 @@ for c in rel_conflicts:
 
 Relationship conflicts typically require expert review rather than voting, because conflicting edge types often reflect genuinely different intelligence assessments rather than data entry errors.
 
-## Domain examples
+## Domain Examples
 
 <Tabs>
 
@@ -456,7 +645,7 @@ print(f"  By severity    : {report['by_severity']}")
 
 </Tabs>
 
-## Resolution strategies at a glance
+## Resolution Strategies at a Glance
 
 | Strategy | How it decides | Best when |
 | :--- | :--- | :--- |
@@ -467,6 +656,29 @@ print(f"  By severity    : {report['by_severity']}")
 | `HIGHEST_CONFIDENCE` | Value from the source with the highest `confidence` field | Automated extractors emit per-record confidence scores |
 | `MANUAL_REVIEW` | Flags the conflict; `resolved=False` | Low-volume, high-stakes decisions |
 | `EXPERT_REVIEW` | Flags for domain expert queue; `resolved=False` | Scientific or legal disambiguation required |
+
+## Common Pitfalls
+
+**Running conflict resolution before deduplication**
+If duplicate nodes for the same real-world entity still exist, `ConflictDetector` treats each duplicate as a separate entity disagreeing with the others — producing spurious conflicts that should never have existed. Always run deduplication first.
+
+**Forgetting to persist resolved values**
+`resolve_conflicts()` returns `ResolutionResult` objects; it does not write them anywhere. Inspecting the results and moving on without updating your canonical entity means nothing has actually changed in your data. See [Persisting resolved values](#persisting-resolved-values).
+
+**Scanning properties one at a time across a large entity set**
+Calling `detect_value_conflicts()` for every property in a manual loop produces redundant passes over your data. Use `detect_entity_conflicts()` instead — it handles all properties in a single call and is the recommended starting point for bulk detection.
+
+**Misunderstanding credibility scores**
+Credibility scores are weights you assign based on your prior knowledge of source reliability — not ground truth. A source with `credibility_score: 0.99` can still be wrong. `CREDIBILITY_WEIGHTED` resolution amplifies your beliefs about source quality; if those beliefs are miscalibrated, the resolutions will be too. Validate scores against known ground truth before relying on them in production.
+
+**Treating resolved values as guaranteed truth**
+A resolved value is the most defensible answer given your sources and strategy — not necessarily the correct one. Low confidence scores and `EXPERT_REVIEW` flags are signals to scrutinize results before writing them to a canonical record or downstream system.
+
+**Using conflict resolution when a single authoritative source already exists**
+If one system is always correct for a given property, read from it directly. Layering conflict resolution over a single source adds complexity, introduces unnecessary doubt, and produces an audit trail that adds no real information.
+
+**Registering rules in a loop to apply one strategy uniformly**
+Calling `set_resolution_rule()` for every entity-property pair just to apply the same strategy to all of them creates O(N) setup for no benefit. Pass `strategy=` directly to `resolve_conflicts()` when one strategy covers the whole batch.
 
 ## Related Guides
 

--- a/docs/guides/conflict-resolution.md
+++ b/docs/guides/conflict-resolution.md
@@ -110,14 +110,14 @@ for r in results:
 ```text
 Conflicts found: 1
   Property : email
-  Values   : ['alice@example.com', 'alice.smith@example.com']
-  Severity : low
+  Values   : ['alice@example.com', 'alice.smith@example.com', 'alice.smith@example.com']
+  Severity : medium
 
 [RESOLVED] cust-001_email_conflict
   Resolved value : alice.smith@example.com
   Strategy       : voting
   Confidence     : 67%
-  Sources used   : ['erp', 'ldap']
+  Sources used   : ['crm', 'erp', 'ldap']
 ```
 
 `detect_entity_conflicts()` scanned both `email` and `phone` automatically — you did not name them. Because `phone` is identical across all three records, no conflict was detected for it. The email disagreement resolves to `alice.smith@example.com` because two of three sources agree on that value.
@@ -168,7 +168,7 @@ cve_records = [
         "cvss_score": 10.0,
         "exploit_status": "unconfirmed",
         "vector": "AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H",
-        "credibility_score": 0.98,
+        "metadata": {"timestamp": "2024-04-11T12:00:00Z"},
     },
     {
         "id": "cve-2024-3400",
@@ -176,7 +176,7 @@ cve_records = [
         "cvss_score": 9.1,
         "exploit_status": "in_wild",
         "vector": "AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
-        "credibility_score": 0.91,
+        "metadata": {"timestamp": "2024-04-12T15:30:00Z"},
     },
     {
         "id": "cve-2024-3400",
@@ -184,7 +184,7 @@ cve_records = [
         "cvss_score": 9.5,
         "exploit_status": "in_wild",
         "vector": "AV:N/AC:H/PR:N/UI:N/S:C/C:H/I:H/A:H",
-        "credibility_score": 0.87,
+        "metadata": {"timestamp": "2024-04-12T12:00:00Z"},
     },
 ]
 
@@ -217,7 +217,7 @@ Conflict: cve-2024-3400_cvss_score_conflict
   Values   : [10.0, 9.1, 9.5]
   Severity : medium
   Sources  : ['nvd', 'commercial_feed', 'vendor_paloalto']
-  Action   : Compare source documents and use most recent or authoritative source
+  Action   : Multiple conflicting values detected. Manual review recommended.
 ```
 
 Each `Conflict` captures the full picture: which entity, which property, every disagreeing value, and which source reported each. This is already enough to build a review queue — but the goal is to resolve these automatically according to rules you set.
@@ -244,8 +244,13 @@ This is cleaner than calling `set_resolution_rule()` in a loop over every entity
 ```python
 resolver = ConflictResolver()
 
+# Register source credibility scores so CREDIBILITY_WEIGHTED can use them
+resolver.source_tracker.set_source_credibility("nvd", 0.98)
+resolver.source_tracker.set_source_credibility("commercial_feed", 0.91)
+resolver.source_tracker.set_source_credibility("vendor_paloalto", 0.87)
+
 # For this CVE, NVD is the most authoritative source on scoring.
-# CREDIBILITY_WEIGHTED will use the credibility_score field on each source record
+# CREDIBILITY_WEIGHTED uses the registered source credibility 
 # to weight the vote — NVD at 0.98 will dominate over the commercial feed at 0.91.
 resolver.set_resolution_rule(
     "cve-2024-3400",
@@ -290,9 +295,9 @@ for r in results:
 [RESOLVED] cve-2024-3400_cvss_score_conflict
   Resolved value : 10.0
   Strategy used  : credibility_weighted
-  Confidence     : 72%
+  Confidence     : 36%
   Sources used   : ['nvd', 'commercial_feed', 'vendor_paloalto']
-  Notes          : Resolved by credibility-weighted voting (weight: 0.98)
+  Notes          : Resolved by credibility-weighted voting (weight: 0.49)
 
 [RESOLVED] cve-2024-3400_exploit_status_conflict
   Resolved value : in_wild
@@ -314,14 +319,11 @@ from semantica.conflicts import ConflictDetector, ConflictResolver, ResolutionSt
 # Drug trial data: efficacy agreed, primary endpoint disputed
 trial_records = [
     {"id": "dapagliflozin", "source": "declare_timi58",
-     "primary_endpoint": "MACE",               "hba1c_reduction_pct": 0.54,
-     "credibility_score": 0.92},
+     "primary_endpoint": "MACE",               "hba1c_reduction_pct": 0.54},
     {"id": "dapagliflozin", "source": "dapa_hf",
-     "primary_endpoint": "HF_hospitalization", "hba1c_reduction_pct": 0.48,
-     "credibility_score": 0.95},
+     "primary_endpoint": "HF_hospitalization", "hba1c_reduction_pct": 0.48},
     {"id": "dapagliflozin", "source": "meta_analysis",
-     "primary_endpoint": "HbA1c_reduction",    "hba1c_reduction_pct": 0.52,
-     "credibility_score": 0.88},
+     "primary_endpoint": "HbA1c_reduction",    "hba1c_reduction_pct": 0.52},
 ]
 
 detector = ConflictDetector()
@@ -329,6 +331,11 @@ efficacy_conflicts  = detector.detect_value_conflicts(trial_records, "hba1c_redu
 endpoint_conflicts  = detector.detect_value_conflicts(trial_records, "primary_endpoint")
 
 resolver = ConflictResolver()
+
+# Register source credibility scores
+resolver.source_tracker.set_source_credibility("declare_timi58", 0.92)
+resolver.source_tracker.set_source_credibility("dapa_hf", 0.95)
+resolver.source_tracker.set_source_credibility("meta_analysis", 0.88)
 
 # Efficacy: credibility-weighted across trials — the meta-analysis (0.88) and
 # the two RCTs (0.92, 0.95) will produce a weighted resolution.
@@ -427,9 +434,9 @@ report = detector.get_conflict_report()
 print(f"Total conflicts detected  : {report['total_conflicts']}")
 print(f"By type                   : {report['by_type']}")
 print(f"By severity               : {report['by_severity']}")
-# Total conflicts detected  : 2
-# By type                   : {'value_conflict': 2}
-# By severity               : {'medium': 2}
+# Total conflicts detected  : 6
+# By type                   : {'value_conflict': 6}
+# By severity               : {'medium': 6}
 ```
 
 The report aggregates every conflict the detector has seen across its lifetime — useful for pipeline monitoring and for identifying which entity types or data sources generate the most disagreements.
@@ -471,11 +478,11 @@ from semantica.conflicts import ConflictDetector, ConflictResolver, ResolutionSt
 
 actor_profiles = [
     {"id": "apt29", "source": "mandiant",    "nation_state": "Russia",
-     "first_seen": "2008", "credibility_score": 0.95},
+     "first_seen": "2008"},
     {"id": "apt29", "source": "crowdstrike", "nation_state": "Russia",
-     "first_seen": "2009", "credibility_score": 0.92},
+     "first_seen": "2009"},
     {"id": "apt29", "source": "oss_blog",    "nation_state": "China",  # wrong
-     "first_seen": "2015", "credibility_score": 0.30},
+     "first_seen": "2015"},
 ]
 
 detector = ConflictDetector()
@@ -483,15 +490,19 @@ nation_conflicts     = detector.detect_value_conflicts(actor_profiles, "nation_s
 first_seen_conflicts = detector.detect_value_conflicts(actor_profiles, "first_seen")
 
 resolver = ConflictResolver()
+resolver.source_tracker.set_source_credibility("mandiant", 0.95)
+resolver.source_tracker.set_source_credibility("crowdstrike", 0.92)
+resolver.source_tracker.set_source_credibility("oss_blog", 0.30)
+
 resolver.set_resolution_rule("apt29", "nation_state", ResolutionStrategy.CREDIBILITY_WEIGHTED)
 resolver.set_resolution_rule("apt29", "first_seen",   ResolutionStrategy.CREDIBILITY_WEIGHTED)
 
 results = resolver.resolve_conflicts(nation_conflicts + first_seen_conflicts)
 for r in results:
     print(f"{r.conflict_id}: {r.resolved_value!r}  [{r.confidence:.0%} confidence]")
-    # apt29_nation_state_conflict: 'Russia'  [83% confidence]
-    # apt29_first_seen_conflict:   '2008'    [73% confidence]
-    # The blog's China attribution (weight 0.30) loses to Mandiant+CrowdStrike (0.95+0.92).
+    # apt29_nation_state_conflict: 'Russia'  [86% confidence]
+    # apt29_first_seen_conflict:   '2008'    [44% confidence]
+    # The blog's China attribution (weight 0.15) loses to Mandiant+CrowdStrike (0.475+0.46).
 
 history = resolver.get_resolution_history()
 print(f"Audit log entries: {len(history)}")
@@ -510,14 +521,11 @@ from semantica.conflicts import ConflictDetector, ConflictResolver, ResolutionSt
 
 cve_records = [
     {"id": "cve-2024-3400", "source": "nvd",
-     "cvss_score": 10.0, "vector": "AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H",
-     "credibility_score": 0.98},
+     "cvss_score": 10.0, "vector": "AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H"},
     {"id": "cve-2024-3400", "source": "mitre",
-     "cvss_score": 9.8,  "vector": "AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
-     "credibility_score": 0.96},
+     "cvss_score": 9.8,  "vector": "AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"},
     {"id": "cve-2024-3400", "source": "paloalto",
-     "cvss_score": 9.5,  "vector": "AV:N/AC:H/PR:N/UI:N/S:C/C:H/I:H/A:H",
-     "credibility_score": 0.90},
+     "cvss_score": 9.5,  "vector": "AV:N/AC:H/PR:N/UI:N/S:C/C:H/I:H/A:H"},
 ]
 
 detector = ConflictDetector()
@@ -525,6 +533,10 @@ score_conflicts  = detector.detect_value_conflicts(cve_records, "cvss_score")
 vector_conflicts = detector.detect_value_conflicts(cve_records, "vector")
 
 resolver = ConflictResolver()
+resolver.source_tracker.set_source_credibility("nvd", 0.98)
+resolver.source_tracker.set_source_credibility("mitre", 0.96)
+resolver.source_tracker.set_source_credibility("paloalto", 0.90)
+
 resolver.set_resolution_rule(
     "cve-2024-3400", "cvss_score", ResolutionStrategy.CREDIBILITY_WEIGHTED
 )
@@ -537,8 +549,8 @@ for r in results:
     if r.resolved:
         print(f"Canonical {r.conflict_id.split('_')[2]}: {r.resolved_value}  "
               f"({r.confidence:.0%} confidence)")
-    # Canonical cvss_score: 10.0   (72% confidence)  — NVD wins
-    # Canonical vector: AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H  (54% confidence)
+    # Canonical cvss_score: 10.0   (35% confidence)  — NVD wins
+    # Canonical vector: AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H  (35% confidence)
 ```
 
 </Tab>
@@ -554,14 +566,11 @@ from semantica.conflicts import ConflictDetector, ConflictResolver, ResolutionSt
 
 drug_records = [
     {"id": "dapagliflozin", "source": "declare_timi58",
-     "hba1c_reduction_pct": 0.54, "primary_endpoint": "MACE",
-     "credibility_score": 0.92},
+     "hba1c_reduction_pct": 0.54, "primary_endpoint": "MACE"},
     {"id": "dapagliflozin", "source": "dapa_hf",
-     "hba1c_reduction_pct": 0.48, "primary_endpoint": "HF_hospitalization",
-     "credibility_score": 0.95},
+     "hba1c_reduction_pct": 0.48, "primary_endpoint": "HF_hospitalization"},
     {"id": "dapagliflozin", "source": "meta_analysis",
-     "hba1c_reduction_pct": 0.52, "primary_endpoint": "HbA1c_reduction",
-     "credibility_score": 0.88},
+     "hba1c_reduction_pct": 0.52, "primary_endpoint": "HbA1c_reduction"},
 ]
 
 detector = ConflictDetector()
@@ -569,6 +578,10 @@ efficacy_conflicts = detector.detect_value_conflicts(drug_records, "hba1c_reduct
 endpoint_conflicts = detector.detect_value_conflicts(drug_records, "primary_endpoint")
 
 resolver = ConflictResolver()
+resolver.source_tracker.set_source_credibility("declare_timi58", 0.92)
+resolver.source_tracker.set_source_credibility("dapa_hf", 0.95)
+resolver.source_tracker.set_source_credibility("meta_analysis", 0.88)
+
 resolver.set_resolution_rule(
     "dapagliflozin", "hba1c_reduction_pct", ResolutionStrategy.CREDIBILITY_WEIGHTED
 )
@@ -584,7 +597,7 @@ review = [r for r in results if not r.resolved]
 print(f"Auto-resolved  : {len(auto)}")
 for r in auto:
     print(f"  {r.conflict_id}: {r.resolved_value}  [{r.confidence:.0%}]")
-    # dapagliflozin_hba1c_reduction_pct_conflict: 0.48  [38%]
+    # dapagliflozin_hba1c_reduction_pct_conflict: 0.48  [35%]
 
 print(f"Expert queue   : {len(review)}")
 for r in review:
@@ -605,14 +618,11 @@ from semantica.conflicts import ConflictDetector, ConflictResolver, ResolutionSt
 
 client_records = [
     {"id": "corp-acme-uk", "source": "crm",
-     "legal_name": "ACME UK Ltd",                "sic_code": "7372",
-     "credibility_score": 0.75},
+     "legal_name": "ACME UK Ltd",                "sic_code": "7372"},
     {"id": "corp-acme-uk", "source": "lei_registry",
-     "legal_name": "ACME United Kingdom Limited", "sic_code": "7371",
-     "credibility_score": 0.99},                  # LEI registry is authoritative
+     "legal_name": "ACME United Kingdom Limited", "sic_code": "7371"},
     {"id": "corp-acme-uk", "source": "credit_bureau",
-     "legal_name": "ACME UK Ltd",                "sic_code": "7372",
-     "credibility_score": 0.85},
+     "legal_name": "ACME UK Ltd",                "sic_code": "7372"},
 ]
 
 detector = ConflictDetector()
@@ -620,6 +630,10 @@ name_conflicts = detector.detect_value_conflicts(client_records, "legal_name")
 sic_conflicts  = detector.detect_value_conflicts(client_records, "sic_code")
 
 resolver = ConflictResolver()
+resolver.source_tracker.set_source_credibility("lei_registry", 0.99)
+resolver.source_tracker.set_source_credibility("credit_bureau", 0.50)
+resolver.source_tracker.set_source_credibility("crm", 0.40)
+
 resolver.set_resolution_rule(
     "corp-acme-uk", "legal_name", ResolutionStrategy.CREDIBILITY_WEIGHTED
 )
@@ -629,10 +643,10 @@ resolver.set_resolution_rule(
 
 results = resolver.resolve_conflicts(name_conflicts + sic_conflicts)
 for r in results:
-    print(f"Canonical {r.conflict_id.split('_')[2]}: {r.resolved_value!r}  "
+    print(f"Canonical {r.conflict_id.split('_')[1]}: {r.resolved_value!r}  "
           f"[{r.confidence:.0%}]")
-    # Canonical legal_name: 'ACME United Kingdom Limited'  [53%]  — LEI registry wins
-    # Canonical sic_code:   '7371'                         [53%]  — LEI registry wins
+    # Canonical legal_name: 'ACME United Kingdom Limited'  [52%]  — LEI registry wins
+    # Canonical sic_code:   '7371'                         [52%]  — LEI registry wins
 
 # Aggregate conflict statistics for the compliance report
 report = detector.get_conflict_report()

--- a/docs/guides/conflict-resolution.md
+++ b/docs/guides/conflict-resolution.md
@@ -297,7 +297,7 @@ for r in results:
   Strategy used  : credibility_weighted
   Confidence     : 36%
   Sources used   : ['nvd', 'commercial_feed', 'vendor_paloalto']
-  Notes          : Resolved by credibility-weighted voting (weight: 0.49)
+  Notes          : Resolved by credibility-weighted voting (weight: 0.98)
 
 [RESOLVED] cve-2024-3400_exploit_status_conflict
   Resolved value : in_wild
@@ -400,7 +400,7 @@ for conflict, result in zip(all_conflicts, results):
 ```
 
 ```text
-  cvss_score = 10.0 (from ['nvd'], confidence 72%)
+  cvss_score = 10.0 (from ['nvd', 'commercial_feed', 'vendor_paloalto'], confidence 36%)
   exploit_status = in_wild (from ['commercial_feed'], confidence 80%)
 ```
 
@@ -502,7 +502,7 @@ for r in results:
     print(f"{r.conflict_id}: {r.resolved_value!r}  [{r.confidence:.0%} confidence]")
     # apt29_nation_state_conflict: 'Russia'  [86% confidence]
     # apt29_first_seen_conflict:   '2008'    [44% confidence]
-    # The blog's China attribution (weight 0.15) loses to Mandiant+CrowdStrike (0.475+0.46).
+    # The blog's China attribution (weight 0.30) loses to Mandiant+CrowdStrike (0.95+0.92).
 
 history = resolver.get_resolution_history()
 print(f"Audit log entries: {len(history)}")
@@ -683,7 +683,7 @@ If duplicate nodes for the same real-world entity still exist, `ConflictDetector
 Calling `detect_value_conflicts()` for every property in a manual loop produces redundant passes over your data. Use `detect_entity_conflicts()` instead — it handles all properties in a single call and is the recommended starting point for bulk detection.
 
 **Misunderstanding credibility scores**
-Credibility scores are weights you assign based on your prior knowledge of source reliability — not ground truth. A source with `credibility_score: 0.99` can still be wrong. `CREDIBILITY_WEIGHTED` resolution amplifies your beliefs about source quality; if those beliefs are miscalibrated, the resolutions will be too. Validate scores against known ground truth before relying on them in production.
+Credibility scores are weights you assign based on your prior knowledge of source reliability — not ground truth. A source registered with `set_source_credibility("source", 0.99)` can still be wrong. `CREDIBILITY_WEIGHTED` resolution amplifies your beliefs about source quality; if those beliefs are miscalibrated, the resolutions will be too. Validate scores against known ground truth before relying on them in production.
 
 **Treating resolved values as guaranteed truth**
 A resolved value is the most defensible answer given your sources and strategy — not necessarily the correct one. Low confidence scores and `EXPERT_REVIEW` flags are signals to scrutinize results before writing them to a canonical record or downstream system.


### PR DESCRIPTION
## Summary

Improves the Conflict Resolution guide for first-time Semantica developers by adding conceptual onboarding, workflow guidance, and implementation-aligned best practices.

## Changes

- Add What Is Conflict Resolution section
- Add Why Use Conflict Resolution section
- Add When To Use / When Not To Use guidance
- Add Typical Workflow overview
- Add beginner-friendly customer record example
- Introduce detect_entity_conflicts as the recommended bulk workflow
- Clarify detect_entity_conflicts vs detect_value_conflicts
- Document set_resolution_rule entity-specific behavior
- Explain entity_id.property_name rule storage model
- Add persistence guidance for resolved values
- Add Common Pitfalls section
- Improve transitions and reduce jargon density

## Notes

- No API changes
- No implementation changes
- Existing examples preserved
- Existing domain tabs preserved
- Documentation aligned with current implementation