### PR TITLE
Fix #788: pin httpx<0.28.0 globally to fix Explorer test suite TestClient breakage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`tests/explorer/test_explorer_api.py` failed with `TypeError: Client.__init__() got an unexpected keyword argument 'app'` on current httpx** (#788, #789) by @Sameer6305
+  - `httpx>=0.28.0` removed the `app=` kwarg that Starlette's `TestClient` relies on to wrap a FastAPI app for testing; `httpx` wasn't pinned anywhere in `pyproject.toml`, so different environments could independently resolve an incompatible transitive version and hit the same break
+  - Added an explicit `httpx<0.28.0` constraint to the main `[project.dependencies]` array (not just a dev extra), so it applies globally across production, dev, and CI installs
+  - Without the pin, the full test suite fails to even complete collection (fails immediately on `tests/explorer/test_vocabulary.py` with the same `TestClient` error); with it, `tests/explorer/test_explorer_api.py` goes from 7 failed/12 passed/58 errors to 77 passed, 0 errors
+
 ## [0.6.0] - 2026-07-21
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,8 @@ dependencies = [
   "python-dotenv>=1.2.1",
   "loguru>=0.7.3",
   "structlog>=22.1.0",
-  "gensim>=4.4.0"
+  "gensim>=4.4.0",
+  "httpx<0.28.0"
 ]
 
 [project.urls]


### PR DESCRIPTION
Closes #788.

## Summary
httpx>=0.28.0 removed the app= kwarg that Starlette's TestClient relies on, breaking
every test that spins up a FastAPI TestClient. httpx wasn't pinned anywhere in
pyproject.toml, so different environments could resolve different transitive
versions and hit this independently.

## Change
Added an explicit httpx<0.28.0 constraint to the main [project.dependencies] array
(not just a dev extra), per maintainer's direction - this makes it a global
constraint across production, dev, and CI environments, closing the "different
environments resolve different versions" gap.

## Verification
- Confirmed the exact failure before the fix: pip install "httpx>=0.28.0" reproduces
  58 errors, all the same TypeError: Client.__init__() got an unexpected keyword
  argument 'app'.
- After the pin: tests/explorer/test_explorer_api.py goes from 7 failed/12 passed/58
  errors to 77 passed, 0 errors.
- Ran git stash to compare against the unmodified baseline: without this pin, the
  full test suite can't even complete collection (fails immediately on
  tests/explorer/test_vocabulary.py with the same TestClient error). So this isn't
  just a test fix - it's what allows the full suite to run at all. The 188 failures
  visible after the pin are pre-existing issues elsewhere in the codebase, not
  introduced by this change.