### PR TITLE
fix: suppress CKV_K8S_21 default-namespace false positive on knowledge-explorer Helm chart

### DIFF
--- a/.checkov.yaml
+++ b/.checkov.yaml
@@ -2,4 +2,11 @@
 # Cloud Run false-positives (CKV_K8S_21/28/30) are suppressed via per-file
 # inline checkov:skip comments in deploy/gcp/cloudrun-service.yaml rather than
 # globally here, so future real Kubernetes manifests are not silently exempted.
+#
+# The knowledge-explorer Helm chart's unconditional templates (service.yaml,
+# deployment.yaml, configmap.yaml) set metadata.namespace to .Release.Namespace,
+# which is only bound at `helm install`/`helm template` time. Checkov's helm
+# framework renders the chart without a namespace override, so it always
+# resolves to "default" and trips CKV_K8S_21 even though the chart is
+# namespace-agnostic by design. Suppressed the same way, per-file.
 skip-check: []

--- a/.checkov.yaml
+++ b/.checkov.yaml
@@ -8,5 +8,5 @@
 # which is only bound at `helm install`/`helm template` time. Checkov's helm
 # framework renders the chart without a namespace override, so it always
 # resolves to "default" and trips CKV_K8S_21 even though the chart is
-# namespace-agnostic by design. Suppressed the same way, per-file.
+# namespace-agnostic by design. Suppressed via metadata annotations on each resource.
 skip-check: []

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Checkov flagged the knowledge-explorer Helm chart for using the default Kubernetes namespace** ([code scanning alert #779](https://github.com/semantica-agi/semantica/security/code-scanning/779), [#778](https://github.com/semantica-agi/semantica/security/code-scanning/778), [#777](https://github.com/semantica-agi/semantica/security/code-scanning/777), `CKV_K8S_21`) by @KaifAhmad1
   - `templates/service.yaml`, `templates/deployment.yaml`, and `templates/configmap.yaml` all already set `metadata.namespace` to `{{ .Release.Namespace }}`, which is only bound at `helm install`/`helm template` time; Checkov's helm framework renders the chart without a namespace override, so it always resolves to `default` and trips `CKV_K8S_21` even though the chart is namespace-agnostic by design
-  - Added a `# checkov:skip=CKV_K8S_21` comment to each of the three files, following the same per-file suppression convention already used for the Cloud Run false positives in `deploy/gcp/cloudrun-service.yaml`, and documented the reasoning in `.checkov.yaml`
+  - Added a `checkov.io/skip1: CKV_K8S_21` metadata annotation to each of the three files to suppress the scanner artifact false-positive properly in Helm templates, and documented the reasoning in `.checkov.yaml`
 
 - **No React error boundaries around lazy-loaded Explorer workspaces — a single render error crashed the whole app** (#768, #794) by @Sameer6305
   - Added an `ErrorBoundary` class component (`explorer/src/ErrorBoundary.tsx`) and wrapped each lazy-loaded workspace's `<Suspense>` block in `App.tsx` with it, keyed on the active sub-view so navigating away from and back to a crashed tab remounts it cleanly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Checkov flagged the knowledge-explorer Helm chart for using the default Kubernetes namespace** ([code scanning alert #779](https://github.com/semantica-agi/semantica/security/code-scanning/779), [#778](https://github.com/semantica-agi/semantica/security/code-scanning/778), [#777](https://github.com/semantica-agi/semantica/security/code-scanning/777), `CKV_K8S_21`) by @KaifAhmad1
+  - `templates/service.yaml`, `templates/deployment.yaml`, and `templates/configmap.yaml` all already set `metadata.namespace` to `{{ .Release.Namespace }}`, which is only bound at `helm install`/`helm template` time; Checkov's helm framework renders the chart without a namespace override, so it always resolves to `default` and trips `CKV_K8S_21` even though the chart is namespace-agnostic by design
+  - Added a `# checkov:skip=CKV_K8S_21` comment to each of the three files, following the same per-file suppression convention already used for the Cloud Run false positives in `deploy/gcp/cloudrun-service.yaml`, and documented the reasoning in `.checkov.yaml`
+
 - **No React error boundaries around lazy-loaded Explorer workspaces — a single render error crashed the whole app** (#768, #794) by @Sameer6305
   - Added an `ErrorBoundary` class component (`explorer/src/ErrorBoundary.tsx`) and wrapped each lazy-loaded workspace's `<Suspense>` block in `App.tsx` with it, keyed on the active sub-view so navigating away from and back to a crashed tab remounts it cleanly
   - Failed retries are capped at 3 before the fallback UI switches from "Try Again" to a "Reload Application" dead-end, preventing infinite retry loops on deterministic crashes; raw error/stack details are logged via `console.error` only and never rendered into the fallback UI

--- a/deploy/helm/knowledge-explorer/templates/configmap.yaml
+++ b/deploy/helm/knowledge-explorer/templates/configmap.yaml
@@ -1,6 +1,4 @@
-# checkov:skip=CKV_K8S_21: namespace is set via .Release.Namespace, bound only at helm install/template time
-# Checkov's helm renderer runs without a namespace override, so this always resolves to "default" here —
-# a scanner artifact, not the deployed value; see .checkov.yaml
+
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -8,6 +6,8 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "knowledge-explorer.labels" . | nindent 4 }}
+  annotations:
+    checkov.io/skip1: CKV_K8S_21=namespace is set via .Release.Namespace, bound only at helm install/template time
 data:
   {{- range $key, $value := .Values.env }}
   {{ $key }}: {{ $value | quote }}

--- a/deploy/helm/knowledge-explorer/templates/configmap.yaml
+++ b/deploy/helm/knowledge-explorer/templates/configmap.yaml
@@ -1,4 +1,6 @@
-# checkov:skip=CKV_K8S_21:namespace is set to .Release.Namespace below, supplied at install time via `helm install -n <namespace>`; Checkov's helm-chart renderer runs without a namespace override and always resolves this to "default", which is a scanner artifact, not the deployed value
+# checkov:skip=CKV_K8S_21: namespace is set via .Release.Namespace, bound only at helm install/template time
+# Checkov's helm renderer runs without a namespace override, so this always resolves to "default" here —
+# a scanner artifact, not the deployed value; see .checkov.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/deploy/helm/knowledge-explorer/templates/configmap.yaml
+++ b/deploy/helm/knowledge-explorer/templates/configmap.yaml
@@ -1,3 +1,4 @@
+# checkov:skip=CKV_K8S_21:namespace is set to .Release.Namespace below, supplied at install time via `helm install -n <namespace>`; Checkov's helm-chart renderer runs without a namespace override and always resolves this to "default", which is a scanner artifact, not the deployed value
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/deploy/helm/knowledge-explorer/templates/deployment.yaml
+++ b/deploy/helm/knowledge-explorer/templates/deployment.yaml
@@ -1,4 +1,6 @@
-# checkov:skip=CKV_K8S_21:namespace is set to .Release.Namespace below, supplied at install time via `helm install -n <namespace>`; Checkov's helm-chart renderer runs without a namespace override and always resolves this to "default", which is a scanner artifact, not the deployed value
+# checkov:skip=CKV_K8S_21: namespace is set via .Release.Namespace, bound only at helm install/template time
+# Checkov's helm renderer runs without a namespace override, so this always resolves to "default" here —
+# a scanner artifact, not the deployed value; see .checkov.yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/deploy/helm/knowledge-explorer/templates/deployment.yaml
+++ b/deploy/helm/knowledge-explorer/templates/deployment.yaml
@@ -1,3 +1,4 @@
+# checkov:skip=CKV_K8S_21:namespace is set to .Release.Namespace below, supplied at install time via `helm install -n <namespace>`; Checkov's helm-chart renderer runs without a namespace override and always resolves this to "default", which is a scanner artifact, not the deployed value
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/deploy/helm/knowledge-explorer/templates/deployment.yaml
+++ b/deploy/helm/knowledge-explorer/templates/deployment.yaml
@@ -1,6 +1,4 @@
-# checkov:skip=CKV_K8S_21: namespace is set via .Release.Namespace, bound only at helm install/template time
-# Checkov's helm renderer runs without a namespace override, so this always resolves to "default" here —
-# a scanner artifact, not the deployed value; see .checkov.yaml
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -8,6 +6,8 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "knowledge-explorer.labels" . | nindent 4 }}
+  annotations:
+    checkov.io/skip1: CKV_K8S_21=namespace is set via .Release.Namespace, bound only at helm install/template time
 spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}

--- a/deploy/helm/knowledge-explorer/templates/service.yaml
+++ b/deploy/helm/knowledge-explorer/templates/service.yaml
@@ -1,3 +1,4 @@
+# checkov:skip=CKV_K8S_21:namespace is set to .Release.Namespace below, supplied at install time via `helm install -n <namespace>`; Checkov's helm-chart renderer runs without a namespace override and always resolves this to "default", which is a scanner artifact, not the deployed value
 apiVersion: v1
 kind: Service
 metadata:

--- a/deploy/helm/knowledge-explorer/templates/service.yaml
+++ b/deploy/helm/knowledge-explorer/templates/service.yaml
@@ -1,6 +1,4 @@
-# checkov:skip=CKV_K8S_21: namespace is set via .Release.Namespace, bound only at helm install/template time
-# Checkov's helm renderer runs without a namespace override, so this always resolves to "default" here —
-# a scanner artifact, not the deployed value; see .checkov.yaml
+
 apiVersion: v1
 kind: Service
 metadata:
@@ -8,6 +6,8 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "knowledge-explorer.labels" . | nindent 4 }}
+  annotations:
+    checkov.io/skip1: CKV_K8S_21=namespace is set via .Release.Namespace, bound only at helm install/template time
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/deploy/helm/knowledge-explorer/templates/service.yaml
+++ b/deploy/helm/knowledge-explorer/templates/service.yaml
@@ -1,4 +1,6 @@
-# checkov:skip=CKV_K8S_21:namespace is set to .Release.Namespace below, supplied at install time via `helm install -n <namespace>`; Checkov's helm-chart renderer runs without a namespace override and always resolves this to "default", which is a scanner artifact, not the deployed value
+# checkov:skip=CKV_K8S_21: namespace is set via .Release.Namespace, bound only at helm install/template time
+# Checkov's helm renderer runs without a namespace override, so this always resolves to "default" here —
+# a scanner artifact, not the deployed value; see .checkov.yaml
 apiVersion: v1
 kind: Service
 metadata:


### PR DESCRIPTION
## Summary
- Fixes 3 open Checkov `CKV_K8S_21` ("The default namespace should not be used") code scanning alerts on the `knowledge-explorer` Helm chart: [#779](https://github.com/semantica-agi/semantica/security/code-scanning/779), [#778](https://github.com/semantica-agi/semantica/security/code-scanning/778), [#777](https://github.com/semantica-agi/semantica/security/code-scanning/777)
- `templates/service.yaml`, `templates/deployment.yaml`, and `templates/configmap.yaml` already set `metadata.namespace: {{ .Release.Namespace }}`, which is only bound at `helm install`/`helm template` time — the chart is intentionally namespace-agnostic
- Checkov's `helm` framework renders the chart without a `--namespace` override, so `.Release.Namespace` always resolves to `default` in the scanned output, which trips the rule as a scanner artifact rather than a real misconfiguration
- Added a `# checkov:skip=CKV_K8S_21` comment to each of the three affected files, following the same per-file suppression convention already established for the Cloud Run false positives in `deploy/gcp/cloudrun-service.yaml` (see `.checkov.yaml`), and documented the new class of false positive there
- Added a CHANGELOG entry under `[Unreleased] / Fixed` referencing the three alerts

## Test plan
- [ ] Confirm alerts #777, #778, #779 auto-close (or can be manually dismissed as "used in tests"/false positive) once this merges and the Defender-for-DevOps workflow re-runs Checkov on `main`
- [x] Verified all other Helm templates (`hpa.yaml`, `ingress.yaml`, `networkpolicy.yaml`) are gated behind disabled `.Values` flags in `values.yaml`, so they don't render in Checkov's default scan and aren't affected