### PR TITLE
Fix Reasoner.add_rule missing deduplication (#732)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`Reasoner.add_rule` had no deduplication, doubling rules and silently emptying `forward_chain()` on rerun** (#732) by @KaifAhmad1
+  - `add_rule()` unconditionally appended to `self.rules`, so re-running the same setup code on an existing `Reasoner` instance (e.g. re-executing a Jupyter cell) duplicated every rule; since `forward_chain()` only records a conclusion if it isn't already in `self.facts`, the second run's duplicated rules matched but produced no new results, with no error or warning
+  - `add_rule()` now compares an incoming rule's `rule_type`, `conditions`, and `conclusion` against existing rules and returns the existing `Rule` instead of appending a duplicate, keeping repeated `add_rule()` calls with the same definition idempotent
+  - Added `test_add_rule_deduplicates_identical_rule`, `test_add_rule_deduplication_is_idempotent_across_forward_chain`, and `test_add_rule_does_not_dedupe_distinct_rules` regression tests
+
 - **`InferenceResult.premises` always empty from `forward_chain`/`backward_chain`** (#739) by @Sameer6305
   - `_match_rule()` discarded matched facts and returned only instantiated conclusions, so `ExplanationGenerator` always produced empty premises lists regardless of which facts actually satisfied a rule, closing #733
   - `_match_rule()` now returns `(conclusion, matched_facts)` tuples; `forward_chain()` threads those facts into `InferenceResult(premises=...)`, merging premises when the same conclusion is derived more than once within a pass

--- a/semantica/reasoning/reasoner.py
+++ b/semantica/reasoning/reasoner.py
@@ -104,6 +104,11 @@ class Reasoner:
                     f"Skipping duplicate rule (same conditions/conclusion as '{existing.rule_id}'): "
                     f"IF {' AND '.join(map(str, rule.conditions))} THEN {rule.conclusion}"
                 )
+                # Rule is a mutable dataclass, so `existing.priority` may have
+                # changed since it was added -- re-sort so the dedup path
+                # keeps the same self-healing ordering the append path has,
+                # rather than leaving self.rules stale relative to priority.
+                self.rules.sort(key=lambda r: r.priority, reverse=True)
                 return existing
 
         self.rules.append(rule)

--- a/semantica/reasoning/reasoner.py
+++ b/semantica/reasoning/reasoner.py
@@ -81,12 +81,31 @@ class Reasoner:
         self.rule_counter = 0
             
     def add_rule(self, rule_def: Union[str, Rule]) -> Rule:
-        """Add a rule to the reasoner."""
+        """Add a rule to the reasoner.
+
+        Rules with the same conditions and conclusion as an already-added
+        rule are not re-appended -- this keeps re-running the same setup
+        code (e.g. a Jupyter cell that calls add_rule() + add_fact() on an
+        existing Reasoner) idempotent instead of silently duplicating rules
+        on every rerun (#732).
+        """
         if isinstance(rule_def, Rule):
             rule = rule_def
         else:
             rule = self._parse_rule_definition(rule_def)
-            
+
+        for existing in self.rules:
+            if (
+                existing.rule_type == rule.rule_type
+                and existing.conditions == rule.conditions
+                and existing.conclusion == rule.conclusion
+            ):
+                self.logger.debug(
+                    f"Skipping duplicate rule (same conditions/conclusion as '{existing.rule_id}'): "
+                    f"IF {' AND '.join(rule.conditions)} THEN {rule.conclusion}"
+                )
+                return existing
+
         self.rules.append(rule)
         # Sort rules by priority
         self.rules.sort(key=lambda r: r.priority, reverse=True)

--- a/semantica/reasoning/reasoner.py
+++ b/semantica/reasoning/reasoner.py
@@ -100,9 +100,9 @@ class Reasoner:
                 and existing.conditions == rule.conditions
                 and existing.conclusion == rule.conclusion
             ):
-                self.logger.debug(
+                self.logger.warning(
                     f"Skipping duplicate rule (same conditions/conclusion as '{existing.rule_id}'): "
-                    f"IF {' AND '.join(rule.conditions)} THEN {rule.conclusion}"
+                    f"IF {' AND '.join(map(str, rule.conditions))} THEN {rule.conclusion}"
                 )
                 return existing
 

--- a/semantica/reasoning/reasoner.py
+++ b/semantica/reasoning/reasoner.py
@@ -88,6 +88,14 @@ class Reasoner:
         code (e.g. a Jupyter cell that calls add_rule() + add_fact() on an
         existing Reasoner) idempotent instead of silently duplicating rules
         on every rerun (#732).
+
+        On dedup, the ORIGINAL rule's confidence, priority, and metadata are
+        retained; the incoming rule's differing fields are discarded, not
+        merged or upserted -- except for priority, where self.rules is
+        re-sorted to reflect any change made directly on the retained Rule
+        object after it was first added (see the re-sort below). If the
+        incoming rule's confidence differs from the retained rule's, a
+        warning is logged so the discrepancy isn't silently swallowed.
         """
         if isinstance(rule_def, Rule):
             rule = rule_def
@@ -104,6 +112,12 @@ class Reasoner:
                     f"Skipping duplicate rule (same conditions/conclusion as '{existing.rule_id}'): "
                     f"IF {' AND '.join(map(str, rule.conditions))} THEN {rule.conclusion}"
                 )
+                if existing.confidence != rule.confidence:
+                    self.logger.warning(
+                        f"Duplicate rule '{existing.rule_id}' was re-added with a different "
+                        f"confidence ({rule.confidence}); the existing confidence "
+                        f"({existing.confidence}) is retained and the new value is discarded."
+                    )
                 # Rule is a mutable dataclass, so `existing.priority` may have
                 # changed since it was added -- re-sort so the dedup path
                 # keeps the same self-healing ordering the append path has,

--- a/tests/reasoning/test_reasoner.py
+++ b/tests/reasoning/test_reasoner.py
@@ -110,6 +110,39 @@ class TestReasoner(unittest.TestCase):
         # unbounded rule duplication.
         self.assertEqual(result2, [])
 
+    def test_add_rule_duplicate_logs_warning(self):
+        """Bug #732 follow-up — a skipped duplicate rule must be surfaced via a
+        warning log, not silently swallowed at debug level."""
+        rule_str = "IF Person(?x) AND Parent(?x, ?y) THEN Child(?y, ?x)"
+        self.reasoner.add_rule(rule_str)
+
+        with self.assertLogs(self.reasoner.logger.name, level="WARNING") as cm:
+            self.reasoner.add_rule(rule_str)
+
+        self.assertTrue(any("duplicate rule" in msg for msg in cm.output))
+
+    def test_add_rule_duplicate_with_non_string_conditions_does_not_raise(self):
+        """Bug #732 follow-up — the duplicate-rule warning message building must
+        not raise TypeError when Rule.conditions contains non-string entries
+        (Rule.conditions is typed List[Any])."""
+        rule = Rule(
+            rule_id="r1",
+            name="Test Rule",
+            conditions=[("Person", "?x")],
+            conclusion="B(?x)",
+        )
+        duplicate = Rule(
+            rule_id="r2",
+            name="Test Rule Duplicate",
+            conditions=[("Person", "?x")],
+            conclusion="B(?x)",
+        )
+        self.reasoner.add_rule(rule)
+        result = self.reasoner.add_rule(duplicate)
+
+        self.assertIs(result, rule)
+        self.assertEqual(len(self.reasoner.rules), 1)
+
     def test_add_rule_does_not_dedupe_distinct_rules(self):
         """Rules with different conditions/conclusions must still both be added."""
         self.reasoner.add_rule("IF A(?x) THEN B(?x)")

--- a/tests/reasoning/test_reasoner.py
+++ b/tests/reasoning/test_reasoner.py
@@ -80,6 +80,42 @@ class TestReasoner(unittest.TestCase):
         self.assertIn("Person(John)", result.premises)
         self.assertIn("Parent(John, Jane)", result.premises)
 
+    def test_add_rule_deduplicates_identical_rule(self):
+        """Bug #732 — re-adding an identical rule string must not duplicate it,
+        so re-running the same setup code (e.g. a Jupyter cell) is idempotent."""
+        rule_str = "IF Person(?x) AND Parent(?x, ?y) THEN Child(?y, ?x)"
+        first = self.reasoner.add_rule(rule_str)
+        second = self.reasoner.add_rule(rule_str)
+
+        self.assertEqual(len(self.reasoner.rules), 1)
+        self.assertIs(first, second)
+
+    def test_add_rule_deduplication_is_idempotent_across_forward_chain(self):
+        """Bug #732 — rerunning add_rule()+add_fact()+forward_chain() on the same
+        Reasoner instance must not grow the rule count on each call."""
+        def run_cell():
+            self.reasoner.add_rule("IF Person(?x) AND Parent(?x, ?y) THEN Child(?y, ?x)")
+            self.reasoner.add_fact("Person(John)")
+            self.reasoner.add_fact("Parent(John, Jane)")
+            return self.reasoner.forward_chain()
+
+        result1 = run_cell()
+        self.assertEqual(len(self.reasoner.rules), 1)
+        self.assertEqual([r.conclusion for r in result1], ["Child(Jane, John)"])
+
+        result2 = run_cell()
+        self.assertEqual(len(self.reasoner.rules), 1)
+        # Nothing new to derive since the fact was already known -- this is
+        # now a consistent, expected empty result rather than a symptom of
+        # unbounded rule duplication.
+        self.assertEqual(result2, [])
+
+    def test_add_rule_does_not_dedupe_distinct_rules(self):
+        """Rules with different conditions/conclusions must still both be added."""
+        self.reasoner.add_rule("IF A(?x) THEN B(?x)")
+        self.reasoner.add_rule("IF A(?x) THEN C(?x)")
+        self.assertEqual(len(self.reasoner.rules), 2)
+
     def test_infer_facts(self):
         facts = ["Person(John)", "Parent(John, Jane)"]
         rules = ["IF Person(?x) AND Parent(?x, ?y) THEN Child(?y, ?x)"]

--- a/tests/reasoning/test_reasoner.py
+++ b/tests/reasoning/test_reasoner.py
@@ -149,6 +149,26 @@ class TestReasoner(unittest.TestCase):
         self.reasoner.add_rule("IF A(?x) THEN C(?x)")
         self.assertEqual(len(self.reasoner.rules), 2)
 
+    def test_add_rule_duplicate_resorts_on_mutated_priority(self):
+        """Bug #732 follow-up — Rule is a mutable dataclass, so an already-added
+        rule's priority may change after it was registered; re-adding it (a
+        duplicate by conditions/conclusion) must still re-sort self.rules
+        rather than leaving it stale relative to the mutated priority."""
+        low = Rule(rule_id="r1", name="Low", conditions=["A(?x)"], conclusion="B(?x)", priority=0)
+        high = Rule(rule_id="r2", name="High", conditions=["C(?x)"], conclusion="D(?x)", priority=5)
+        self.reasoner.add_rule(low)
+        self.reasoner.add_rule(high)
+        self.assertEqual([r.rule_id for r in self.reasoner.rules], ["r2", "r1"])
+
+        # Mutate the already-registered low-priority rule to outrank "high",
+        # then re-add it (matches by conditions/conclusion -> dedup path).
+        low.priority = 10
+        result = self.reasoner.add_rule(low)
+
+        self.assertIs(result, low)
+        self.assertEqual(len(self.reasoner.rules), 2)
+        self.assertEqual([r.rule_id for r in self.reasoner.rules], ["r1", "r2"])
+
     def test_infer_facts(self):
         facts = ["Person(John)", "Parent(John, Jane)"]
         rules = ["IF Person(?x) AND Parent(?x, ?y) THEN Child(?y, ?x)"]

--- a/tests/reasoning/test_reasoner.py
+++ b/tests/reasoning/test_reasoner.py
@@ -121,6 +121,27 @@ class TestReasoner(unittest.TestCase):
 
         self.assertTrue(any("duplicate rule" in msg for msg in cm.output))
 
+    def test_add_rule_duplicate_with_different_confidence_logs_warning(self):
+        """Re-adding an identical rule (same conditions/conclusion) with a
+        different confidence must warn that the new confidence is discarded
+        and the original is retained, not silently drop it."""
+        rule_v1 = Rule(
+            rule_id="r1", name="Rule", conditions=["A(?x)"], conclusion="B(?x)",
+            confidence=0.6,
+        )
+        rule_v2 = Rule(
+            rule_id="r2", name="Rule v2", conditions=["A(?x)"], conclusion="B(?x)",
+            confidence=0.95,
+        )
+        self.reasoner.add_rule(rule_v1)
+
+        with self.assertLogs(self.reasoner.logger.name, level="WARNING") as cm:
+            result = self.reasoner.add_rule(rule_v2)
+
+        self.assertIs(result, rule_v1)
+        self.assertEqual(result.confidence, 0.6)
+        self.assertTrue(any("different confidence" in msg for msg in cm.output))
+
     def test_add_rule_duplicate_with_non_string_conditions_does_not_raise(self):
         """Bug #732 follow-up — the duplicate-rule warning message building must
         not raise TypeError when Rule.conditions contains non-string entries


### PR DESCRIPTION
## Summary
- `Reasoner.add_rule()` unconditionally appended to `self.rules`, so re-running the same setup code on an existing `Reasoner` instance (e.g. re-executing a Jupyter cell) duplicated every rule
- Because `forward_chain()` only records a conclusion if it isn't already in `self.facts`, the second run's duplicated rules matched but produced no new results — silently, with no error or warning
- `add_rule()` now compares an incoming rule's `rule_type`, `conditions`, and `conclusion` against existing rules and returns the existing `Rule` instead of appending a duplicate, so repeated `add_rule()` calls with the same definition are idempotent

Closes #732

## Test plan
- [x] Added `test_add_rule_deduplicates_identical_rule` — re-adding an identical rule string does not duplicate it
- [x] Added `test_add_rule_deduplication_is_idempotent_across_forward_chain` — mirrors the issue's exact repro (rerunning `add_rule()`+`add_fact()`+`forward_chain()` on the same instance keeps the rule count stable)
- [x] Added `test_add_rule_does_not_dedupe_distinct_rules` — rules with different conditions/conclusions are still both added
- [x] `python -m pytest tests/reasoning/ -q` — 41 passed