### PR TITLE
docs: refresh README hero with premium tagline and regulated-domains callout

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,15 +2,19 @@
 
 <img src="Semantica Logo.png" alt="Semantica" width="420"/>
 
-### Context and Accountability Infrastructure for AI Agents
+### Graph-Native Infrastructure for Context and Accountable AI Systems
 
-#### <mark>**The Open Source Palantir for AI Agents**</mark>
+#### *The Open Source Palantir for AI Agents*
 
 > Ingest your enterprise data, extract what matters, build a Context Graph and knowledge graph (KG), and run graph analytics and causal reasoning over all of it, with full decision provenance baked in. Explainable, traceable, and trustworthy by design.
 
-**Decision Intelligence &nbsp;·&nbsp; Context Management &nbsp;·&nbsp; Deterministic Reasoning &nbsp;·&nbsp; Traceability**
+**Decision Intelligence &nbsp;·&nbsp; Context Management &nbsp;·&nbsp; Deterministic Reasoning &nbsp;·&nbsp; Ontology Management &nbsp;·&nbsp; SKOS Vocabularies &nbsp;·&nbsp; Traceability**
 
 **Open Source &nbsp;·&nbsp; Auditable &nbsp;·&nbsp; Governed &nbsp;·&nbsp; Self-Hostable &nbsp;·&nbsp; Zero Vendor Lock-In**
+
+#### Built for High-Stakes, Regulated Domains
+
+*Finance &nbsp;·&nbsp; Healthcare &nbsp;·&nbsp; Legal &nbsp;·&nbsp; Government &nbsp;·&nbsp; Defense &nbsp;&nbsp;([details ↓](#built-for-high-stakes-domains))*
 
 [![GitHub Stars](https://img.shields.io/github/stars/semantica-agi/semantica?style=flat-square&color=FFD700&logo=github&logoColor=white&label=Stars)](https://github.com/semantica-agi/semantica) [![GitHub Forks](https://img.shields.io/github/forks/semantica-agi/semantica?style=flat-square&color=6E40C9&logo=github&logoColor=white&label=Forks)](https://github.com/semantica-agi/semantica/network/members) [![Contributors](https://img.shields.io/github/contributors/semantica-agi/semantica?style=flat-square&color=2EA043&logo=github&logoColor=white)](https://github.com/semantica-agi/semantica/graphs/contributors) [![PyPI](https://img.shields.io/pypi/v/semantica.svg?style=flat-square&color=0066CC&logo=pypi&logoColor=white)](https://pypi.org/project/semantica/) [![Total Downloads](https://static.pepy.tech/badge/semantica?style=flat-square)](https://pepy.tech/project/semantica) [![Python 3.8+](https://img.shields.io/badge/python-3.8+-3776AB?style=flat-square&logo=python&logoColor=white)](https://www.python.org/) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg?style=flat-square)](https://opensource.org/licenses/MIT) [![CI](https://img.shields.io/github/actions/workflow/status/semantica-agi/semantica/ci.yml?style=flat-square&label=CI)](https://github.com/semantica-agi/semantica/actions) [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/semantica-agi/semantica)
 


### PR DESCRIPTION
## Summary
- New tagline: "Graph-Native Infrastructure for Context and Accountable AI Systems"
- Feature pills now include Ontology Management and SKOS Vocabularies
- Swapped the yellow `<mark>` highlight subhead for a cleaner italic style
- Added a "Built for High-Stakes, Regulated Domains" teaser in the hero that links down to the existing full section

## Test plan
- [x] Rendered README locally to confirm formatting/links resolve
- [ ] Visual check on GitHub after merge