### PR TITLE
fix(ontology): wire live SHACL validation into /shacl/validate and /health (closes #772)

### DIFF
--- a/docs/reference/context.md
+++ b/docs/reference/context.md
@@ -586,6 +586,47 @@ history = memory.get_conversation_history(conversation_id="conv_001", max_items=
 | `max_memory_size` | `int` | `10000` | Max items before LRU eviction |
 | `retention_policy` | `str` | `"unlimited"` | `"N_days"` (e.g. `"30_days"`) or `"unlimited"` |
 
+### Markdown Round Trips
+
+`AgentMemory` can export human-editable Markdown and import the edited files back.
+Each file contains one memory item, with required metadata in YAML frontmatter and
+the memory content in the Markdown body:
+
+```markdown
+---
+id: mem_compliance_rule
+created_at: '2026-07-22T09:00:00+00:00'
+updated_at: '2026-07-22T10:30:00+00:00'
+type: compliance
+tags:
+- trading
+- approval
+---
+
+All trades must be pre-approved.
+```
+
+```python
+from pathlib import Path
+
+# A single selected memory can be returned as Markdown text.
+document = memory.export(format="markdown", type="compliance")
+
+# Export a memory set as one stable Markdown file per item.
+memory.export(format="markdown", destination="memory_export/")
+
+# New IDs create memories; existing IDs are updated in place.
+count = memory.import_data(Path("memory_export/"), format="markdown")
+```
+
+The required frontmatter fields are `id`, `created_at`, `updated_at`, and either
+`type` or `kind`. Optional metadata can be edited at the top level. Imports reject
+malformed or duplicate fields before changing memory, and re-importing unchanged
+files is idempotent. Memory-local `entities` and `relationships` are preserved as
+provenance but are not applied to `ContextGraph` by Markdown import. Use a dedicated
+export directory: matching files are overwritten, but unrelated or stale Markdown
+files are not deleted automatically.
+
 
 ## PolicyEngine
 

--- a/docs/reference/context.md
+++ b/docs/reference/context.md
@@ -625,7 +625,11 @@ malformed or duplicate fields before changing memory, and re-importing unchanged
 files is idempotent. Memory-local `entities` and `relationships` are preserved as
 provenance but are not applied to `ContextGraph` by Markdown import. Use a dedicated
 export directory: matching files are overwritten, but unrelated or stale Markdown
-files are not deleted automatically.
+files are not deleted automatically. Export refuses to overwrite symbolic links and
+uses atomic file replacement. Timestamp offsets are preserved in Markdown and
+normalized to UTC only for comparisons, so aware and local-naive records can be
+queried together safely. Vector-store writes are deferred until the in-memory import
+commits; adapter synchronization remains best-effort and logs failures.
 
 
 ## PolicyEngine

--- a/semantica/context/agent_memory.py
+++ b/semantica/context/agent_memory.py
@@ -404,7 +404,10 @@ class AgentMemory:
             self.logger.debug(f"Stored memory item: {memory_id}")
 
             # Apply retention policy
-            self._apply_retention_policy(skip_vector=skip_vector)
+            suppress_vector_mutations = options.get("_suppress_vector_mutations", False)
+            self._apply_retention_policy(
+                suppress_vector_mutations=suppress_vector_mutations
+            )
 
             self.progress_tracker.stop_tracking(
                 tracking_id, status="completed", message=f"Stored memory: {memory_id}"
@@ -587,14 +590,18 @@ class AgentMemory:
         # Remove from vector store unless a caller is staging an atomic local update.
         if not skip_vector:
             if self.vector_store:
+                vector_ids = list(self._vector_ids.get(memory_id, [])) or [
+                    memory_id
+                ]
                 try:
-                    vector_ids = list(self._vector_ids.get(memory_id, [])) or [
-                        memory_id
-                    ]
                     self._delete_vector_ids(vector_ids)
+                    self._vector_ids.pop(memory_id, None)
                 except Exception as e:
-                    self.logger.warning(f"Failed to delete from vector store: {e}")
-            self._vector_ids.pop(memory_id, None)
+                    self.logger.warning(
+                        f"Failed to delete from vector store for memory {memory_id} (IDs: {vector_ids}): {e}"
+                    )
+            else:
+                self._vector_ids.pop(memory_id, None)
 
         memory_item = self.memory_items[memory_id]
 
@@ -861,11 +868,11 @@ class AgentMemory:
             vector_ids = list(previous_vector_ids.get(memory_id, [])) or [memory_id]
             try:
                 self._delete_vector_ids(vector_ids)
+                self._vector_ids.pop(memory_id, None)
             except Exception as exc:
                 self.logger.warning(
-                    f"Failed to delete vector for memory {memory_id}: {exc}"
+                    f"Failed to delete vector for memory {memory_id} (IDs: {vector_ids}): {exc}"
                 )
-            self._vector_ids.pop(memory_id, None)
 
     def _update_knowledge_graph(
         self,
@@ -1012,7 +1019,9 @@ class AgentMemory:
 
         return results
 
-    def _apply_retention_policy(self, *, skip_vector: bool = False) -> None:
+    def _apply_retention_policy(
+        self, *, suppress_vector_mutations: bool = False
+    ) -> None:
         """Apply memory retention policy."""
         if self.retention_policy == "unlimited":
             return
@@ -1037,7 +1046,7 @@ class AgentMemory:
                 memory_ids_to_delete.append(memory_id)
 
         for memory_id in memory_ids_to_delete:
-            self.delete_memory(memory_id, skip_vector=skip_vector)
+            self.delete_memory(memory_id, skip_vector=suppress_vector_mutations)
 
         if memory_ids_to_delete:
             self.logger.info(
@@ -1186,6 +1195,7 @@ class AgentMemory:
                 memory_id=memory_id,
                 timestamp=timestamp,
                 skip_vector=True,
+                _suppress_vector_mutations=True,
                 **replacement_options,
             )
         except Exception:
@@ -2099,6 +2109,7 @@ class AgentMemory:
                         memory_id=current_memory_id,
                         timestamp=memory["timestamp"],
                         skip_vector=True,
+                        _suppress_vector_mutations=True,
                         skip_graph=True,
                     )
                     success = stored_id == current_memory_id and self.exists(

--- a/semantica/context/agent_memory.py
+++ b/semantica/context/agent_memory.py
@@ -60,10 +60,12 @@ License: MIT
 
 import copy
 import hashlib
+import os
 import re
+import tempfile
 from collections import deque
 from dataclasses import dataclass, field
-from datetime import date, datetime, timedelta
+from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, Union
 
@@ -204,6 +206,7 @@ class AgentMemory:
         # In-memory storage
         self.memory_items: Dict[str, MemoryItem] = {}
         self.memory_index: deque = deque(maxlen=self.max_memory_size)
+        self._vector_ids: Dict[str, List[str]] = {}
 
         # Hierarchical Memory: Short-term buffer
         # Note: We use a list for flexible pruning (tokens & count).
@@ -234,6 +237,7 @@ class AgentMemory:
             "memory_items": {k: v.to_dict() for k, v in self.memory_items.items()},
             "memory_index": list(self.memory_index),
             "short_term_memory": [item.to_dict() for item in self.short_term_memory],
+            "vector_ids": self._vector_ids,
             "stats": self.stats,
         }
 
@@ -279,6 +283,11 @@ class AgentMemory:
         self.short_term_memory = [
             MemoryItem.from_dict(item) for item in data.get("short_term_memory", [])
         ]
+        self._vector_ids = {
+            memory_id: list(vector_ids)
+            for memory_id, vector_ids in data.get("vector_ids", {}).items()
+            if isinstance(vector_ids, list)
+        }
         self.stats = data.get(
             "stats",
             {"total_items": 0, "items_by_type": {}, "last_accessed": None},
@@ -323,6 +332,30 @@ class AgentMemory:
             memory_id = options.get("memory_id") or self._generate_memory_id()
             timestamp = options.get("timestamp") or datetime.now()
 
+            if memory_id in self.memory_items:
+                replacement_options = dict(options)
+                replacement_options.pop("memory_id", None)
+                replacement_options.pop("timestamp", None)
+                replaced = self._replace_memory_item(
+                    memory_id,
+                    content,
+                    metadata=metadata or {},
+                    entities=entities or [],
+                    relationships=relationships or [],
+                    timestamp=timestamp,
+                    **replacement_options,
+                )
+                if not replaced:
+                    raise RuntimeError(
+                        f"Failed to replace existing memory item: {memory_id}"
+                    )
+                self.progress_tracker.stop_tracking(
+                    tracking_id,
+                    status="completed",
+                    message=f"Stored memory: {memory_id}",
+                )
+                return memory_id
+
             # Create memory item
             memory_item = MemoryItem(
                 content=content,
@@ -341,24 +374,11 @@ class AgentMemory:
             skip_vector = options.get("skip_vector", False)
             if self.vector_store and not skip_vector:
                 try:
-                    self.progress_tracker.update_tracking(
-                        tracking_id, message="Generating embedding..."
+                    vector_ids = self._store_memory_vector(
+                        memory_item, tracking_id=tracking_id
                     )
-                    embedding = self._generate_embedding(content)
-                    memory_item.embedding = embedding
-
-                    # Store in vector store
-                    if hasattr(self.vector_store, "store_vectors"):
-                        # Use concrete VectorStore implementation
-                        if isinstance(memory_item.embedding, list):
-                            vectors = [np.array(memory_item.embedding)]
-                        else:
-                            vectors = [memory_item.embedding]
-                        meta = [memory_item.metadata]
-                        self.vector_store.store_vectors(vectors=vectors, metadata=meta)
-                    elif hasattr(self.vector_store, "add"):
-                        # Use VectorStore protocol
-                        self.vector_store.add([memory_item])
+                    if vector_ids:
+                        self._vector_ids[memory_id] = vector_ids
                 except Exception as e:
                     self.logger.warning(f"Failed to store in vector store: {e}")
 
@@ -384,7 +404,7 @@ class AgentMemory:
             self.logger.debug(f"Stored memory item: {memory_id}")
 
             # Apply retention policy
-            self._apply_retention_policy()
+            self._apply_retention_policy(skip_vector=skip_vector)
 
             self.progress_tracker.stop_tracking(
                 tracking_id, status="completed", message=f"Stored memory: {memory_id}"
@@ -551,7 +571,7 @@ class AgentMemory:
             "relationships": memory_item.relationships,
         }
 
-    def delete_memory(self, memory_id: str) -> bool:
+    def delete_memory(self, memory_id: str, *, skip_vector: bool = False) -> bool:
         """
         Delete memory item.
 
@@ -564,12 +584,17 @@ class AgentMemory:
         if memory_id not in self.memory_items:
             return False
 
-        # Remove from vector store
-        if self.vector_store and hasattr(self.vector_store, "delete"):
-            try:
-                self.vector_store.delete(memory_id)
-            except Exception as e:
-                self.logger.warning(f"Failed to delete from vector store: {e}")
+        # Remove from vector store unless a caller is staging an atomic local update.
+        if not skip_vector:
+            if self.vector_store:
+                try:
+                    vector_ids = list(self._vector_ids.get(memory_id, [])) or [
+                        memory_id
+                    ]
+                    self._delete_vector_ids(vector_ids)
+                except Exception as e:
+                    self.logger.warning(f"Failed to delete from vector store: {e}")
+            self._vector_ids.pop(memory_id, None)
 
         memory_item = self.memory_items[memory_id]
 
@@ -746,6 +771,102 @@ class AgentMemory:
             return self.vector_store.embed(content)
         return None
 
+    def _store_memory_vector(
+        self, memory_item: MemoryItem, tracking_id: Optional[str] = None
+    ) -> List[str]:
+        """Store one memory embedding and return adapter-provided vector IDs."""
+        if not self.vector_store:
+            return []
+
+        if tracking_id is not None:
+            self.progress_tracker.update_tracking(
+                tracking_id, message="Generating embedding..."
+            )
+
+        memory_item.embedding = self._generate_embedding(memory_item.content)
+        stored_ids: Any = None
+        fallback_to_memory_id = False
+
+        if hasattr(self.vector_store, "store_vectors"):
+            embedding = memory_item.embedding
+            vectors = (
+                [np.array(embedding)] if isinstance(embedding, list) else [embedding]
+            )
+            stored_ids = self.vector_store.store_vectors(
+                vectors=vectors, metadata=[memory_item.metadata]
+            )
+        elif hasattr(self.vector_store, "add"):
+            stored_ids = self.vector_store.add([memory_item])
+            fallback_to_memory_id = True
+        else:
+            return []
+
+        if isinstance(stored_ids, str):
+            return [stored_ids]
+        if isinstance(stored_ids, (list, tuple)):
+            return [str(vector_id) for vector_id in stored_ids]
+        if fallback_to_memory_id and memory_item.memory_id:
+            return [memory_item.memory_id]
+        return []
+
+    def _delete_vector_ids(self, vector_ids: List[str]) -> None:
+        """Delete adapter vector IDs using Semantica's supported interfaces."""
+        if not self.vector_store or not vector_ids:
+            return
+
+        if hasattr(self.vector_store, "delete_vectors"):
+            deleted = self.vector_store.delete_vectors(vector_ids)
+        elif hasattr(self.vector_store, "delete"):
+            deleted = self.vector_store.delete(vector_ids)
+        else:
+            return
+
+        if deleted is False:
+            raise RuntimeError(f"Vector store did not delete IDs: {vector_ids}")
+
+    def _sync_committed_vector_changes(
+        self, previous_state: Dict[str, Any], changed_ids: List[str]
+    ) -> None:
+        """Best-effort vector sync after in-memory changes can no longer roll back."""
+        if not self.vector_store:
+            return
+
+        previous_items = previous_state["memory_items"]
+        previous_vector_ids = previous_state["vector_ids"]
+
+        for memory_id in changed_ids:
+            memory_item = self.memory_items.get(memory_id)
+            if memory_item is None:
+                continue
+
+            old_ids = list(previous_vector_ids.get(memory_id, []))
+            if memory_id in previous_items and not old_ids:
+                old_ids = [memory_id]
+
+            try:
+                new_ids = self._store_memory_vector(memory_item)
+                if new_ids:
+                    self._vector_ids[memory_id] = new_ids
+                    stale_ids = [
+                        vector_id for vector_id in old_ids if vector_id not in new_ids
+                    ]
+                    self._delete_vector_ids(stale_ids)
+            except Exception as exc:
+                self.logger.warning(
+                    f"Failed to synchronize vector for memory {memory_id}: {exc}"
+                )
+
+        removed_ids = set(previous_items).difference(self.memory_items)
+        for memory_id in removed_ids:
+            vector_ids = list(previous_vector_ids.get(memory_id, [])) or [memory_id]
+            try:
+                self._delete_vector_ids(vector_ids)
+            except Exception as exc:
+                self.logger.warning(
+                    f"Failed to delete vector for memory {memory_id}: {exc}"
+                )
+            self._vector_ids.pop(memory_id, None)
+
     def _update_knowledge_graph(
         self,
         entities: List[EntityDict],
@@ -834,7 +955,9 @@ class AgentMemory:
                 from dateutil.parser import parse
 
                 start_date = parse(start_date)
-            if memory_item.timestamp < start_date:
+            if self._timestamp_comparison_key(
+                memory_item.timestamp
+            ) < self._timestamp_comparison_key(start_date):
                 return False
 
         if "end_date" in filters:
@@ -843,10 +966,17 @@ class AgentMemory:
                 from dateutil.parser import parse
 
                 end_date = parse(end_date)
-            if memory_item.timestamp > end_date:
+            if self._timestamp_comparison_key(
+                memory_item.timestamp
+            ) > self._timestamp_comparison_key(end_date):
                 return False
 
         return True
+
+    @staticmethod
+    def _timestamp_comparison_key(timestamp: datetime) -> datetime:
+        """Convert aware or local-naive timestamps to a comparable UTC value."""
+        return timestamp.astimezone(timezone.utc)
 
     def _keyword_search(
         self, query: str, max_results: int, filters: Dict[str, Any]
@@ -882,7 +1012,7 @@ class AgentMemory:
 
         return results
 
-    def _apply_retention_policy(self) -> None:
+    def _apply_retention_policy(self, *, skip_vector: bool = False) -> None:
         """Apply memory retention policy."""
         if self.retention_policy == "unlimited":
             return
@@ -901,11 +1031,13 @@ class AgentMemory:
         # Delete old items
         memory_ids_to_delete = []
         for memory_id, memory_item in self.memory_items.items():
-            if memory_item.timestamp < cutoff_date:
+            if self._timestamp_comparison_key(
+                memory_item.timestamp
+            ) < self._timestamp_comparison_key(cutoff_date):
                 memory_ids_to_delete.append(memory_id)
 
         for memory_id in memory_ids_to_delete:
-            self.delete_memory(memory_id)
+            self.delete_memory(memory_id, skip_vector=skip_vector)
 
         if memory_ids_to_delete:
             self.logger.info(
@@ -1042,8 +1174,10 @@ class AgentMemory:
     ) -> bool:
         """Replace a memory while retaining its identity and recoverable state."""
         state = self._snapshot_memory_state()
+        replacement_options = dict(options)
+        sync_vector = not replacement_options.pop("skip_vector", False)
         try:
-            self.delete_memory(memory_id)
+            self.delete_memory(memory_id, skip_vector=True)
             new_id = self.store(
                 content,
                 metadata=metadata,
@@ -1051,7 +1185,8 @@ class AgentMemory:
                 relationships=relationships,
                 memory_id=memory_id,
                 timestamp=timestamp,
-                **options,
+                skip_vector=True,
+                **replacement_options,
             )
         except Exception:
             self._restore_memory_state(state)
@@ -1060,6 +1195,8 @@ class AgentMemory:
         if new_id != memory_id or not self.exists(memory_id):
             self._restore_memory_state(state)
             return False
+        if sync_vector:
+            self._sync_committed_vector_changes(state, [memory_id])
         return True
 
     def _snapshot_memory_state(self) -> Dict[str, Any]:
@@ -1068,6 +1205,7 @@ class AgentMemory:
             "memory_items": dict(self.memory_items),
             "memory_index": deque(self.memory_index, maxlen=self.memory_index.maxlen),
             "short_term_memory": list(self.short_term_memory),
+            "vector_ids": copy.deepcopy(self._vector_ids),
             "stats": copy.deepcopy(self.stats),
         }
 
@@ -1076,6 +1214,7 @@ class AgentMemory:
         self.memory_items = state["memory_items"]
         self.memory_index = state["memory_index"]
         self.short_term_memory = state["short_term_memory"]
+        self._vector_ids = state["vector_ids"]
         self.stats = state["stats"]
 
     def delete(self, memory_id: str) -> bool:
@@ -1307,7 +1446,9 @@ class AgentMemory:
         """
         results = []
         sorted_items = sorted(
-            self.memory_items.items(), key=lambda x: x[1].timestamp, reverse=True
+            self.memory_items.items(),
+            key=lambda item: self._timestamp_comparison_key(item[1].timestamp),
+            reverse=True,
         )
         for memory_id, _ in sorted_items[:limit]:
             mem_dict = self.get_memory(memory_id)
@@ -1344,9 +1485,13 @@ class AgentMemory:
 
             end_date = parse(end_date)
 
+        normalized_start = self._timestamp_comparison_key(start_date)
+        normalized_end = self._timestamp_comparison_key(end_date)
+
         results = []
         for memory_id, memory_item in self.memory_items.items():
-            if start_date <= memory_item.timestamp <= end_date:
+            normalized_timestamp = self._timestamp_comparison_key(memory_item.timestamp)
+            if normalized_start <= normalized_timestamp <= normalized_end:
                 mem_dict = self.get_memory(memory_id)
                 if mem_dict:
                     results.append(mem_dict)
@@ -1584,13 +1729,44 @@ class AgentMemory:
         for filename, document in documents:
             file_path = destination_path / filename
             try:
-                file_path.write_text(document, encoding="utf-8")
+                self._write_markdown_file(file_path, document)
             except OSError as exc:
                 raise OSError(
                     f"Failed to write Markdown memory to {file_path}"
                 ) from exc
 
         return str(destination_path)
+
+    @staticmethod
+    def _write_markdown_file(file_path: Path, document: str) -> None:
+        """Atomically replace a Markdown file without following output symlinks."""
+        if file_path.is_symlink():
+            raise ValueError(
+                f"Refusing to overwrite Markdown symbolic link: {file_path}"
+            )
+
+        temporary_path = None
+        try:
+            with tempfile.NamedTemporaryFile(
+                mode="w",
+                encoding="utf-8",
+                dir=str(file_path.parent),
+                prefix=f".{file_path.name}.",
+                suffix=".tmp",
+                delete=False,
+            ) as temporary_file:
+                temporary_path = Path(temporary_file.name)
+                temporary_file.write(document)
+                temporary_file.flush()
+                os.fsync(temporary_file.fileno())
+
+            # os.replace swaps the directory entry itself, so a raced symlink is
+            # replaced rather than followed.
+            os.replace(temporary_path, file_path)
+            temporary_path = None
+        finally:
+            if temporary_path is not None:
+                temporary_path.unlink(missing_ok=True)
 
     def _memory_to_markdown(self, memory: Dict[str, Any]) -> str:
         memory_id = memory.get("memory_id")
@@ -1893,6 +2069,7 @@ class AgentMemory:
 
         state = self._snapshot_memory_state()
         imported = 0
+        changed_ids = []
         current_source = "markdown document"
         current_memory_id = "unknown"
         try:
@@ -1910,6 +2087,7 @@ class AgentMemory:
                         entities=memory["entities"],
                         relationships=memory["relationships"],
                         timestamp=memory["timestamp"],
+                        skip_vector=True,
                         skip_graph=True,
                     )
                 else:
@@ -1920,6 +2098,7 @@ class AgentMemory:
                         relationships=memory["relationships"],
                         memory_id=current_memory_id,
                         timestamp=memory["timestamp"],
+                        skip_vector=True,
                         skip_graph=True,
                     )
                     success = stored_id == current_memory_id and self.exists(
@@ -1928,6 +2107,7 @@ class AgentMemory:
 
                 if not success:
                     raise RuntimeError("memory store did not confirm the requested ID")
+                changed_ids.append(current_memory_id)
                 imported += 1
         except Exception as exc:
             self._restore_memory_state(state)
@@ -1936,6 +2116,7 @@ class AgentMemory:
                 f"from {current_source}: {exc}"
             ) from exc
 
+        self._sync_committed_vector_changes(state, changed_ids)
         return imported
 
     def _markdown_record_matches(self, memory_id: str, memory: Dict[str, Any]) -> bool:

--- a/semantica/context/agent_memory.py
+++ b/semantica/context/agent_memory.py
@@ -58,16 +58,57 @@ Author: Semantica Contributors
 License: MIT
 """
 
+import copy
+import hashlib
+import re
 from collections import deque
 from dataclasses import dataclass, field
-from datetime import datetime, timedelta
-from typing import Any, Dict, List, Optional, Union
+from datetime import date, datetime, timedelta
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import numpy as np
+import yaml
 
 from ..utils.logging import get_logger
 from ..utils.progress_tracker import get_progress_tracker
 from ..utils.types import EntityDict, RelationshipDict
+
+
+class _UniqueKeySafeLoader(yaml.SafeLoader):
+    """Safe YAML loader that rejects ambiguous duplicate mapping keys."""
+
+
+def _construct_unique_mapping(
+    loader: _UniqueKeySafeLoader, node: yaml.MappingNode, deep: bool = False
+) -> Dict[Any, Any]:
+    loader.flatten_mapping(node)
+    mapping = {}
+    for key_node, value_node in node.value:
+        key = loader.construct_object(key_node, deep=deep)
+        try:
+            duplicate = key in mapping
+        except TypeError as exc:
+            raise yaml.constructor.ConstructorError(
+                "while constructing a mapping",
+                node.start_mark,
+                "found an unhashable key",
+                key_node.start_mark,
+            ) from exc
+        if duplicate:
+            raise yaml.constructor.ConstructorError(
+                "while constructing a mapping",
+                node.start_mark,
+                f"found duplicate key {key!r}",
+                key_node.start_mark,
+            )
+        mapping[key] = loader.construct_object(value_node, deep=deep)
+    return mapping
+
+
+_UniqueKeySafeLoader.add_constructor(
+    yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG, _construct_unique_mapping
+)
 
 
 @dataclass
@@ -120,6 +161,20 @@ class AgentMemory:
     • Long-term Memory: Vector store for persistent semantic history
     • Knowledge Graph: Structured context integration
     """
+
+    _MARKDOWN_RESERVED_FIELDS = frozenset(
+        {
+            "id",
+            "created_at",
+            "updated_at",
+            "type",
+            "kind",
+            "entities",
+            "relationships",
+            "metadata",
+        }
+    )
+    _MARKDOWN_EXTENSIONS = frozenset({".md", ".markdown"})
 
     def __init__(self, config: Optional[Dict[str, Any]] = None, **kwargs):
         """
@@ -206,7 +261,7 @@ class AgentMemory:
             with open(file_path, "r", encoding="utf-8") as f:
                 data = json.load(f)
         elif os.path.exists(legacy_path):
-            # Legacy pickle files: refuse to load them to prevent deserialization attacks.
+            # Refuse legacy pickle files to prevent deserialization attacks.
             # Users must re-save memory in the new JSON format.
             self.logger.warning(
                 f"Legacy pickle file found at {legacy_path}. "
@@ -218,9 +273,7 @@ class AgentMemory:
             return
 
         raw_items = data.get("memory_items", {})
-        self.memory_items = {
-            k: MemoryItem.from_dict(v) for k, v in raw_items.items()
-        }
+        self.memory_items = {k: MemoryItem.from_dict(v) for k, v in raw_items.items()}
         raw_index = data.get("memory_index", [])
         self.memory_index = deque(raw_index, maxlen=self.max_memory_size)
         self.short_term_memory = [
@@ -253,6 +306,7 @@ class AgentMemory:
                 - memory_id: Custom memory ID
                 - timestamp: Custom timestamp
                 - skip_vector: If True, skip vector store (Short-term only)
+                - skip_graph: If True, keep entities local to the memory item
 
         Returns:
             Memory ID
@@ -313,7 +367,8 @@ class AgentMemory:
             self.memory_index.append(memory_id)
 
             # 3. Update Knowledge Graph
-            if self.knowledge_graph and entities:
+            skip_graph = options.get("skip_graph", False)
+            if self.knowledge_graph and entities and not skip_graph:
                 self.progress_tracker.update_tracking(
                     tracking_id, message="Updating knowledge graph..."
                 )
@@ -516,14 +571,29 @@ class AgentMemory:
             except Exception as e:
                 self.logger.warning(f"Failed to delete from vector store: {e}")
 
+        memory_item = self.memory_items[memory_id]
+
         # Remove from memory
         del self.memory_items[memory_id]
 
-        # Remove from index
-        if memory_id in self.memory_index:
-            self.memory_index.remove(memory_id)
+        # Remove every occurrence in case a custom ID was stored more than once.
+        self.memory_index = deque(
+            (item_id for item_id in self.memory_index if item_id != memory_id),
+            maxlen=self.memory_index.maxlen,
+        )
+
+        self.short_term_memory = [
+            item for item in self.short_term_memory if item.memory_id != memory_id
+        ]
 
         self.stats["total_items"] = max(0, self.stats["total_items"] - 1)
+        item_type = memory_item.metadata.get("type", "general")
+        if item_type in self.stats["items_by_type"]:
+            self.stats["items_by_type"][item_type] = max(
+                0, self.stats["items_by_type"][item_type] - 1
+            )
+            if self.stats["items_by_type"][item_type] == 0:
+                del self.stats["items_by_type"][item_type]
 
         self.logger.debug(f"Deleted memory item: {memory_id}")
         return True
@@ -628,7 +698,6 @@ class AgentMemory:
 
     def _generate_memory_id(self) -> str:
         """Generate unique memory ID."""
-        import hashlib
         import time
 
         timestamp = str(time.time())
@@ -917,6 +986,8 @@ class AgentMemory:
         memory_id: str,
         content: Optional[str] = None,
         metadata: Optional[Dict[str, Any]] = None,
+        entities: Optional[List[EntityDict]] = None,
+        relationships: Optional[List[RelationshipDict]] = None,
         **kwargs,
     ) -> bool:
         """
@@ -926,6 +997,8 @@ class AgentMemory:
             memory_id: Memory ID to update
             content: New content (optional)
             metadata: New metadata (optional, merged with existing)
+            entities: Replacement entities (optional)
+            relationships: Replacement relationships (optional)
             **kwargs: Additional fields to update
 
         Returns:
@@ -942,18 +1015,68 @@ class AgentMemory:
         current_metadata = memory_item.metadata.copy()
         if metadata:
             current_metadata.update(metadata)
+        current_entities = entities if entities is not None else memory_item.entities
+        current_relationships = (
+            relationships if relationships is not None else memory_item.relationships
+        )
 
-        # Delete old and create new
-        self.delete_memory(memory_id)
-        new_id = self.store(
+        return self._replace_memory_item(
+            memory_id,
             current_content,
             metadata=current_metadata,
-            entities=memory_item.entities,
-            relationships=memory_item.relationships,
+            entities=current_entities,
+            relationships=current_relationships,
+            timestamp=kwargs.pop("timestamp", memory_item.timestamp),
             **kwargs,
         )
 
-        return new_id is not None
+    def _replace_memory_item(
+        self,
+        memory_id: str,
+        content: str,
+        metadata: Dict[str, Any],
+        entities: List[EntityDict],
+        relationships: List[RelationshipDict],
+        timestamp: datetime,
+        **options,
+    ) -> bool:
+        """Replace a memory while retaining its identity and recoverable state."""
+        state = self._snapshot_memory_state()
+        try:
+            self.delete_memory(memory_id)
+            new_id = self.store(
+                content,
+                metadata=metadata,
+                entities=entities,
+                relationships=relationships,
+                memory_id=memory_id,
+                timestamp=timestamp,
+                **options,
+            )
+        except Exception:
+            self._restore_memory_state(state)
+            raise
+
+        if new_id != memory_id or not self.exists(memory_id):
+            self._restore_memory_state(state)
+            return False
+        return True
+
+    def _snapshot_memory_state(self) -> Dict[str, Any]:
+        """Capture mutable in-memory state for an update or import rollback."""
+        return {
+            "memory_items": dict(self.memory_items),
+            "memory_index": deque(self.memory_index, maxlen=self.memory_index.maxlen),
+            "short_term_memory": list(self.short_term_memory),
+            "stats": copy.deepcopy(self.stats),
+        }
+
+    def _restore_memory_state(self, state: Dict[str, Any]) -> None:
+        """Restore state captured by :meth:`_snapshot_memory_state`."""
+        self.memory_items = state["memory_items"]
+        self.memory_index = state["memory_index"]
+        self.short_term_memory = state["short_term_memory"]
+        self.stats = state["stats"]
 
     def delete(self, memory_id: str) -> bool:
         """
@@ -1332,14 +1455,19 @@ class AgentMemory:
 
     # Export/Import
     def export(
-        self, conversation_id: Optional[str] = None, format: str = "json", **filters
+        self,
+        conversation_id: Optional[str] = None,
+        format: str = "json",
+        destination: Optional[Union[str, Path]] = None,
+        **filters,
     ) -> Union[str, Dict[str, Any]]:
         """
         Export memories.
 
         Args:
             conversation_id: Export specific conversation (optional)
-            format: Export format ('json' or 'dict', default: 'json')
+            format: Export format ('json', 'dict', or 'markdown', default: 'json')
+            destination: Optional directory for one-file-per-memory Markdown export
             **filters: Additional filters
 
         Returns:
@@ -1369,17 +1497,19 @@ class AgentMemory:
             import json
 
             return json.dumps(export_data, indent=2, default=str)
+        if format == "markdown":
+            return self._export_markdown(memories, destination=destination)
         return export_data
 
     def import_data(
-        self, data: Union[str, Dict[str, Any]], format: str = "json"
+        self, data: Union[str, Path, Dict[str, Any]], format: str = "json"
     ) -> int:
         """
         Import memories.
 
         Args:
             data: Data to import
-            format: Data format ('json' or 'dict', default: 'json')
+            format: Data format ('json', 'dict', or 'markdown', default: 'json')
 
         Returns:
             Number of memories imported
@@ -1392,6 +1522,9 @@ class AgentMemory:
 
             if isinstance(data, str):
                 data = json.loads(data)
+        elif format == "markdown":
+            memories = self._import_markdown_payload(data)
+            return self._import_markdown_records(memories)
 
         if not isinstance(data, dict):
             raise ValueError("Invalid data format")
@@ -1413,6 +1546,451 @@ class AgentMemory:
                 self.logger.warning(f"Failed to import memory: {e}")
 
         return imported
+
+    def _export_markdown(
+        self,
+        memories: List[Dict[str, Any]],
+        destination: Optional[Union[str, Path]] = None,
+    ) -> str:
+        documents = []
+        filenames = set()
+        for memory in memories:
+            filename = self._memory_markdown_filename(memory.get("memory_id"))
+            normalized_filename = filename.casefold()
+            if normalized_filename in filenames:
+                raise ValueError(
+                    f"Cannot export Markdown: duplicate filename {filename!r}."
+                )
+            filenames.add(normalized_filename)
+            documents.append((filename, self._memory_to_markdown(memory)))
+
+        if destination is None:
+            if not documents:
+                return ""
+            if len(documents) > 1:
+                raise ValueError(
+                    "Markdown export without a destination supports one memory item. "
+                    "Pass a destination directory to export multiple items."
+                )
+            return documents[0][1]
+
+        destination_path = Path(destination)
+        if destination_path.exists() and not destination_path.is_dir():
+            raise ValueError(
+                f"Markdown export destination is not a directory: {destination_path}"
+            )
+        destination_path.mkdir(parents=True, exist_ok=True)
+
+        for filename, document in documents:
+            file_path = destination_path / filename
+            try:
+                file_path.write_text(document, encoding="utf-8")
+            except OSError as exc:
+                raise OSError(
+                    f"Failed to write Markdown memory to {file_path}"
+                ) from exc
+
+        return str(destination_path)
+
+    def _memory_to_markdown(self, memory: Dict[str, Any]) -> str:
+        memory_id = memory.get("memory_id")
+        source = f"memory {memory_id!r}"
+        if not isinstance(memory_id, str) or not memory_id.strip():
+            raise ValueError(f"Cannot export {source}: 'memory_id' must be a string.")
+
+        raw_metadata = memory.get("metadata")
+        if raw_metadata is None:
+            raw_metadata = {}
+        if not isinstance(raw_metadata, dict):
+            raise ValueError(f"Cannot export {source}: 'metadata' must be a mapping.")
+        metadata = dict(raw_metadata)
+
+        created_at = self._parse_markdown_datetime(
+            memory.get("timestamp"), "created_at", source
+        )
+        updated_at = self._parse_markdown_datetime(
+            metadata.pop("updated_at", created_at), "updated_at", source
+        )
+        memory_type = metadata.pop("type", "general")
+        if not isinstance(memory_type, str) or not memory_type.strip():
+            raise ValueError(f"Cannot export {source}: 'type' must be a string.")
+
+        frontmatter = {
+            "id": memory_id,
+            "created_at": created_at.isoformat(),
+            "updated_at": updated_at.isoformat(),
+            "type": memory_type,
+        }
+
+        nested_metadata = {}
+        if any(not isinstance(key, str) for key in metadata):
+            raise ValueError(f"Cannot export {source}: metadata keys must be strings.")
+        for key in sorted(metadata):
+            value = metadata[key]
+            if key in self._MARKDOWN_RESERVED_FIELDS:
+                nested_metadata[key] = value
+            else:
+                frontmatter[key] = value
+
+        if nested_metadata:
+            frontmatter["metadata"] = nested_metadata
+        entities = memory.get("entities")
+        relationships = memory.get("relationships")
+        if entities is None:
+            entities = []
+        if relationships is None:
+            relationships = []
+        self._validate_markdown_mapping_list(entities, "entities", source)
+        self._validate_markdown_mapping_list(relationships, "relationships", source)
+        if entities:
+            frontmatter["entities"] = entities
+        if relationships:
+            frontmatter["relationships"] = relationships
+
+        try:
+            yaml_text = yaml.safe_dump(
+                frontmatter,
+                sort_keys=False,
+                allow_unicode=True,
+                default_flow_style=False,
+            )
+        except yaml.YAMLError as exc:
+            raise ValueError(
+                f"Cannot export {source}: metadata is not YAML serializable."
+            ) from exc
+
+        body = memory.get("content", "")
+        if not isinstance(body, str):
+            raise ValueError(f"Cannot export {source}: 'content' must be a string.")
+        return f"---\n{yaml_text}---\n\n{body}"
+
+    def _memory_markdown_filename(self, memory_id: Optional[str]) -> str:
+        if not isinstance(memory_id, str) or not memory_id.strip():
+            raise ValueError(
+                "Cannot create Markdown filename without a string memory ID."
+            )
+
+        slug = re.sub(r"[^A-Za-z0-9._-]+", "-", memory_id)
+        slug = re.sub(r"-+", "-", slug).strip("._-")[:80].rstrip("._-")
+        slug = slug or "memory"
+        digest = hashlib.sha256(memory_id.encode("utf-8")).hexdigest()[:12]
+        return f"{slug}--{digest}.md"
+
+    def _import_markdown_payload(
+        self, data: Union[str, Path, Dict[str, Any]]
+    ) -> List[Tuple[str, Dict[str, Any]]]:
+        if isinstance(data, Path):
+            documents = self._read_markdown_path(data)
+        elif isinstance(data, str):
+            if not data:
+                return []
+
+            documents = None
+            if "\n" not in data and "\r" not in data:
+                candidate = Path(data)
+                try:
+                    if candidate.exists():
+                        documents = self._read_markdown_path(candidate)
+                except OSError:
+                    pass
+
+            if documents is None:
+                documents = [("markdown document", data)]
+        else:
+            raise ValueError(
+                "Invalid Markdown data format. Expected Markdown text or a path."
+            )
+
+        memories = []
+        memory_sources = {}
+        for source, document in documents:
+            memory = self._markdown_to_memory_dict(document, source=source)
+            memory_id = memory["memory_id"]
+            if memory_id in memory_sources:
+                raise ValueError(
+                    f"Duplicate Markdown memory ID {memory_id!r} in {source}; "
+                    f"already defined in {memory_sources[memory_id]}."
+                )
+            memory_sources[memory_id] = source
+            memories.append((source, memory))
+
+        return memories
+
+    def _read_markdown_path(self, path: Path) -> List[Tuple[str, str]]:
+        if not path.exists():
+            raise FileNotFoundError(f"Markdown import path does not exist: {path}")
+
+        if path.is_dir():
+            file_paths = sorted(
+                (
+                    file_path
+                    for file_path in path.iterdir()
+                    if file_path.is_file()
+                    and file_path.suffix.lower() in self._MARKDOWN_EXTENSIONS
+                ),
+                key=lambda file_path: (file_path.name.casefold(), file_path.name),
+            )
+        elif path.is_file():
+            file_paths = [path]
+        else:
+            raise ValueError(f"Markdown import path is not a file or directory: {path}")
+
+        return [
+            (str(file_path), file_path.read_text(encoding="utf-8"))
+            for file_path in file_paths
+        ]
+
+    def _markdown_to_memory_dict(
+        self, document: str, source: str = "markdown document"
+    ) -> Dict[str, Any]:
+        if not document.startswith("---"):
+            raise ValueError(
+                f"Invalid Markdown frontmatter in {source}: "
+                "document must start with '---'."
+            )
+
+        lines = document.splitlines(keepends=True)
+        if not lines or lines[0].rstrip("\r\n") != "---":
+            raise ValueError(
+                f"Invalid Markdown frontmatter in {source}: "
+                "opening delimiter is malformed."
+            )
+
+        closing_index = next(
+            (
+                index
+                for index, line in enumerate(lines[1:], start=1)
+                if line.rstrip("\r\n") == "---"
+            ),
+            None,
+        )
+        if closing_index is None:
+            raise ValueError(
+                f"Invalid Markdown frontmatter in {source}: missing closing '---'."
+            )
+
+        yaml_text = "".join(lines[1:closing_index])
+        try:
+            loaded_frontmatter = yaml.load(yaml_text, Loader=_UniqueKeySafeLoader)
+            frontmatter = {} if loaded_frontmatter is None else loaded_frontmatter
+        except yaml.YAMLError as exc:
+            raise ValueError(
+                f"Invalid Markdown frontmatter in {source}: {exc}"
+            ) from exc
+
+        if not isinstance(frontmatter, dict):
+            raise ValueError(
+                f"Invalid Markdown frontmatter in {source}: expected a YAML mapping."
+            )
+
+        if any(not isinstance(key, str) for key in frontmatter):
+            raise ValueError(
+                f"Invalid Markdown frontmatter in {source}: "
+                "field names must be strings."
+            )
+
+        missing_fields = [
+            field
+            for field in ("id", "created_at", "updated_at")
+            if field not in frontmatter
+        ]
+        if "type" not in frontmatter and "kind" not in frontmatter:
+            missing_fields.append("type or kind")
+        if missing_fields:
+            fields = ", ".join(repr(field) for field in missing_fields)
+            raise ValueError(
+                f"Invalid Markdown frontmatter in {source}: "
+                f"missing required field(s) {fields}."
+            )
+
+        memory_id = frontmatter["id"]
+        if not isinstance(memory_id, str) or not memory_id.strip():
+            raise ValueError(
+                f"Invalid Markdown frontmatter in {source}: 'id' must be a string."
+            )
+
+        memory_type = frontmatter.get("type", frontmatter.get("kind"))
+        if not isinstance(memory_type, str) or not memory_type.strip():
+            raise ValueError(
+                f"Invalid Markdown frontmatter in {source}: "
+                "'type' or 'kind' must be a string."
+            )
+        if (
+            "type" in frontmatter
+            and "kind" in frontmatter
+            and frontmatter["type"] != frontmatter["kind"]
+        ):
+            raise ValueError(
+                f"Invalid Markdown frontmatter in {source}: "
+                "'type' and 'kind' must match when both are provided."
+            )
+
+        created_at = self._parse_markdown_datetime(
+            frontmatter["created_at"], "created_at", source
+        )
+        updated_at = self._parse_markdown_datetime(
+            frontmatter["updated_at"], "updated_at", source
+        )
+
+        nested_metadata = frontmatter.get("metadata", {})
+        if nested_metadata is None:
+            nested_metadata = {}
+        if not isinstance(nested_metadata, dict):
+            raise ValueError(
+                f"Invalid Markdown frontmatter in {source}: "
+                "'metadata' must be a mapping."
+            )
+        if any(not isinstance(key, str) for key in nested_metadata):
+            raise ValueError(
+                f"Invalid Markdown frontmatter in {source}: "
+                "metadata field names must be strings."
+            )
+        conflicting_metadata = {"type", "updated_at"}.intersection(nested_metadata)
+        if conflicting_metadata:
+            fields = ", ".join(sorted(conflicting_metadata))
+            raise ValueError(
+                f"Invalid Markdown frontmatter in {source}: nested metadata "
+                f"duplicates reserved field(s): {fields}."
+            )
+
+        entities = frontmatter.get("entities", [])
+        relationships = frontmatter.get("relationships", [])
+        self._validate_markdown_mapping_list(entities, "entities", source)
+        self._validate_markdown_mapping_list(relationships, "relationships", source)
+
+        metadata = dict(nested_metadata)
+        for key, value in frontmatter.items():
+            if key not in self._MARKDOWN_RESERVED_FIELDS:
+                if key in metadata:
+                    raise ValueError(
+                        f"Invalid Markdown frontmatter in {source}: metadata field "
+                        f"{key!r} is defined both at the top level and in 'metadata'."
+                    )
+                metadata[key] = value
+        metadata["type"] = memory_type
+        metadata["updated_at"] = updated_at.isoformat()
+
+        body = "".join(lines[closing_index + 1 :])
+        if body.startswith("\r\n"):
+            body = body[2:]
+        elif body.startswith("\n"):
+            body = body[1:]
+
+        return {
+            "memory_id": memory_id,
+            "content": body,
+            "timestamp": created_at,
+            "metadata": metadata,
+            "entities": entities,
+            "relationships": relationships,
+        }
+
+    def _import_markdown_records(
+        self, memories: List[Tuple[str, Dict[str, Any]]]
+    ) -> int:
+        if not memories:
+            return 0
+
+        state = self._snapshot_memory_state()
+        imported = 0
+        current_source = "markdown document"
+        current_memory_id = "unknown"
+        try:
+            for current_source, memory in memories:
+                current_memory_id = memory["memory_id"]
+                if self._markdown_record_matches(current_memory_id, memory):
+                    imported += 1
+                    continue
+
+                if self.exists(current_memory_id):
+                    success = self._replace_memory_item(
+                        current_memory_id,
+                        memory["content"],
+                        metadata=memory["metadata"],
+                        entities=memory["entities"],
+                        relationships=memory["relationships"],
+                        timestamp=memory["timestamp"],
+                        skip_graph=True,
+                    )
+                else:
+                    stored_id = self.store(
+                        memory["content"],
+                        metadata=memory["metadata"],
+                        entities=memory["entities"],
+                        relationships=memory["relationships"],
+                        memory_id=current_memory_id,
+                        timestamp=memory["timestamp"],
+                        skip_graph=True,
+                    )
+                    success = stored_id == current_memory_id and self.exists(
+                        current_memory_id
+                    )
+
+                if not success:
+                    raise RuntimeError("memory store did not confirm the requested ID")
+                imported += 1
+        except Exception as exc:
+            self._restore_memory_state(state)
+            raise RuntimeError(
+                f"Failed to import Markdown memory {current_memory_id!r} "
+                f"from {current_source}: {exc}"
+            ) from exc
+
+        return imported
+
+    def _markdown_record_matches(self, memory_id: str, memory: Dict[str, Any]) -> bool:
+        existing = self.memory_items.get(memory_id)
+        if existing is None:
+            return False
+
+        return (
+            existing.content == memory["content"]
+            and existing.timestamp == memory["timestamp"]
+            and existing.metadata == memory["metadata"]
+            and existing.entities == memory["entities"]
+            and existing.relationships == memory["relationships"]
+        )
+
+    def _parse_markdown_datetime(
+        self, value: Any, field_name: str, source: str
+    ) -> datetime:
+        if isinstance(value, datetime):
+            parsed = value
+        elif isinstance(value, date):
+            parsed = datetime.combine(value, datetime.min.time())
+        elif isinstance(value, str) and value.strip():
+            candidate = value.strip()
+            if candidate.endswith("Z"):
+                candidate = candidate[:-1] + "+00:00"
+            try:
+                parsed = datetime.fromisoformat(candidate)
+            except ValueError as exc:
+                raise ValueError(
+                    f"Invalid Markdown frontmatter in {source}: "
+                    f"'{field_name}' must be an ISO-8601 datetime."
+                ) from exc
+        else:
+            raise ValueError(
+                f"Invalid Markdown frontmatter in {source}: "
+                f"'{field_name}' must be an ISO-8601 datetime."
+            )
+
+        return parsed
+
+    def _validate_markdown_mapping_list(
+        self, value: Any, field_name: str, source: str
+    ) -> None:
+        if not isinstance(value, list):
+            raise ValueError(
+                f"Invalid Markdown frontmatter in {source}: "
+                f"'{field_name}' must be a list."
+            )
+        for index, item in enumerate(value):
+            if not isinstance(item, dict):
+                raise ValueError(
+                    f"Invalid Markdown frontmatter in {source}: "
+                    f"'{field_name}[{index}]' must be a mapping."
+                )
 
     # Statistics
     def stats(self, **filters) -> Dict[str, Any]:

--- a/semantica/context/agent_memory.py
+++ b/semantica/context/agent_memory.py
@@ -2126,7 +2126,8 @@ class AgentMemory:
 
         return (
             existing.content == memory["content"]
-            and existing.timestamp == memory["timestamp"]
+            and self._timestamp_comparison_key(existing.timestamp)
+            == self._timestamp_comparison_key(memory["timestamp"])
             and existing.metadata == memory["metadata"]
             and existing.entities == memory["entities"]
             and existing.relationships == memory["relationships"]

--- a/semantica/explorer/routes/ontology.py
+++ b/semantica/explorer/routes/ontology.py
@@ -697,8 +697,8 @@ def _node_belongs_to_ontology(node: Dict[str, Any], ontology_uri: str) -> bool:
         return True
     if _node_source_ontology(node) == ontology_uri:
         return True
-    namespace = _extract_namespace(ontology_uri)
-    return bool(namespace and nid.startswith(namespace))
+    stem = ontology_uri.rstrip("#/")
+    return nid.startswith((stem + "#", stem + "/"))
 
 
 def _is_ontology_entity(node: Dict[str, Any]) -> bool:
@@ -778,6 +778,17 @@ def _ontology_entities(nodes: List[Dict[str, Any]], ontology_uri: Optional[str] 
     result = []
     for node in nodes:
         if not _is_ontology_entity(node):
+            continue
+        if ontology_uri and not _node_belongs_to_ontology(node, ontology_uri):
+            continue
+        result.append(node)
+    return result
+
+
+def _data_graph_entities(nodes: List[Dict[str, Any]], ontology_uri: Optional[str] = None) -> List[Dict[str, Any]]:
+    result = []
+    for node in nodes:
+        if _classify_node_type(node.get("type", "")) not in {"class", "property", "individual", "concept", "scheme"}:
             continue
         if ontology_uri and not _node_belongs_to_ontology(node, ontology_uri):
             continue
@@ -2093,13 +2104,48 @@ async def ontology_health(
 
     documentation_score = ((with_comment / total) * 80.0) + (20.0 if entry.version or entry.source_url else 0.0)
 
-    shacl_dimension = HealthDimension(
-        key="shacl",
-        label="SHACL Conformance",
-        score=0.0,
-        status="unavailable",
-        detail="Live SHACL validation is available in SHACL Studio when optional validation dependencies are installed.",
-    )
+    try:
+        shacl_turtle, _ = await _generated_shacl_for_uri(request, session, uri)
+        data_graph_turtle = await _data_graph_turtle_for_uri(request, session, uri)
+        from ...ontology import OntologyEngine
+        engine = OntologyEngine()
+        report = await asyncio.to_thread(
+            engine.validate_graph,
+            data_graph_turtle,
+            shacl=shacl_turtle,
+            data_graph_format="turtle",
+            shacl_format="turtle",
+        )
+        shacl_score = 100.0 if report.conforms else max(0.0, 100.0 - (report.violation_count * 20.0))
+        shacl_status = "ok" if report.conforms else "warning"
+        shacl_detail = (
+            "Graph conforms to all generated SHACL constraints."
+            if report.conforms
+            else f"Graph has {report.violation_count} SHACL violation(s)."
+        )
+        shacl_dimension = HealthDimension(
+            key="shacl",
+            label="SHACL Conformance",
+            score=round(shacl_score, 1),
+            status=shacl_status,
+            detail=shacl_detail,
+        )
+    except ImportError:
+        shacl_dimension = HealthDimension(
+            key="shacl",
+            label="SHACL Conformance",
+            score=0.0,
+            status="unavailable",
+            detail="Live SHACL validation is available in SHACL Studio when optional validation dependencies are installed.",
+        )
+    except Exception as exc:
+        shacl_dimension = HealthDimension(
+            key="shacl",
+            label="SHACL Conformance",
+            score=0.0,
+            status="critical",
+            detail=f"Live SHACL validation failed: {exc}",
+        )
 
     dimensions = [
         HealthDimension(
@@ -2178,6 +2224,172 @@ async def _generated_shacl_for_uri(
     return shacl_turtle, _summarize_shapes(shacl_turtle)
 
 
+async def _data_graph_turtle_for_uri(
+    request: Request,
+    session: GraphSession,
+    uri: str,
+) -> str:
+    try:
+        import rdflib
+    except ImportError as exc:
+        raise ImportError("rdflib is not installed.") from exc
+
+    registry = {entry.uri: entry for entry in await _registry_entries(request, session)}
+    if uri not in registry:
+        raise HTTPException(status_code=404, detail="Ontology not found in registry.")
+
+    nodes, _ = await asyncio.to_thread(session.get_nodes, skip=0, limit=_MAX_ANALYSIS_NODES)
+    edges, _ = await asyncio.to_thread(session.get_edges, skip=0, limit=_MAX_ANALYSIS_NODES)
+    entities = _data_graph_entities(nodes, uri)
+
+    g = rdflib.Graph()
+    base_namespace = _extract_namespace(uri) or (uri.rstrip("#/") + "#")
+
+    OWL = rdflib.Namespace("http://www.w3.org/2002/07/owl#")
+    RDF = rdflib.RDF
+    RDFS = rdflib.RDFS
+    SKOS = rdflib.Namespace("http://www.w3.org/2004/02/skos/core#")
+    DCT = rdflib.Namespace("http://purl.org/dc/terms/")
+    DC = rdflib.Namespace("http://purl.org/dc/elements/1.1/")
+    SH = rdflib.Namespace("http://www.w3.org/ns/shacl#")
+    XSD = rdflib.XSD
+    ONTO = rdflib.Namespace(base_namespace)
+
+    g.bind("owl", OWL)
+    g.bind("rdf", RDF)
+    g.bind("rdfs", RDFS)
+    g.bind("skos", SKOS)
+    g.bind("dct", DCT)
+    g.bind("dc", DC)
+    g.bind("sh", SH)
+    g.bind("xsd", XSD)
+    g.bind("onto", ONTO)
+
+    def _resolve_uri(val: str, base_ns: str) -> rdflib.URIRef:
+        val_str = str(val).strip()
+        if val_str == "a":
+            return rdflib.RDF.type
+        if val_str.startswith(("http://", "https://", "urn:", "ftp://")):
+            return rdflib.URIRef(val_str)
+        prefix_map = {
+            "owl": "http://www.w3.org/2002/07/owl#",
+            "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+            "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+            "skos": "http://www.w3.org/2004/02/skos/core#",
+            "dct": "http://purl.org/dc/terms/",
+            "dc": "http://purl.org/dc/elements/1.1/",
+            "sh": "http://www.w3.org/ns/shacl#",
+            "xsd": "http://www.w3.org/2001/XMLSchema#",
+        }
+        if ":" in val_str and not val_str.startswith("/"):
+            prefix, _, rest = val_str.partition(":")
+            if prefix in prefix_map:
+                return rdflib.URIRef(prefix_map[prefix] + rest)
+        if val_str.startswith("#"):
+            return rdflib.URIRef(base_ns.rstrip("#/") + val_str)
+        return rdflib.URIRef(base_ns.rstrip("#/") + "#" + val_str.lstrip("#/"))
+
+    _shorthand_types = {
+        "class": "owl:Class",
+        "object_property": "owl:ObjectProperty",
+        "datatype_property": "owl:DatatypeProperty",
+        "annotation_property": "owl:AnnotationProperty",
+        "property": "rdf:Property",
+        "individual": "owl:NamedIndividual",
+        "concept": "skos:Concept",
+        "scheme": "skos:ConceptScheme",
+        "ontology": "owl:Ontology",
+    }
+    _uri_predicates = {
+        "rdf:type",
+        "a",
+        "rdfs:subClassOf",
+        "rdfs:domain",
+        "rdfs:range",
+        "owl:equivalentClass",
+        "owl:equivalentProperty",
+        "owl:sameAs",
+        "skos:exactMatch",
+        "skos:closeMatch",
+        "skos:broadMatch",
+        "skos:narrowMatch",
+        "skos:relatedMatch",
+        "sh:targetClass",
+        "sh:targetNode",
+    }
+    _literal_predicates = {
+        "rdfs:label",
+        "rdfs:comment",
+        "skos:definition",
+        "skos:prefLabel",
+        "skos:altLabel",
+        "dct:description",
+        "dct:title",
+        "dc:title",
+        "dc:description",
+        "version",
+    }
+    _skip_keys = {
+        "id",
+        "type",
+        "content",
+        "valid_from",
+        "valid_until",
+        "scheme_uri",
+        "ontology_uri",
+        "ontology",
+    }
+
+    entity_ids = set()
+    for node in entities:
+        nid_str = str(node.get("id", "")).strip()
+        if not nid_str:
+            continue
+        entity_ids.add(nid_str)
+        subj = _resolve_uri(nid_str, base_namespace)
+
+        node_type = node.get("type", "")
+        if node_type:
+            for t in _as_uri_list(node_type):
+                t_mapped = _shorthand_types.get(str(t).lower(), str(t))
+                g.add((subj, rdflib.RDF.type, _resolve_uri(t_mapped, base_namespace)))
+
+        content = str(node.get("content", "")).strip()
+        props = node.get("properties", {}) or {}
+        if content and "rdfs:label" not in props and "pref_label" not in props and "label" not in props:
+            g.add((subj, RDFS.label, rdflib.Literal(content)))
+
+        for key, val in props.items():
+            if key in _skip_keys or val is None or val == "":
+                continue
+            pred = _resolve_uri(str(key), base_namespace)
+            for item in _as_uri_list(val) if isinstance(val, (list, dict)) else [val]:
+                if item is None or item == "":
+                    continue
+                if str(key) in _uri_predicates or (
+                    str(key) not in _literal_predicates
+                    and str(item).strip().startswith(("http://", "https://", "urn:"))
+                ):
+                    g.add((subj, pred, _resolve_uri(str(item), base_namespace)))
+                else:
+                    g.add((subj, pred, rdflib.Literal(str(item))))
+
+    for edge in edges:
+        source = str(edge.get("source", edge.get("source_id", ""))).strip()
+        target = str(edge.get("target", edge.get("target_id", ""))).strip()
+        pred_str = str(edge.get("type", "related_to")).strip()
+        if not source or not target:
+            continue
+        if source in entity_ids or target in entity_ids:
+            g.add((
+                _resolve_uri(source, base_namespace),
+                _resolve_uri(pred_str, base_namespace),
+                _resolve_uri(target, base_namespace),
+            ))
+
+    return await asyncio.to_thread(g.serialize, format="turtle")
+
+
 @router.post("/shacl/generate", response_model=ShaclGenerateResponse)
 async def generate_shacl(
     request: Request,
@@ -2209,7 +2421,11 @@ async def list_shacl_shapes(
 
 
 @router.post("/shacl/validate", response_model=ShaclValidationResponse)
-async def validate_shacl(body: ShaclValidateRequest):
+async def validate_shacl(
+    request: Request,
+    body: ShaclValidateRequest,
+    session: GraphSession = Depends(get_session),
+):
     if not body.shacl_turtle.strip():
         raise HTTPException(status_code=422, detail="SHACL Turtle cannot be empty.")
 
@@ -2226,17 +2442,79 @@ async def validate_shacl(body: ShaclValidateRequest):
             detail=f"Invalid Turtle syntax: {exc}",
         ) from exc
 
-    # Live data-graph validation requires pySHACL wired to OntologyEngine.validate_graph().
+    if not body.uri:
+        return ShaclValidationResponse(
+            uri=body.uri,
+            conforms=False,
+            status="unavailable",
+            message=(
+                "Turtle parsed successfully. "
+                "No target ontology URI was provided — "
+                "specify 'uri' to execute live SHACL validation against an ontology data graph."
+            ),
+            violations=[],
+        )
+
+    try:
+        data_graph_turtle = await _data_graph_turtle_for_uri(request, session, body.uri)
+        from ...ontology import OntologyEngine
+        engine = OntologyEngine()
+        report = await asyncio.to_thread(
+            engine.validate_graph,
+            data_graph_turtle,
+            shacl=body.shacl_turtle,
+            data_graph_format="turtle",
+            shacl_format="turtle",
+        )
+    except ImportError as exc:
+        return ShaclValidationResponse(
+            uri=body.uri,
+            conforms=False,
+            status="unavailable",
+            message=(
+                "Turtle parsed successfully. "
+                f"Live SHACL validation is unavailable: {exc}"
+            ),
+            violations=[],
+        )
+    except HTTPException:
+        raise
+    except Exception as exc:
+        return ShaclValidationResponse(
+            uri=body.uri,
+            conforms=False,
+            status="error",
+            message=f"SHACL validation error: {exc}",
+            violations=[],
+        )
+
+    violations = [
+        ShaclViolation(
+            node=str(v.focus_node) if v.focus_node is not None else None,
+            path=str(v.result_path) if v.result_path is not None else None,
+            severity=str(v.severity or "Violation"),
+            message=str(
+                v.message
+                or v.explanation
+                or f"SHACL constraint violation ({v.constraint}) on {v.focus_node}"
+            ),
+            focus_node=str(v.focus_node) if v.focus_node is not None else None,
+            source_shape=str(v.shape) if v.shape is not None else None,
+        )
+        for v in report.violations
+    ]
+    summary_msg = (
+        "Graph conforms to SHACL shapes."
+        if report.conforms
+        else f"SHACL validation found {len(violations)} violation(s)."
+    )
     return ShaclValidationResponse(
         uri=body.uri,
-        conforms=False,
-        status="unavailable",
-        message=(
-            "Turtle parsed successfully. "
-            "Live graph validation is not yet wired to a data graph — "
-            "install semantica[shacl] and connect OntologyEngine.validate_graph() to enable full validation."
-        ),
-        violations=[],
+        conforms=report.conforms,
+        status="success",
+        message=summary_msg,
+        violations=violations,
+        report_text=report.raw_report,
     )
 
 

--- a/semantica/explorer/routes/ontology.py
+++ b/semantica/explorer/routes/ontology.py
@@ -670,6 +670,14 @@ def _extract_namespace(uri: str) -> Optional[str]:
     return None
 
 
+def _ontology_namespace(uri: str) -> str:
+    if "#" in uri:
+        return uri.rsplit("#", 1)[0] + "#"
+    if uri.endswith("/"):
+        return uri
+    return uri.rstrip("#/") + "#"
+
+
 def _alignment_id(source_uri: str, relation: str, target_uri: str) -> str:
     key = f"{source_uri}|{relation}|{target_uri}"
     return str(uuid.uuid5(uuid.NAMESPACE_OID, key))
@@ -831,14 +839,14 @@ def _ontology_dict_from_nodes(uri: str, name: str, nodes: List[Dict[str, Any]], 
 
     return {
         "name": name,
-        "namespace": _extract_namespace(uri) or uri.rstrip("#/") + "#",
+        "namespace": _ontology_namespace(uri),
         "classes": classes,
         "properties": properties,
     }
 
 
 def _basic_shacl_turtle(uri: str, name: str, nodes: List[Dict[str, Any]]) -> str:
-    namespace = _extract_namespace(uri) or uri.rstrip("#/") + "#"
+    namespace = _ontology_namespace(uri)
     lines = [
         "@prefix sh: <http://www.w3.org/ns/shacl#> .",
         "@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .",
@@ -2243,7 +2251,7 @@ async def _data_graph_turtle_for_uri(
     entities = _data_graph_entities(nodes, uri)
 
     g = rdflib.Graph()
-    base_namespace = _extract_namespace(uri) or (uri.rstrip("#/") + "#")
+    base_namespace = _ontology_namespace(uri)
 
     OWL = rdflib.Namespace("http://www.w3.org/2002/07/owl#")
     RDF = rdflib.RDF
@@ -2280,11 +2288,13 @@ async def _data_graph_turtle_for_uri(
             "dc": "http://purl.org/dc/elements/1.1/",
             "sh": "http://www.w3.org/ns/shacl#",
             "xsd": "http://www.w3.org/2001/XMLSchema#",
+            "onto": base_ns,
         }
         if ":" in val_str and not val_str.startswith("/"):
             prefix, _, rest = val_str.partition(":")
             if prefix in prefix_map:
                 return rdflib.URIRef(prefix_map[prefix] + rest)
+            return rdflib.URIRef(val_str)
         if val_str.startswith("#"):
             return rdflib.URIRef(base_ns.rstrip("#/") + val_str)
         return rdflib.URIRef(base_ns.rstrip("#/") + "#" + val_str.lstrip("#/"))

--- a/tests/context/test_agent_memory_markdown.py
+++ b/tests/context/test_agent_memory_markdown.py
@@ -13,6 +13,7 @@ class TrackingVectorStore:
         self.items = {}
         self.events = []
         self.fail_after_add = False
+        self.fail_on_delete = False
 
     def add(self, items):
         memory_ids = []
@@ -25,6 +26,8 @@ class TrackingVectorStore:
         return memory_ids
 
     def delete(self, memory_ids):
+        if getattr(self, "fail_on_delete", False):
+            raise RuntimeError("vector delete failed")
         self.events.append(("delete", list(memory_ids)))
         for memory_id in memory_ids:
             self.items.pop(memory_id, None)
@@ -684,3 +687,47 @@ def test_markdown_export_destination_must_be_a_directory(tmp_path):
 
     with pytest.raises(ValueError, match="not a directory"):
         AgentMemory().export(format="markdown", destination=destination)
+
+
+def test_retention_policy_deletes_vector_even_when_current_store_skips_vector():
+    vector_store = TrackingVectorStore()
+    memory = AgentMemory(retention_policy="1_days", vector_store=vector_store)
+
+    memory.store(
+        "Old content",
+        metadata={"type": "note"},
+        memory_id="mem_old",
+        timestamp=datetime.now(),
+    )
+    assert "mem_old" in vector_store.items
+
+    # Simulate 5 days passing since mem_old was stored
+    memory.memory_items["mem_old"].timestamp = datetime.now() - timedelta(days=5)
+
+    memory.store(
+        "New short term content",
+        metadata={"type": "note"},
+        memory_id="mem_new",
+        timestamp=datetime.now(),
+        skip_vector=True,
+    )
+
+    assert not memory.exists("mem_old")
+    assert "mem_old" not in vector_store.items
+
+
+def test_delete_memory_retains_vector_ids_when_vector_deletion_fails():
+    vector_store = TrackingVectorStore()
+    memory = AgentMemory(vector_store=vector_store)
+
+    memory.store(
+        "Content to be deleted",
+        metadata={"type": "note"},
+        memory_id="mem_fail_delete",
+    )
+    assert "mem_fail_delete" in memory._vector_ids
+
+    vector_store.fail_on_delete = True
+    memory.delete_memory("mem_fail_delete")
+
+    assert "mem_fail_delete" in memory._vector_ids

--- a/tests/context/test_agent_memory_markdown.py
+++ b/tests/context/test_agent_memory_markdown.py
@@ -632,6 +632,10 @@ def test_exported_filenames_cannot_escape_or_collide_with_destination(tmp_path):
     assert not (tmp_path / "outside.md").exists()
 
 
+@pytest.mark.skipif(
+    __import__("sys").platform == "win32",
+    reason="Symlink creation on Windows requires elevated privileges or Developer Mode",
+)
 def test_markdown_export_rejects_symlink_without_touching_target(tmp_path):
     memory = AgentMemory()
     memory.store(

--- a/tests/context/test_agent_memory_markdown.py
+++ b/tests/context/test_agent_memory_markdown.py
@@ -1,11 +1,50 @@
 from copy import deepcopy
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, patch
 
 import pytest
 import yaml
 
 from semantica.context.agent_memory import AgentMemory
+
+
+class TrackingVectorStore:
+    def __init__(self):
+        self.items = {}
+        self.events = []
+        self.fail_after_add = False
+
+    def add(self, items):
+        memory_ids = []
+        for item in items:
+            self.items[item.memory_id] = deepcopy(item)
+            memory_ids.append(item.memory_id)
+        self.events.append(("add", memory_ids))
+        if self.fail_after_add:
+            raise RuntimeError("vector add failed after mutation")
+        return memory_ids
+
+    def delete(self, memory_ids):
+        self.events.append(("delete", list(memory_ids)))
+        for memory_id in memory_ids:
+            self.items.pop(memory_id, None)
+        return True
+
+
+class TrackingConcreteVectorStore:
+    def __init__(self):
+        self.events = []
+        self.next_id = 0
+
+    def store_vectors(self, vectors, metadata):
+        vector_id = f"vec_{self.next_id}"
+        self.next_id += 1
+        self.events.append(("store", vector_id))
+        return [vector_id]
+
+    def delete_vectors(self, vector_ids):
+        self.events.append(("delete", list(vector_ids)))
+        return True
 
 
 def markdown_document(frontmatter, body=""):
@@ -168,6 +207,38 @@ def test_public_update_preserves_id_and_statistics():
     assert list(memory.memory_index) == ["mem_update"]
     assert memory.stats["total_items"] == 1
     assert memory.stats["items_by_type"] == {"decision": 1}
+
+
+def test_reusing_custom_id_replaces_item_without_statistics_drift():
+    vector_store = TrackingVectorStore()
+    memory = AgentMemory(vector_store=vector_store)
+    memory.store(
+        "Original",
+        metadata={"type": "note"},
+        memory_id="mem_reused",
+        timestamp=datetime(2026, 7, 22, 9, 0, 0),
+    )
+
+    vector_store.events.clear()
+    memory.store(
+        "Replacement",
+        metadata={"type": "decision"},
+        memory_id="mem_reused",
+        timestamp=datetime(2026, 7, 22, 10, 0, 0),
+    )
+
+    assert memory.get("mem_reused")["content"] == "Replacement"
+    assert list(memory.memory_index) == ["mem_reused"]
+    assert [item.memory_id for item in memory.short_term_memory] == ["mem_reused"]
+    assert memory.stats["total_items"] == 1
+    assert memory.stats["items_by_type"] == {"decision": 1}
+    assert vector_store.items["mem_reused"].content == "Replacement"
+    assert vector_store.events == [("add", ["mem_reused"])]
+
+    assert memory.delete_memory("mem_reused")
+    assert memory.stats["total_items"] == 0
+    assert memory.stats["items_by_type"] == {}
+    assert vector_store.items == {}
 
 
 def test_reimporting_unchanged_markdown_does_not_rewrite_memory():
@@ -333,6 +404,132 @@ def test_operational_failure_restores_existing_in_memory_state():
     assert [item.memory_id for item in memory.short_term_memory] == ["mem_existing"]
 
 
+def test_failed_markdown_update_does_not_mutate_vector_store_before_rollback():
+    vector_store = TrackingVectorStore()
+    memory = AgentMemory(vector_store=vector_store)
+    memory.store(
+        "Original",
+        metadata={"type": "note"},
+        memory_id="mem_existing",
+        timestamp=datetime(2026, 7, 22, 9, 0, 0),
+    )
+    vector_store.events.clear()
+    original_store = memory.store
+
+    def fail_after_local_store(*args, **kwargs):
+        original_store(*args, **kwargs)
+        raise RuntimeError("local store failed")
+
+    with patch.object(memory, "store", side_effect=fail_after_local_store):
+        with pytest.raises(RuntimeError, match="local store failed"):
+            memory.import_data(
+                markdown_document(required_frontmatter("mem_existing"), "Replacement"),
+                format="markdown",
+            )
+
+    assert memory.get("mem_existing")["content"] == "Original"
+    assert vector_store.items["mem_existing"].content == "Original"
+    assert vector_store.events == []
+
+
+def test_vector_sync_runs_after_markdown_commit_and_never_triggers_rollback():
+    vector_store = TrackingVectorStore()
+    memory = AgentMemory(vector_store=vector_store)
+    memory.store(
+        "Original",
+        metadata={"type": "note"},
+        memory_id="mem_existing",
+        timestamp=datetime(2026, 7, 22, 9, 0, 0),
+    )
+    vector_store.events.clear()
+    vector_store.fail_after_add = True
+
+    assert (
+        memory.import_data(
+            markdown_document(required_frontmatter("mem_existing"), "Replacement"),
+            format="markdown",
+        )
+        == 1
+    )
+
+    assert memory.get("mem_existing")["content"] == "Replacement"
+    assert vector_store.items["mem_existing"].content == "Replacement"
+    assert vector_store.events == [("add", ["mem_existing"])]
+
+
+def test_markdown_update_replaces_concrete_adapter_vector_id_after_commit():
+    vector_store = TrackingConcreteVectorStore()
+    memory = AgentMemory(vector_store=vector_store)
+    memory.store(
+        "Original",
+        metadata={"type": "note"},
+        memory_id="mem_existing",
+        timestamp=datetime(2026, 7, 22, 9, 0, 0),
+    )
+    assert memory._vector_ids == {"mem_existing": ["vec_0"]}
+    vector_store.events.clear()
+
+    assert (
+        memory.import_data(
+            markdown_document(required_frontmatter("mem_existing"), "Replacement"),
+            format="markdown",
+        )
+        == 1
+    )
+
+    assert memory._vector_ids == {"mem_existing": ["vec_1"]}
+    assert vector_store.events == [("store", "vec_1"), ("delete", ["vec_0"])]
+
+
+def test_vector_id_mapping_survives_save_and_load(tmp_path):
+    vector_store = TrackingConcreteVectorStore()
+    memory = AgentMemory(vector_store=vector_store)
+    memory.store(
+        "Persisted",
+        metadata={"type": "note"},
+        memory_id="mem_persisted",
+    )
+    memory.save(str(tmp_path))
+
+    restored = AgentMemory(vector_store=vector_store)
+    restored.load(str(tmp_path))
+    vector_store.events.clear()
+
+    assert restored._vector_ids == {"mem_persisted": ["vec_0"]}
+    assert restored.delete_memory("mem_persisted")
+    assert vector_store.events == [("delete", ["vec_0"])]
+
+
+def test_failed_multi_file_import_never_starts_vector_synchronization(tmp_path):
+    vector_store = TrackingVectorStore()
+    memory = AgentMemory(vector_store=vector_store)
+    for name in ("a-first.md", "b-second.md"):
+        memory_id = name[:-3]
+        (tmp_path / name).write_text(
+            markdown_document(required_frontmatter(memory_id), name),
+            encoding="utf-8",
+        )
+
+    original_store = memory.store
+    calls = 0
+
+    def fail_on_second_store(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        stored_id = original_store(*args, **kwargs)
+        if calls == 2:
+            raise RuntimeError("second local store failed")
+        return stored_id
+
+    with patch.object(memory, "store", side_effect=fail_on_second_store):
+        with pytest.raises(RuntimeError, match="second local store failed"):
+            memory.import_data(tmp_path, format="markdown")
+
+    assert memory.count() == 0
+    assert vector_store.events == []
+    assert vector_store.items == {}
+
+
 def test_import_does_not_report_retention_pruned_memory_as_successful():
     memory = AgentMemory(retention_policy="1_days")
     fields = required_frontmatter(
@@ -346,6 +543,44 @@ def test_import_does_not_report_retention_pruned_memory_as_successful():
 
     assert memory.count() == 0
     assert memory.stats["total_items"] == 0
+
+
+def test_timezone_aware_import_supports_retention_sorting_and_date_filters():
+    now_utc = datetime.now(timezone.utc)
+    memory = AgentMemory(retention_policy="1_days")
+    memory.store(
+        "Naive memory",
+        metadata={"type": "note"},
+        memory_id="mem_naive",
+        timestamp=datetime.now(),
+    )
+    fields = required_frontmatter(
+        "mem_aware",
+        created_at=now_utc.isoformat(),
+        updated_at=now_utc.isoformat(),
+    )
+
+    assert (
+        memory.import_data(markdown_document(fields, "Aware memory"), "markdown") == 1
+    )
+    assert memory.get("mem_aware")["timestamp"].endswith("+00:00")
+    assert {item["memory_id"] for item in memory.get_recent()} == {
+        "mem_naive",
+        "mem_aware",
+    }
+
+    start = now_utc - timedelta(hours=1)
+    end = now_utc + timedelta(hours=1)
+    assert {item["memory_id"] for item in memory.get_by_date(start, end)} == {
+        "mem_naive",
+        "mem_aware",
+    }
+    assert {
+        item["memory_id"]
+        for item in memory.retrieve(
+            "memory", start_date=start.isoformat(), end_date=end.isoformat()
+        )
+    } == {"mem_naive", "mem_aware"}
 
 
 def test_exported_filenames_cannot_escape_or_collide_with_destination(tmp_path):
@@ -369,6 +604,28 @@ def test_exported_filenames_cannot_escape_or_collide_with_destination(tmp_path):
     assert len({path.name.casefold() for path in exported_files}) == 4
     assert all(path.parent == destination for path in exported_files)
     assert not (tmp_path / "outside.md").exists()
+
+
+def test_markdown_export_rejects_symlink_without_touching_target(tmp_path):
+    memory = AgentMemory()
+    memory.store(
+        "Protected content",
+        metadata={"type": "note", "updated_at": "2026-07-22T10:00:00"},
+        memory_id="mem_symlink",
+        timestamp=datetime(2026, 7, 22, 9, 0, 0),
+    )
+    destination = tmp_path / "export"
+    destination.mkdir()
+    outside = tmp_path / "outside.md"
+    outside.write_text("do not overwrite", encoding="utf-8")
+    output_path = destination / memory._memory_markdown_filename("mem_symlink")
+    output_path.symlink_to(outside)
+
+    with pytest.raises(ValueError, match="symbolic link"):
+        memory.export(format="markdown", destination=destination)
+
+    assert output_path.is_symlink()
+    assert outside.read_text(encoding="utf-8") == "do not overwrite"
 
 
 def test_empty_markdown_export_and_import_are_no_ops():

--- a/tests/context/test_agent_memory_markdown.py
+++ b/tests/context/test_agent_memory_markdown.py
@@ -257,6 +257,29 @@ def test_reimporting_unchanged_markdown_does_not_rewrite_memory():
     assert memory.count() == 1
 
 
+def test_naive_and_aware_equivalent_timestamps_match_idempotently():
+    memory = AgentMemory()
+    utc_dt = datetime(2026, 7, 22, 9, 0, 0, tzinfo=timezone.utc)
+    naive_dt = utc_dt.astimezone().replace(tzinfo=None)
+    memory.store(
+        "Unchanged",
+        metadata={"type": "note", "updated_at": "2026-07-22T10:00:00+00:00"},
+        memory_id="mem_test",
+        timestamp=naive_dt,
+    )
+    document = markdown_document(
+        required_frontmatter("mem_test", created_at="2026-07-22T09:00:00+00:00"),
+        "Unchanged",
+    )
+
+    with patch.object(
+        memory, "_replace_memory_item", wraps=memory._replace_memory_item
+    ) as replace:
+        assert memory.import_data(document, format="markdown") == 1
+
+    replace.assert_not_called()
+
+
 def test_kind_is_accepted_as_the_type_alias():
     frontmatter = required_frontmatter()
     frontmatter["kind"] = frontmatter.pop("type")

--- a/tests/context/test_agent_memory_markdown.py
+++ b/tests/context/test_agent_memory_markdown.py
@@ -1,0 +1,406 @@
+from copy import deepcopy
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+import yaml
+
+from semantica.context.agent_memory import AgentMemory
+
+
+def markdown_document(frontmatter, body=""):
+    yaml_text = yaml.safe_dump(frontmatter, sort_keys=False, allow_unicode=True)
+    return f"---\n{yaml_text}---\n\n{body}"
+
+
+def required_frontmatter(memory_id="mem_test", **overrides):
+    frontmatter = {
+        "id": memory_id,
+        "created_at": "2026-07-22T09:00:00+00:00",
+        "updated_at": "2026-07-22T10:00:00+00:00",
+        "type": "note",
+    }
+    frontmatter.update(overrides)
+    return frontmatter
+
+
+def test_markdown_round_trip_is_lossless_and_deterministic():
+    memory = AgentMemory()
+    content = "\n# Editable memory\n\n<!-- marker-like body text -->\n\n"
+    memory.store(
+        content,
+        metadata={
+            "type": "note",
+            "updated_at": "2026-07-22T12:30:00+00:00",
+            "source": "caf\u00e9 review",
+            "tags": ["alpha", "beta"],
+            "id": "metadata-id",
+            "kind": "metadata-kind",
+        },
+        entities=[{"id": "ent_1", "type": "topic", "text": "Memory"}],
+        relationships=[
+            {
+                "source_id": "ent_1",
+                "target_id": "ent_2",
+                "type": "related_to",
+                "confidence": 0.9,
+            }
+        ],
+        memory_id="mem_round_trip",
+        timestamp=datetime.fromisoformat("2026-07-22T12:00:00+00:00"),
+    )
+
+    exported = memory.export(format="markdown")
+    restored = AgentMemory()
+
+    assert restored.import_data(exported, format="markdown") == 1
+    assert restored.get("mem_round_trip") == memory.get("mem_round_trip")
+    assert restored.export(format="markdown") == exported
+    assert "caf\u00e9 review" in exported
+
+
+def test_markdown_directory_round_trip_uses_one_stable_file_per_memory(tmp_path):
+    memory = AgentMemory()
+    for index in range(2):
+        timestamp = f"2026-07-22T0{index + 8}:00:00"
+        memory.store(
+            f"Memory {index}",
+            metadata={
+                "type": "reference",
+                "updated_at": timestamp,
+                "source": f"source-{index}",
+            },
+            memory_id=f"mem_{index}",
+            timestamp=datetime.fromisoformat(timestamp),
+        )
+
+    first_export = tmp_path / "first"
+    assert memory.export(format="markdown", destination=first_export) == str(
+        first_export
+    )
+    first_files = sorted(first_export.glob("*.md"))
+    assert len(first_files) == 2
+
+    restored = AgentMemory()
+    assert restored.import_data(first_export, format="markdown") == 2
+    assert set(restored.memory_items) == {"mem_0", "mem_1"}
+
+    second_export = tmp_path / "second"
+    restored.export(format="markdown", destination=second_export)
+    assert {path.name: path.read_text(encoding="utf-8") for path in first_files} == {
+        path.name: path.read_text(encoding="utf-8")
+        for path in sorted(second_export.glob("*.md"))
+    }
+
+
+def test_multiple_memories_require_a_destination_but_filters_can_select_one():
+    memory = AgentMemory()
+    for memory_type in ("note", "reference"):
+        memory.store(
+            memory_type,
+            metadata={
+                "type": memory_type,
+                "updated_at": "2026-07-22T10:00:00",
+            },
+            memory_id=f"mem_{memory_type}",
+            timestamp=datetime(2026, 7, 22, 9, 0, 0),
+        )
+
+    with pytest.raises(ValueError, match="destination"):
+        memory.export(format="markdown")
+
+    exported = memory.export(format="markdown", type="note")
+    assert "id: mem_note" in exported
+    assert "id: mem_reference" not in exported
+
+
+def test_markdown_update_replaces_supported_fields_and_preserves_id():
+    memory = AgentMemory()
+    memory.store(
+        "Original content",
+        metadata={
+            "type": "note",
+            "updated_at": "2026-07-22T09:30:00",
+            "remove_me": True,
+        },
+        memory_id="mem_existing",
+        timestamp=datetime(2026, 7, 22, 9, 0, 0),
+    )
+    edited = markdown_document(
+        required_frontmatter(
+            "mem_existing",
+            created_at="2026-07-22T09:15:00",
+            updated_at="2026-07-22T11:00:00",
+            type="decision",
+            source="manual edit",
+        ),
+        "Updated content",
+    )
+
+    assert memory.import_data(edited, format="markdown") == 1
+
+    updated = memory.get("mem_existing")
+    assert memory.count() == 1
+    assert updated["memory_id"] == "mem_existing"
+    assert updated["content"] == "Updated content"
+    assert updated["timestamp"] == "2026-07-22T09:15:00"
+    assert updated["metadata"] == {
+        "type": "decision",
+        "source": "manual edit",
+        "updated_at": "2026-07-22T11:00:00",
+    }
+    assert memory.stats["items_by_type"] == {"decision": 1}
+    assert [item.memory_id for item in memory.short_term_memory] == ["mem_existing"]
+
+
+def test_public_update_preserves_id_and_statistics():
+    memory = AgentMemory()
+    memory.store(
+        "Original",
+        metadata={"type": "note"},
+        memory_id="mem_update",
+        timestamp=datetime(2026, 7, 22, 9, 0, 0),
+    )
+
+    assert memory.update("mem_update", content="Updated", metadata={"type": "decision"})
+    assert memory.get("mem_update")["content"] == "Updated"
+    assert set(memory.memory_items) == {"mem_update"}
+    assert list(memory.memory_index) == ["mem_update"]
+    assert memory.stats["total_items"] == 1
+    assert memory.stats["items_by_type"] == {"decision": 1}
+
+
+def test_reimporting_unchanged_markdown_does_not_rewrite_memory():
+    memory = AgentMemory()
+    document = markdown_document(required_frontmatter(), "Unchanged")
+    assert memory.import_data(document, format="markdown") == 1
+    before = memory.get("mem_test")
+
+    with patch.object(
+        memory, "_replace_memory_item", wraps=memory._replace_memory_item
+    ) as replace:
+        assert memory.import_data(document, format="markdown") == 1
+
+    replace.assert_not_called()
+    assert memory.get("mem_test") == before
+    assert memory.count() == 1
+
+
+def test_kind_is_accepted_as_the_type_alias():
+    frontmatter = required_frontmatter()
+    frontmatter["kind"] = frontmatter.pop("type")
+
+    memory = AgentMemory()
+    assert (
+        memory.import_data(
+            markdown_document(frontmatter, "Kind alias"), format="markdown"
+        )
+        == 1
+    )
+    assert memory.get("mem_test")["metadata"]["type"] == "note"
+
+
+@pytest.mark.parametrize("missing_field", ["id", "created_at", "updated_at", "type"])
+def test_required_frontmatter_fields_are_enforced(missing_field):
+    frontmatter = required_frontmatter()
+    frontmatter.pop(missing_field)
+
+    with pytest.raises(ValueError, match="missing required"):
+        AgentMemory().import_data(
+            markdown_document(frontmatter, "Invalid"), format="markdown"
+        )
+
+
+@pytest.mark.parametrize(
+    ("overrides", "message"),
+    [
+        ({"id": 123}, "'id' must be a string"),
+        ({"created_at": "yesterday"}, "ISO-8601"),
+        ({"updated_at": "later"}, "ISO-8601"),
+        ({"type": ["note"]}, "must be a string"),
+        ({"kind": "decision"}, "must match"),
+        ({"metadata": []}, "must be a mapping"),
+        ({"entities": {}}, "must be a list"),
+        ({"entities": ["entity"]}, "must be a mapping"),
+        ({"relationships": [1]}, "must be a mapping"),
+        ({"metadata": {"type": "nested"}}, "duplicates reserved"),
+        ({"metadata": {"source": "nested"}, "source": "top"}, "defined both"),
+    ],
+)
+def test_invalid_frontmatter_values_return_actionable_errors(overrides, message):
+    document = markdown_document(required_frontmatter(**overrides), "Invalid")
+
+    with pytest.raises(ValueError, match=message):
+        AgentMemory().import_data(document, format="markdown")
+
+
+@pytest.mark.parametrize(
+    "document",
+    [
+        "not frontmatter",
+        "---\nid: broken",
+        "---\nid: [unterminated\n---\n",
+        (
+            "---\nid: first\nid: second\ncreated_at: 2026-07-22T09:00:00\n"
+            "updated_at: 2026-07-22T10:00:00\ntype: note\n---\n"
+        ),
+    ],
+)
+def test_malformed_frontmatter_is_rejected(document):
+    with pytest.raises(ValueError, match="frontmatter"):
+        AgentMemory().import_data(document, format="markdown")
+
+
+def test_directory_is_fully_validated_before_any_memory_is_changed(tmp_path):
+    valid = markdown_document(required_frontmatter("mem_valid"), "Valid")
+    invalid_fields = required_frontmatter("mem_invalid")
+    invalid_fields.pop("updated_at")
+    invalid = markdown_document(invalid_fields, "Invalid")
+    (tmp_path / "a-valid.md").write_text(valid, encoding="utf-8")
+    (tmp_path / "z-invalid.md").write_text(invalid, encoding="utf-8")
+
+    memory = AgentMemory()
+    with pytest.raises(ValueError, match="updated_at"):
+        memory.import_data(tmp_path, format="markdown")
+
+    assert memory.count() == 0
+
+
+def test_duplicate_ids_in_a_directory_are_rejected_before_import(tmp_path):
+    document = markdown_document(required_frontmatter("mem_duplicate"), "Body")
+    (tmp_path / "first.md").write_text(document, encoding="utf-8")
+    (tmp_path / "second.markdown").write_text(document, encoding="utf-8")
+
+    memory = AgentMemory()
+    with pytest.raises(ValueError, match="Duplicate Markdown memory ID"):
+        memory.import_data(tmp_path, format="markdown")
+
+    assert memory.count() == 0
+
+
+def test_markdown_import_keeps_provenance_out_of_the_context_graph():
+    knowledge_graph = MagicMock()
+    memory = AgentMemory(knowledge_graph=knowledge_graph)
+    fields = required_frontmatter(
+        entities=[{"id": "entity_1", "type": "topic"}],
+        relationships=[
+            {
+                "source_id": "entity_1",
+                "target_id": "entity_2",
+                "type": "related_to",
+            }
+        ],
+    )
+
+    assert (
+        memory.import_data(markdown_document(fields, "Provenance"), format="markdown")
+        == 1
+    )
+    assert memory.get("mem_test")["entities"][0]["id"] == "entity_1"
+    knowledge_graph.add_nodes.assert_not_called()
+    knowledge_graph.add_edges.assert_not_called()
+
+
+def test_operational_failure_restores_existing_in_memory_state():
+    memory = AgentMemory()
+    memory.store(
+        "Original",
+        metadata={
+            "type": "note",
+            "updated_at": "2026-07-22T09:30:00",
+        },
+        memory_id="mem_existing",
+        timestamp=datetime(2026, 7, 22, 9, 0, 0),
+    )
+    before_memory = deepcopy(memory.get("mem_existing"))
+    before_stats = deepcopy(memory.stats)
+    edited_fields = required_frontmatter("mem_existing")
+    original_store = memory.store
+
+    def fail_after_store(*args, **kwargs):
+        original_store(*args, **kwargs)
+        raise RuntimeError("store unavailable")
+
+    with patch.object(memory, "store", side_effect=fail_after_store):
+        with pytest.raises(RuntimeError, match="store unavailable"):
+            memory.import_data(
+                markdown_document(edited_fields, "Edited"), format="markdown"
+            )
+
+    assert memory.get("mem_existing") == before_memory
+    assert memory.stats == before_stats
+    assert list(memory.memory_index) == ["mem_existing"]
+    assert [item.memory_id for item in memory.short_term_memory] == ["mem_existing"]
+
+
+def test_import_does_not_report_retention_pruned_memory_as_successful():
+    memory = AgentMemory(retention_policy="1_days")
+    fields = required_frontmatter(
+        "mem_expired",
+        created_at="2000-01-01T00:00:00",
+        updated_at="2000-01-01T00:00:00",
+    )
+
+    with pytest.raises(RuntimeError, match="did not confirm"):
+        memory.import_data(markdown_document(fields, "Expired"), format="markdown")
+
+    assert memory.count() == 0
+    assert memory.stats["total_items"] == 0
+
+
+def test_exported_filenames_cannot_escape_or_collide_with_destination(tmp_path):
+    memory = AgentMemory()
+    for memory_id in ("../outside", "a/b", "a\\b", "A/B"):
+        memory.store(
+            memory_id,
+            metadata={
+                "type": "note",
+                "updated_at": "2026-07-22T10:00:00",
+            },
+            memory_id=memory_id,
+            timestamp=datetime(2026, 7, 22, 9, 0, 0),
+        )
+
+    destination = tmp_path / "export"
+    memory.export(format="markdown", destination=destination)
+    exported_files = list(destination.glob("*.md"))
+
+    assert len(exported_files) == 4
+    assert len({path.name.casefold() for path in exported_files}) == 4
+    assert all(path.parent == destination for path in exported_files)
+    assert not (tmp_path / "outside.md").exists()
+
+
+def test_empty_markdown_export_and_import_are_no_ops():
+    memory = AgentMemory()
+
+    assert memory.export(format="markdown") == ""
+    assert memory.import_data("", format="markdown") == 0
+
+
+def test_legacy_dict_import_behavior_is_unchanged():
+    memory = AgentMemory()
+    data = {
+        "memories": [
+            {
+                "memory_id": "source_id",
+                "content": "Legacy import",
+                "metadata": {"type": "note"},
+                "timestamp": "2000-01-01T00:00:00",
+            }
+        ]
+    }
+
+    assert memory.import_data(data, format="dict") == 1
+    assert not memory.exists("source_id")
+    imported = next(iter(memory.memory_items.values()))
+    assert imported.content == "Legacy import"
+    assert imported.metadata == {"type": "note"}
+
+
+def test_markdown_export_destination_must_be_a_directory(tmp_path):
+    destination = tmp_path / "memory.md"
+    destination.write_text("occupied", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="not a directory"):
+        AgentMemory().export(format="markdown", destination=destination)

--- a/tests/explorer/test_ontology_subissue3.py
+++ b/tests/explorer/test_ontology_subissue3.py
@@ -361,3 +361,39 @@ def test_health_shacl_dimension_degrades_gracefully_on_real_error(client):
     shacl_dim = next(d for d in payload["dimensions"] if d["key"] == "shacl")
     assert shacl_dim["status"] == "critical"
     assert "boom" in shacl_dim["detail"]
+
+
+@pytest.mark.asyncio
+async def test_data_graph_turtle_resolves_onto_prefix_and_unknown_curies(client):
+    from unittest.mock import MagicMock
+    from semantica.explorer.routes.ontology import _data_graph_turtle_for_uri
+
+    graph = client.app.state.session.graph
+    onto_uri = "http://example.org/onto-a"
+    person_a = "http://example.org/onto-a#Person"
+    person_inst = "http://example.org/onto-a#person-with-name"
+    graph.add_node(
+        person_inst,
+        node_type="owl:NamedIndividual",
+        content="Person With Name",
+        scheme_uri=onto_uri,
+        **{
+            "rdf:type": person_a,
+            "onto:name": "Alice",
+            "custom:prop": "http://custom.example/val",
+        },
+    )
+
+    ttl = await _data_graph_turtle_for_uri(MagicMock(), client.app.state.session, onto_uri)
+    assert "http://example.org/onto-a#name" in ttl or "onto:name" in ttl
+    assert "http://example.org/#onto:name" not in ttl
+    assert "http://example.org/onto-a#custom:prop" not in ttl
+
+
+def test_ontology_namespace_helper_handles_all_uri_forms():
+    from semantica.explorer.routes.ontology import _ontology_namespace
+
+    assert _ontology_namespace("http://example.org/onto-a") == "http://example.org/onto-a#"
+    assert _ontology_namespace("http://example.org/onto-a/") == "http://example.org/onto-a/"
+    assert _ontology_namespace("http://example.org/onto-a#") == "http://example.org/onto-a#"
+    assert _ontology_namespace("http://example.org/onto-a#schema") == "http://example.org/onto-a#"

--- a/tests/explorer/test_ontology_subissue3.py
+++ b/tests/explorer/test_ontology_subissue3.py
@@ -1,5 +1,7 @@
 """Tests for Ontology Hub subissue 3 APIs."""
 
+from unittest.mock import patch
+
 import pytest
 
 from semantica.context.context_graph import ContextGraph
@@ -147,15 +149,28 @@ def test_shacl_validate_returns_unavailable(client):
     response = client.post(
         "/api/ontology/shacl/validate",
         json={
-            "uri": "http://example.org/onto-a",
             "shacl_turtle": "@prefix sh: <http://www.w3.org/ns/shacl#> .",
         },
     )
     assert response.status_code == 200
     payload = response.json()
-    assert payload["status"] == "unavailable", "stub must not report conforms=True before validation is wired"
+    assert payload["status"] == "unavailable"
     assert payload["conforms"] is False
     assert isinstance(payload["violations"], list)
+
+    with patch.dict("sys.modules", {"pyshacl": None}):
+        res_no_pyshacl = client.post(
+            "/api/ontology/shacl/validate",
+            json={
+                "uri": "http://example.org/onto-a",
+                "shacl_turtle": "@prefix sh: <http://www.w3.org/ns/shacl#> .",
+            },
+        )
+        assert res_no_pyshacl.status_code == 200
+        payload_no_pyshacl = res_no_pyshacl.json()
+        assert payload_no_pyshacl["status"] == "unavailable"
+        assert payload_no_pyshacl["conforms"] is False
+        assert isinstance(payload_no_pyshacl["violations"], list)
 
 
 def test_shacl_validate_rejects_empty_turtle(client):
@@ -166,20 +181,68 @@ def test_shacl_validate_rejects_empty_turtle(client):
     assert response.status_code == 422
 
 
+def test_shacl_validate_detects_missing_required_property(client):
+    graph = client.app.state.session.graph
+    onto_uri = "http://example.org/onto-a"
+    person_a = "http://example.org/onto-a#Person"
+    person_inst = "http://example.org/onto-a#person-no-name"
+    graph.add_node(
+        person_inst,
+        node_type="owl:NamedIndividual",
+        content="Person Without Name",
+        scheme_uri=onto_uri,
+        **{
+            "rdf:type": person_a,
+            "rdfs:label": "Person Without Name",
+        },
+    )
+
+    shacl_turtle = """
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix onto: <http://example.org/onto-a#> .
+
+onto:PersonNameShape a sh:NodeShape ;
+    sh:targetClass onto:Person ;
+    sh:property [
+        sh:path onto:name ;
+        sh:minCount 1 ;
+        sh:severity sh:Violation ;
+        sh:message "Person must have a name." ;
+    ] .
+"""
+
+    response = client.post(
+        "/api/ontology/shacl/validate",
+        json={
+            "uri": onto_uri,
+            "shacl_turtle": shacl_turtle,
+        },
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["status"] == "success"
+    assert payload["conforms"] is False
+    assert len(payload["violations"]) >= 1
+    violation = payload["violations"][0]
+    assert violation["severity"] == "Violation"
+    assert "person-no-name" in str(violation["focus_node"]) or "person-no-name" in str(violation["node"])
+
+
 def test_health_returns_404_for_unknown_ontology(client):
     response = client.get("/api/ontology/health?uri=http%3A%2F%2Fnot-loaded.example%2Fonto")
     assert response.status_code == 404
 
 
 def test_health_shacl_dimension_is_zero_when_unavailable(client):
-    payload = client.get("/api/ontology/health?uri=http%3A%2F%2Fexample.org%2Fonto-a").json()
-    shacl_dim = next(d for d in payload["dimensions"] if d["key"] == "shacl")
-    assert shacl_dim["status"] == "unavailable"
-    assert shacl_dim["score"] == 0.0
-    # Total score must NOT include the unavailable dimension in its average.
-    scoreable = [d for d in payload["dimensions"] if d["status"] != "unavailable"]
-    expected_total = round(sum(d["score"] for d in scoreable) / len(scoreable), 1)
-    assert payload["total_score"] == expected_total
+    with patch.dict("sys.modules", {"pyshacl": None}):
+        payload = client.get("/api/ontology/health?uri=http%3A%2F%2Fexample.org%2Fonto-a").json()
+        shacl_dim = next(d for d in payload["dimensions"] if d["key"] == "shacl")
+        assert shacl_dim["status"] == "unavailable"
+        assert shacl_dim["score"] == 0.0
+        # Total score must NOT include the unavailable dimension in its average.
+        scoreable = [d for d in payload["dimensions"] if d["status"] != "unavailable"]
+        expected_total = round(sum(d["score"] for d in scoreable) / len(scoreable), 1)
+        assert payload["total_score"] == expected_total
 
 
 def test_delete_unknown_alignment_returns_404(client):
@@ -261,3 +324,40 @@ def test_health_alignment_coverage_uses_set_lookup(client):
     payload = client.get("/api/ontology/health?uri=http%3A%2F%2Fexample.org%2Fonto-a").json()
     alignment_dim = next(d for d in payload["dimensions"] if d["key"] == "alignment")
     assert alignment_dim["score"] > 0.0, "alignment coverage must be non-zero after recording an alignment"
+
+
+def test_suggest_alignments_unaffected_by_individuals(client):
+    graph = client.app.state.session.graph
+    graph.add_node(
+        "http://example.org/onto-a#individual-person",
+        node_type="owl:NamedIndividual",
+        content="Person",
+        scheme_uri="http://example.org/onto-a",
+        **{"rdf:type": "http://example.org/onto-a#Person", "rdfs:label": "Person"},
+    )
+    response = client.post(
+        "/api/ontology/suggest-alignments",
+        json={
+            "source_ontology_uri": "http://example.org/onto-a",
+            "target_ontology_uri": "http://example.org/onto-b",
+            "threshold": 0.35,
+            "limit": 5,
+        },
+    )
+    assert response.status_code == 200
+    suggestions = response.json()
+    assert suggestions
+    for s in suggestions:
+        assert "individual-person" not in s["source_uri"]
+        assert "individual-person" not in s["target_uri"]
+
+
+def test_health_shacl_dimension_degrades_gracefully_on_real_error(client):
+    import semantica.explorer.routes.ontology as ont_mod
+    with patch.object(ont_mod, "_data_graph_turtle_for_uri", side_effect=RuntimeError("boom")):
+        response = client.get("/api/ontology/health?uri=http%3A%2F%2Fexample.org%2Fonto-a")
+    assert response.status_code == 200
+    payload = response.json()
+    shacl_dim = next(d for d in payload["dimensions"] if d["key"] == "shacl")
+    assert shacl_dim["status"] == "critical"
+    assert "boom" in shacl_dim["detail"]


### PR DESCRIPTION
Closes #772

## What was asked

`routes/ontology.py:2222` had `pass # rdflib unavailable; skip syntax check`
inside `POST /shacl/validate`. The issue reporter confirmed this was **not**
silent — the endpoint always returned `status="unavailable"` with a clear
message — and reclassified it from "bug" to "feature-completeness gap":
live SHACL validation was disclosed as missing, but never actually implemented.
Flagged as worth completing if feasible.

## What this PR implements

**1. A real data graph for validation to run against**
`/shacl/validate` had no data graph to validate a submitted SHACL shape
against — only a Turtle *syntax* check. Added `_data_graph_turtle_for_uri()`,
which pulls the loaded ontology's nodes/edges from the session and serializes
them into an RDF/Turtle instance graph (proper CURIE resolution across
owl/rdfs/skos/dct/dc, arbitrary node-property projection as predicates, typed
individuals included).

**2. Wired the endpoint to `OntologyEngine.validate_graph()`**
`POST /shacl/validate` now runs the submitted shapes against that data graph
via pyshacl (already an optional dependency: `semantica[shacl]`), returning
real `conforms` + structured violations instead of a hardcoded stub.

**3. Same live validation added to `GET /health`**
The SHACL Conformance dimension was hardcoded to `status="unavailable",
score=0.0`. It now runs the same validation using the ontology's
auto-generated shapes and reports real `ok`/`warning` status and score.

**4. Preserved honest disclosure in every fallback path**
- No `uri` provided → `200`, `status="unavailable"`, explains why.
- `pyshacl`/`rdflib` not installed → `200`, `status="unavailable"`, names the
  missing dependency. Never silently passes, never crashes.

## Why this ended up bigger than the one-line stub

The issue itself was filed as optional ("worth completing... otherwise fine
to close as known/documented"). Implementing it properly surfaced two
pre-existing bugs that had nothing to do with the original stub, both of
which were only found by actually exercising the new code path live rather
than trusting a green test run:

- **Cross-ontology namespace leak:** `_node_belongs_to_ontology`'s prefix
  fallback used `_extract_namespace()`, which splits only on the last `/`.
  For sibling ontologies sharing a domain (e.g. `.../onto-a` and
  `.../onto-b`), this matched entities across ontologies that shouldn't be
  related — e.g. `onto-b`'s "Person Record" class leaking into `onto-a`'s
  validated entity set. Fixed by comparing against the full URI stem.
- **`HealthDimension.status` Literal didn't include `"error"`:** an early
  version of the fix caught real (non-`ImportError`) exceptions and reported
  `status="error"`, which isn't a valid value on that model — causing
  Pydantic to throw and the *entire* `/health` endpoint to 422 on any real
  bug. Fixed to use `status="critical"` (already valid), with a regression
  test forcing this exact path so it can't silently return.
- **`/suggest-alignments` scope:** widening entity classification to include
  individuals (needed for the data graph) would have also pulled individuals
  into unrelated alignment suggestions. Scoped to a dedicated
  `_data_graph_entities()` helper used only by the validator, with a test
  confirming `/suggest-alignments` output is unaffected.

## Why we didn't reuse `RDFExporter.export_to_rdf`

Checked `semantica/export/rdf_exporter.py` first — it already serializes
entities/relationships to Turtle, but only emits `type` + `text` +
`confidence` per entity with no arbitrary property projection and no CURIE
namespace resolution. Not sufficient for SHACL constraint checking, which
needs full property fidelity. A purpose-built serializer was necessary.

## Testing

- `tests/explorer/test_ontology_subissue3.py`: 18/18 passing, including new
  coverage for: pyshacl-missing disclosure, no-uri disclosure, a real
  violation detection case (missing required property), the
  `/suggest-alignments` non-regression, and the health-endpoint
  graceful-degradation-on-real-error case.
- `tests/ontology/`: 83/83 passing (pre-existing suite, unaffected).