### PR TITLE
docs: surface pip install at the top of README and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@
 
 [![Website](https://img.shields.io/badge/Website-getsemantica.ai-000000?style=flat-square&logo=googlechrome&logoColor=white)](https://getsemantica.ai/) [![Docs](https://img.shields.io/badge/Docs-docs.getsemantica.ai-0099FF?style=flat-square&logo=readthedocs&logoColor=white)](https://docs.getsemantica.ai/) [![Discord](https://img.shields.io/badge/Discord-Join%20Community-5865F2?style=flat-square&logo=discord&logoColor=white)](https://discord.gg/sV34vps5hH) [![Twitter/X](https://img.shields.io/badge/Follow-%40BuildSemantica-000000?style=flat-square&logo=x&logoColor=white)](https://x.com/BuildSemantica) [![YouTube](https://img.shields.io/badge/YouTube-Watch%20Demos-FF0000?style=flat-square&logo=youtube&logoColor=white)](https://www.youtube.com/watch?v=QfnNZg4-dZA) [![Changelog](https://img.shields.io/badge/Changelog-View-6E40C9?style=flat-square&logo=keepachangelog&logoColor=white)](CHANGELOG.md)
 
+```bash
+pip install semantica
+```
+
 </div>
 
 ---

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,6 +3,10 @@ title: "Semantica"
 description: "The Accountability and Context Layer for AI: Context Graphs · Decision Intelligence · Full Provenance"
 ---
 
+```bash
+pip install semantica
+```
+
 Your AI agent just made a decision. Now someone needs to explain it.
 
 *What did it know at the time? Which facts shaped the outcome? Where did those facts come from? Has it made the same call before: and did that go well?*


### PR DESCRIPTION
## Summary
- Adds a prominent `pip install semantica` code block near the top of README.md, right after the badges/social row and before the demo video
- Adds the same `pip install semantica` snippet as the first thing on the docs landing page (docs/index.md), ahead of the opening copy

Both locations already referenced the install command further down (Quick Start / Start Here sections) — this just makes it the first actionable thing a visitor sees.

## Test plan
- [x] Rendered README.md and docs/index.md locally to confirm formatting