### PR TITLE
fix(agno): log shared context decision tracking failures - #779

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Agno `_AgentScopedStore.upsert_memory` silently swallowed decision recording failures** (#779)
+  - `upsert_memory()` now logs `logger.warning("[%s] record_decision failed: %s", self._role, exc)` when `record_decision()` fails, matching the error-logging convention used for `store()` in the same method
+  - Preserves graceful fallback behavior: `record_decision()` remains optional and `upsert_memory()` continues without propagating the exception
+  - Added regression coverage in `tests/integrations/agno/test_shared_context.py` for both `store()` and `record_decision()` warning paths
+
 - **MCP `handle_get_causal_chain` returned an empty-but-valid-looking response when both `CausalChainAnalyzer` and the graph fallback were unavailable** (#781, #817) by @Sameer6305 and @KaifAhmad1
   - Returns an explicit `{"error": "Causal chain analysis is not supported on this graph backend", "chain": []}` instead of `{"chain": [], "count": 0, "direction": ...}`, letting clients distinguish "unsupported" from a legitimately empty chain
   - The fallback path now introspects `graph.get_causal_chain`'s signature to forward `direction`/`max_depth` (or a `depth` kwarg, or nothing, depending on what the backend accepts) instead of always calling with just `decision_id`, matching the primary analyzer path's behavior

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **Agno `_AgentScopedStore.upsert_memory` silently swallowed decision recording failures** (#779)
-  - `upsert_memory()` now logs `logger.warning("[%s] record_decision failed: %s", self._role, exc)` when `record_decision()` fails, matching the error-logging convention used for `store()` in the same method
+  - `upsert_memory()` now logs `logger.warning("[%s] record_decision failed: %s", self._role, exc, exc_info=True)` when `record_decision()` fails, matching the error-logging convention used for `store()` in the same method with traceback context preserved
   - Preserves graceful fallback behavior: `record_decision()` remains optional and `upsert_memory()` continues without propagating the exception
   - Added regression coverage in `tests/integrations/agno/test_shared_context.py` for both `store()` and `record_decision()` warning paths
 

--- a/integrations/agno/shared_context.py
+++ b/integrations/agno/shared_context.py
@@ -83,7 +83,7 @@ class _AgentScopedStore(AgnoContextStore):
         try:
             self._context.store(mem_text, conversation_id=self.session_id)
         except Exception as exc:
-            logger.warning("[%s] store failed: %s", self._role, exc)
+            logger.warning("[%s] store failed: %s", self._role, exc, exc_info=True)
 
         if self.decision_tracking:
             try:
@@ -95,7 +95,7 @@ class _AgentScopedStore(AgnoContextStore):
                     confidence=1.0,
                 )
             except Exception as exc:
-                logger.warning("[%s] record_decision failed: %s", self._role, exc)
+                logger.warning("[%s] record_decision failed: %s", self._role, exc, exc_info=True)
 
         if hasattr(memory, "id"):
             memory.id = mem_id

--- a/integrations/agno/shared_context.py
+++ b/integrations/agno/shared_context.py
@@ -94,8 +94,8 @@ class _AgentScopedStore(AgnoContextStore):
                     outcome="stored",
                     confidence=1.0,
                 )
-            except Exception:
-                pass
+            except Exception as exc:
+                logger.warning("[%s] record_decision failed: %s", self._role, exc)
 
         if hasattr(memory, "id"):
             memory.id = mem_id

--- a/tests/integrations/agno/test_shared_context.py
+++ b/tests/integrations/agno/test_shared_context.py
@@ -174,6 +174,24 @@ class TestSharedMemoryPool(unittest.TestCase):
         memories = self.analyst.read_memories(limit=2)
         self.assertTrue(len(memories) <= 2)
 
+    def test_upsert_memory_store_failure_logs_warning(self):
+        self.shared._context.store.side_effect = RuntimeError("store error")
+        with self.assertLogs("semantica.integrations.agno.shared_context", level="WARNING") as cm:
+            mem = self.researcher.upsert_memory(self._make_row("Test store fail"))
+        self.assertIsNotNone(mem)
+        self.assertIn(mem.id, self.researcher._memories)
+        self.assertTrue(any("store failed:" in msg and "store error" in msg for msg in cm.output))
+        self.shared._context.store.side_effect = None
+
+    def test_upsert_memory_record_decision_failure_logs_warning(self):
+        self.shared._context.record_decision.side_effect = RuntimeError("decision error")
+        with self.assertLogs("semantica.integrations.agno.shared_context", level="WARNING") as cm:
+            mem = self.researcher.upsert_memory(self._make_row("Test decision fail"))
+        self.assertIsNotNone(mem)
+        self.assertIn(mem.id, self.researcher._memories)
+        self.assertTrue(any("record_decision failed:" in msg and "decision error" in msg for msg in cm.output))
+        self.shared._context.record_decision.side_effect = None
+
 
 class TestSharedContextDecisions(unittest.TestCase):
 


### PR DESCRIPTION
Closes #779

## Summary

Fixes a silent exception handling path in `AgnoSharedContext` where `record_decision()` failures during `_AgentScopedStore.upsert_memory()` were swallowed without any visibility.

### Changes

- Replace the silent `except Exception: pass` with a warning log when `record_decision()` fails.
- Preserve the existing graceful degradation behavior:
  - `record_decision()` remains optional.
  - `upsert_memory()` continues successfully.
  - The memory is still stored and returned.
  - No exception is propagated to callers.
- Add regression tests covering:
  - `record_decision()` warning path.
  - `store()` warning path.
- Update the changelog with the fix.

## Why

`store()` failures were already logged, while `record_decision()` failures were silently ignored. This inconsistency made troubleshooting decision-tracking issues difficult and hid operational failures that should be visible to users and maintainers.

This change makes the error handling consistent while preserving the existing API behavior and graceful fallback semantics.

## Testing

- Added regression tests for both warning paths in `TestSharedMemoryPool`.
- Ran the Agno integration test suite.

**Results:**
112 passed, 4 warnings