### PR TITLE
docs(readme): highlight dual RDF + LPG graph storage support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@
 
 **Open Source &nbsp;·&nbsp; Auditable &nbsp;·&nbsp; Governed &nbsp;·&nbsp; Self-Hostable**
 
+**Polyglot Graph Storage — RDF: Blazegraph &nbsp;·&nbsp; Apache Jena &nbsp;·&nbsp; Eclipse RDF4J &nbsp;&nbsp;|&nbsp;&nbsp; LPG: Neo4j &nbsp;·&nbsp; FalkorDB &nbsp;·&nbsp; Apache AGE &nbsp;·&nbsp; AWS Neptune**
+
 [![GitHub Stars](https://img.shields.io/github/stars/semantica-agi/semantica?style=flat-square&color=FFD700&logo=github&logoColor=white&label=Stars)](https://github.com/semantica-agi/semantica) [![PyPI](https://img.shields.io/pypi/v/semantica.svg?style=flat-square&color=0066CC&logo=pypi&logoColor=white)](https://pypi.org/project/semantica/) [![Total Downloads](https://static.pepy.tech/badge/semantica?style=flat-square)](https://pepy.tech/project/semantica) [![Python 3.8+](https://img.shields.io/badge/python-3.8+-3776AB?style=flat-square&logo=python&logoColor=white)](https://www.python.org/) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg?style=flat-square)](https://opensource.org/licenses/MIT) [![CI](https://img.shields.io/github/actions/workflow/status/semantica-agi/semantica/ci.yml?style=flat-square&label=CI)](https://github.com/semantica-agi/semantica/actions) [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/semantica-agi/semantica)
 
 [![Website](https://img.shields.io/badge/Website-getsemantica.ai-000000?style=flat-square&logo=googlechrome&logoColor=white)](https://getsemantica.ai/) [![Docs](https://img.shields.io/badge/Docs-docs.getsemantica.ai-0099FF?style=flat-square&logo=readthedocs&logoColor=white)](https://docs.getsemantica.ai/) [![Discord](https://img.shields.io/badge/Discord-Join%20Community-5865F2?style=flat-square&logo=discord&logoColor=white)](https://discord.gg/sV34vps5hH) [![Twitter/X](https://img.shields.io/badge/Follow-%40BuildSemantica-000000?style=flat-square&logo=x&logoColor=white)](https://x.com/BuildSemantica) [![YouTube](https://img.shields.io/badge/YouTube-Watch%20Demos-FF0000?style=flat-square&logo=youtube&logoColor=white)](https://www.youtube.com/watch?v=QfnNZg4-dZA) [![Changelog](https://img.shields.io/badge/Changelog-View-6E40C9?style=flat-square&logo=keepachangelog&logoColor=white)](CHANGELOG.md)
@@ -32,7 +34,8 @@
 - **Full Auditability:** W3C PROV-O provenance on every fact, with audit trails exportable to JSON, CSV, or RDF
 - **Deterministic Reasoning:** Forward chaining, Rete network, Datalog, and SPARQL with fully explainable paths, not black boxes
 - **Knowledge Pipeline:** Multi-source ingestion, entity-aware chunking, and semantic deduplication with provenance-preserving merges
-- **Flexible Storage & Visualization:** Swap vector stores and graph databases without touching your code; explore it all in an interactive browser workbench
+- **Polyglot Graph Storage:** Native support for both RDF (Blazegraph, Apache Jena, Eclipse RDF4J via SPARQL) and Labeled Property Graphs (Neo4j, FalkorDB, Apache AGE, AWS Neptune via Cypher), plus vector stores, all swappable without touching your code
+- **Flexible Storage & Visualization:** Swap storage backends freely; explore it all in an interactive browser workbench
 - **Drop-in Integrations:** Native Agno support, a full-featured MCP server, a comprehensive CLI, a REST API, and plugins across major editors
 
 ---
@@ -1303,7 +1306,8 @@ For contributor / dev-server setup, see the full local setup guide:
 | **Provenance** | W3C PROV-O · every fact traced to source · audit log export JSON/CSV/RDF |
 | **Ontology Hub** | SHACL Studio · visual editor · cross-ontology alignments · 5-dimension health dashboard |
 | **Vector Store** | FAISS · Pinecone · Weaviate · Qdrant · Milvus · PgVector · hybrid + filtered search |
-| **Graph Databases** | Neo4j · FalkorDB · Apache AGE · AWS Neptune |
+| **Graph Databases (LPG)** | Neo4j · FalkorDB · Apache AGE · AWS Neptune |
+| **Triplet Stores (RDF)** | Blazegraph · Apache Jena · Eclipse RDF4J · unified `TripletStore` interface · SPARQL query & bulk load |
 | **LLM Providers** | **All already supported today:** OpenAI (GPT-4o, o1, o3) · Anthropic (Claude 4) · Google Gemini · Mistral · Meta Llama · Groq · Cohere · Azure OpenAI · AWS Bedrock · Ollama · DeepSeek · Perplexity · Together AI · Fireworks AI · Replicate · HuggingFace · via `semantica.llms` and LiteLLM |
 
 ---

--- a/README.md
+++ b/README.md
@@ -1307,7 +1307,7 @@ For contributor / dev-server setup, see the full local setup guide:
 | **Ontology Hub** | SHACL Studio · visual editor · cross-ontology alignments · 5-dimension health dashboard |
 | **Vector Store** | FAISS · Pinecone · Weaviate · Qdrant · Milvus · PgVector · hybrid + filtered search |
 | **Graph Databases (LPG)** | Neo4j · FalkorDB · Apache AGE · AWS Neptune |
-| **Triplet Stores (RDF)** | Blazegraph · Apache Jena · Eclipse RDF4J · unified `TripletStore` interface · SPARQL query & bulk load |
+| **Triple Stores (RDF)** | Blazegraph · Apache Jena · Eclipse RDF4J · unified `TripletStore` interface · SPARQL query & bulk load |
 | **LLM Providers** | **All already supported today:** OpenAI (GPT-4o, o1, o3) · Anthropic (Claude 4) · Google Gemini · Mistral · Meta Llama · Groq · Cohere · Azure OpenAI · AWS Bedrock · Ollama · DeepSeek · Perplexity · Together AI · Fireworks AI · Replicate · HuggingFace · via `semantica.llms` and LiteLLM |
 
 ---
@@ -1354,7 +1354,12 @@ pip install semantica[all]      # everything
 ```bash
 pip install semantica[agno]                 # Agno multi-agent integration
 pip install semantica[llm-litellm]          # OpenAI, Anthropic, Gemini, Mistral, Llama, Groq, Cohere, Bedrock, Ollama, DeepSeek, and more
-pip install semantica[graph-neo4j]          # Neo4j graph store
+pip install semantica[graph-neo4j]          # Neo4j graph store (LPG)
+pip install semantica[graph-falkordb]       # FalkorDB graph store (LPG)
+pip install semantica[graph-apache-age]     # Apache AGE graph store (LPG)
+pip install semantica[graph-amazon-neptune] # AWS Neptune graph store (LPG)
+# RDF triple stores (Blazegraph, Apache Jena, Eclipse RDF4J) need no extra —
+# semantica.triplet_store talks SPARQL over HTTP using the core `requests` dependency
 pip install semantica[vectorstore-qdrant]   # Qdrant vector store
 pip install semantica[vectorstore-pinecone] # Pinecone vector store
 pip install semantica[db-snowflake]         # Snowflake
@@ -1364,7 +1369,7 @@ pip install semantica[viz]                  # HTML interactive visualization
 pip install semantica[watch]                # Directory file watcher
 ```
 
-For production deployments, use Docker or Kubernetes rather than a local `pip install`. Set `SEMANTICA_SECRET_KEY`, configure a persistent graph store (Neo4j / FalkorDB), and point the vector store at a hosted backend (Qdrant / Pinecone). See [ARCHITECTURE.md](ARCHITECTURE.md) for the full deployment topology.
+For production deployments, use Docker or Kubernetes rather than a local `pip install`. Set `SEMANTICA_SECRET_KEY`, configure a persistent LPG graph store (Neo4j / FalkorDB / Apache AGE / AWS Neptune) and/or RDF triple store (Blazegraph / Apache Jena / Eclipse RDF4J), and point the vector store at a hosted backend (Qdrant / Pinecone). See [ARCHITECTURE.md](ARCHITECTURE.md) for the full deployment topology.
 
 ```bash
 # From source

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -139,9 +139,10 @@ models-huggingface = [
 graph-neo4j = ["neo4j>=5.0.0"]
 graph-falkordb = ["falkordb>=1.0.0", "redis>=4.3.0"]
 graph-amazon-neptune = ["boto3>=1.24.0", "neo4j>=5.0.0"]
+graph-apache-age = ["psycopg2-binary>=2.9.0"]
 
 graph-all = [
-  "semantica[graph-neo4j,graph-falkordb,graph-amazon-neptune]"
+  "semantica[graph-neo4j,graph-falkordb,graph-amazon-neptune,graph-apache-age]"
 ]
 
 # ---- Vector Store Backends ----


### PR DESCRIPTION
## Summary
- Semantica already ships both an RDF triplet-store stack (Blazegraph, Apache Jena, Eclipse RDF4J via a unified `TripletStore`/SPARQL interface) and an LPG graph-store stack (Neo4j, FalkorDB, Apache AGE, AWS Neptune via Cypher), but the README only surfaced the LPG side.
- Added a hero highlight line naming both formats and all backends, updated the "What Semantica gives you" bullets, and split the Features-at-a-Glance table row into `Graph Databases (LPG)` and `Triplet Stores (RDF)`.

## Test plan
- [x] Verified backend lists against `semantica/triplet_store/__init__.py` and `semantica/graph_store/__init__.py`
- [ ] Docs-only change; no code paths affected