### PR TITLE
docs: fix misleading index_path persistence claim across guides

### DIFF
--- a/docs/guides/decision-intelligence.md
+++ b/docs/guides/decision-intelligence.md
@@ -559,7 +559,7 @@ context.save("agent_state/")
 
 # Start of next session
 context = AgentContext(
-    vector_store=VectorStore(backend="faiss", dimension=768, index_path="decisions.faiss"),
+    vector_store=VectorStore(backend="faiss", dimension=768),
     knowledge_graph=ContextGraph(),
     decision_tracking=True,
 )

--- a/docs/guides/graphrag.md
+++ b/docs/guides/graphrag.md
@@ -83,7 +83,7 @@ from semantica.context import AgentContext, ContextGraph
 from semantica.vector_store import VectorStore
 
 # FAISS runs locally with no external dependencies
-vs = VectorStore(backend="faiss", dimension=768, index_path="intel.faiss")
+vs = VectorStore(backend="faiss", dimension=768)
 graph = ContextGraph(advanced_analytics=True)
 
 context = AgentContext(

--- a/docs/guides/ingest.md
+++ b/docs/guides/ingest.md
@@ -468,8 +468,7 @@ def run_daily_ingest(since: datetime = None):
 
     graph   = ContextGraph(advanced_analytics=True)
     context = AgentContext(
-        vector_store    = VectorStore(backend="faiss", dimension=768,
-                                      index_path="cti_index.faiss"),
+        vector_store    = VectorStore(backend="faiss", dimension=768),
         knowledge_graph = graph,
         graph_expansion = True,
     )

--- a/docs/guides/semantic-extraction.md
+++ b/docs/guides/semantic-extraction.md
@@ -313,7 +313,7 @@ def ingest_intel_report(
 # Process all 200 reports
 intel_graph = ContextGraph(advanced_analytics=True)
 intel_agent = AgentContext(
-    vector_store=VectorStore(backend="faiss", dimension=768, index_path="intel.faiss"),
+    vector_store=VectorStore(backend="faiss", dimension=768),
     knowledge_graph=intel_graph,
     decision_tracking=True,
 )

--- a/docs/reference/context.md
+++ b/docs/reference/context.md
@@ -272,7 +272,7 @@ icon: "brain"
 </Tip>
 
 <Tip>
-  **Persist your vector store between runs.** Pass `index_path="context.faiss"` to `VectorStore` so the FAISS index survives process restarts.
+  **Persist your context between runs.** `VectorStore` does not auto-persist — passing `index_path=` to its constructor is a no-op. Call `context.save("agent_state/")` to write memory, the vector index, and the graph to disk, and `context.load("agent_state/")` on the next process to restore them. See the "Persist & Restore" tab under [Real-World Patterns](#real-world-patterns) below.
 </Tip>
 
 ### Memory Methods


### PR DESCRIPTION
## Summary

`VectorStore(backend="faiss", ..., index_path="...")` does **not** make the FAISS index persist across restarts. `index_path` is silently absorbed into `FAISSStore`'s `**config` kwargs (`semantica/vector_store/faiss_store.py`, `__init__`) and is never read anywhere in that file — it's a dead kwarg. Real persistence requires calling `VectorStore.save(path)` / `.load(path)` explicitly, or `AgentContext.save(path)` / `.load(path)`, which cascades to the vector store.

Several docs pages still implied `index_path=` alone gives you "restart-safe" persistence. This is a follow-up to #691, which fixed the same false claim in `docs/guides/agent-memory.md` but missed these other files.

- `docs/reference/context.md` — rewrote the "Persist your vector store between runs" tip (the worst offender, since it's in the authoritative API reference) to explain the actual `save()`/`load()` mechanism instead of the dead `index_path` kwarg.
- `docs/guides/graphrag.md` — dropped the dead `index_path=...` kwarg from a `VectorStore(backend="faiss", ...)` call.
- `docs/guides/decision-intelligence.md` — same.
- `docs/guides/ingest.md` — same.
- `docs/guides/semantic-extraction.md` — same.

No code changes — this is docs-only, correcting the docs to match current actual `VectorStore`/`FAISSStore` behavior. (Wiring `index_path` up in `FAISSStore` instead is a separate code-behavior decision, not made here.)

## Test plan

- [x] Grepped `docs/` for remaining `index_path` occurrences — only `docs/guides/agent-memory.md` (in-flight fix via still-open #691) and my own corrected explanatory sentence in `context.md` remain.
- [x] Reviewed each edited file's surrounding context for other repetitions of the "index_path = restart-safe" myth — none found beyond the constructor calls fixed.
- N/A automated tests (docs-only change).