### PR TITLE
ci: retry CodeQL init on transient bundle-download ECONNRESET

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,7 +22,36 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v7
 
-      - name: Initialize CodeQL
+      # The CodeQL bundle download (github/codeql-action/init's "Setup CodeQL
+      # tools" step) streams a ~1GB tarball from GitHub's release CDN and
+      # does not retry on a transient connection reset (ECONNRESET) itself
+      # (github/codeql-action, unresolved as of v4 / CLI 2.26.1: the HTTP
+      # error is retryable but isn't retried internally). Since a `uses:`
+      # step can't be wrapped by a shell-level retry action, attempt init
+      # up to 3 times; each retry is a fresh download attempt with no
+      # meaningful state carried over from a failed attempt.
+      - name: Initialize CodeQL (attempt 1)
+        id: codeql-init-1
+        uses: github/codeql-action/init@v4
+        continue-on-error: true
+        with:
+          languages: python
+          queries: security-and-quality
+          config-file: .github/codeql/codeql-config.yml
+
+      - name: Initialize CodeQL (attempt 2)
+        id: codeql-init-2
+        if: steps.codeql-init-1.outcome == 'failure'
+        uses: github/codeql-action/init@v4
+        continue-on-error: true
+        with:
+          languages: python
+          queries: security-and-quality
+          config-file: .github/codeql/codeql-config.yml
+
+      - name: Initialize CodeQL (attempt 3)
+        id: codeql-init-3
+        if: steps.codeql-init-2.outcome == 'failure'
         uses: github/codeql-action/init@v4
         with:
           languages: python


### PR DESCRIPTION
## Summary
- The CodeQL "Analyze Python" job (run #928) failed on the #757 merge commit with `ECONNRESET` while streaming the CodeQL bundle download inside `codeql-action/init`'s "Setup CodeQL tools" step — before any analysis of repo code runs. This is not caused by the merged JenaStore changes.
- Confirmed via `codeql-action`'s changelog/issue tracker that this is a known, currently-unaddressed gap: the download error is retryable but the action does not retry it internally.
- Since a `uses:` step can't be wrapped by a shell-level retry action, `Initialize CodeQL` now runs up to 3 times, each attempt only firing if the previous one failed — so the common case (success on attempt 1) costs nothing extra, and a repeat of this exact flake self-heals within the same job run instead of requiring a manual re-run.

## Test plan
- [x] Validated the workflow YAML parses correctly (`yaml.safe_load`)
- [x] Confirmed the cascading `if: steps.<id>.outcome == 'failure'` conditions skip correctly on success and only fire the next attempt on failure
- [ ] Merge and confirm the `CodeQL / Analyze Python` check passes on the next push to `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)