### PR TITLE
Use pytest.approx for float comparison in test_llm_cost_tracking

### DIFF
--- a/tests/provenance/test_llms_real_tracking.py
+++ b/tests/provenance/test_llms_real_tracking.py
@@ -109,7 +109,7 @@ class TestRealLLMProvenanceTracking:
             assert lineage is not None
             total_cost += lineage["metadata"]["total_cost"]
         
-        assert total_cost == sum(costs)
+        assert total_cost == pytest.approx(sum(costs))
     
     def test_llm_latency_tracking(self):
         """Test that LLM latency is tracked."""


### PR DESCRIPTION
Fixes #745. Replaces exact float equality with pytest.approx to avoid floating-point summation precision failures.