### PR TITLE
feat(explorer): add temporal diff comparison UI to the Temporal panel (#793)

### DIFF
--- a/explorer/src/workspaces/GraphWorkspace/plugins/temporalDiffState.ts
+++ b/explorer/src/workspaces/GraphWorkspace/plugins/temporalDiffState.ts
@@ -1,0 +1,23 @@
+// Fetch wrapper for GET /api/temporal/diff (see semantica/explorer/routes/temporal.py).
+// added_nodes are node IDs active at to_time but not at from_time; removed_nodes are the
+// inverse. Both are plain node-ID lists (no edge-level diffing), matching the snapshot
+// route's active_node_ids shape used elsewhere in this workspace.
+export interface TemporalDiffResult {
+  from_time: string;
+  to_time: string;
+  added_nodes: string[];
+  removed_nodes: string[];
+}
+
+export async function fetchTemporalDiff(
+  fromTime: string,
+  toTime: string,
+  signal?: AbortSignal,
+): Promise<TemporalDiffResult> {
+  const params = new URLSearchParams({ from_time: fromTime, to_time: toTime });
+  const response = await fetch(`/api/temporal/diff?${params}`, { signal });
+  if (!response.ok) {
+    throw new Error(`Temporal diff request failed with status ${response.status}`);
+  }
+  return response.json();
+}

--- a/explorer/src/workspaces/GraphWorkspace/plugins/temporalOverlayPlugin.tsx
+++ b/explorer/src/workspaces/GraphWorkspace/plugins/temporalOverlayPlugin.tsx
@@ -120,15 +120,18 @@ function DiffSection({ context }: { context: GraphPluginContext }) {
   }, []);
 
   const handleCompare = () => {
-    if (!fromTime.trim() || !toTime.trim()) {
+    const from = fromTime.trim();
+    const to = toTime.trim();
+
+    if (!from || !to) {
       setValidationMessage("Both a from and to time are required.");
       return;
     }
-    if (!isValidDateInput(fromTime) || !isValidDateInput(toTime)) {
+    if (!isValidDateInput(from) || !isValidDateInput(to)) {
       setValidationMessage("Enter valid ISO datetimes, e.g. 2024-01-01T00:00:00.");
       return;
     }
-    if (new Date(fromTime).getTime() >= new Date(toTime).getTime()) {
+    if (new Date(from).getTime() >= new Date(to).getTime()) {
       setValidationMessage("From time must be before to time.");
       return;
     }
@@ -143,7 +146,7 @@ function DiffSection({ context }: { context: GraphPluginContext }) {
     previousColorsRef.current = new Map();
     setRequestState({ status: "loading" });
 
-    fetchTemporalDiff(fromTime, toTime, controller.signal)
+    fetchTemporalDiff(from, to, controller.signal)
       .then((result) => {
         if (controller.signal.aborted) {
           return;

--- a/explorer/src/workspaces/GraphWorkspace/plugins/temporalOverlayPlugin.tsx
+++ b/explorer/src/workspaces/GraphWorkspace/plugins/temporalOverlayPlugin.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useRef, useState, type CSSProperties } from "react";
 import { Loader2 } from "lucide-react";
+import type Graph from "graphology";
 
-import { graph } from "../../../store/graphStore";
+import { graph, type NodeAttributes } from "../../../store/graphStore";
 import { GRAPH_THEME } from "../graphTheme";
 import { fetchTemporalDiff, type TemporalDiffResult } from "./temporalDiffState";
 import type { GraphPlugin, GraphPluginContext } from "./types";
@@ -40,11 +41,42 @@ const DIFF_REMOVED_COLOR = GRAPH_THEME.ui.control.dangerText;
 // state every diffed node is in here. baseColor is read unconditionally by resolveNodeColor's
 // default branch regardless of interaction state or zoom tier, so it is the one attribute
 // confirmed to actually render the diff highlight.
+//
+// Writes go to BOTH the store graph and context.displayGraph:
+// - context.displayGraph is the live Graph instance currently bound to Sigma (updated by
+//   GraphCanvas.tsx via sigma.setGraph() / runtimeRef.current.displayGraph = displayGraph
+//   whenever the display graph is rebuilt). The nodeReducer reads attributes from this
+//   instance, so writing here makes the highlight visible in the currently-rendered frame.
+// - graph (store singleton) carries the value into the *next* display graph rebuild:
+//   aggregateDisplayGraph copies node attributes shallowly from the store graph, so a
+//   mutation that only touches context.displayGraph would be lost on the next rebuild.
+// Using a type assertion to Graph<NodeAttributes, EdgeAttributes> is consistent with how
+// the rest of GraphCanvas/graphSceneState cast the same union when they need to call
+// mutation methods; TypeScript cannot resolve setNodeAttribute across the union directly.
+
+function toMutable(g: GraphPluginContext["displayGraph"]) {
+  return g as Graph<NodeAttributes>;
+}
+
+function writeBaseColor(
+  context: GraphPluginContext,
+  nodeId: string,
+  color: string | undefined,
+): void {
+  // Write to the store graph first (survives display graph rebuilds).
+  if (graph.hasNode(nodeId)) {
+    graph.setNodeAttribute(nodeId, "baseColor", color);
+  }
+  // Write to the current display graph instance Sigma is rendering.
+  const dg = toMutable(context.displayGraph);
+  if (dg !== graph && dg.hasNode(nodeId)) {
+    dg.setNodeAttribute(nodeId, "baseColor", color);
+  }
+}
+
 function clearDiffHighlight(context: GraphPluginContext, previousColors: Map<string, string | undefined>) {
   previousColors.forEach((color, nodeId) => {
-    if (graph.hasNode(nodeId)) {
-      graph.setNodeAttribute(nodeId, "baseColor", color);
-    }
+    writeBaseColor(context, nodeId, color);
   });
   context.scene?.requestRender();
 }
@@ -52,9 +84,11 @@ function clearDiffHighlight(context: GraphPluginContext, previousColors: Map<str
 function applyDiffHighlight(context: GraphPluginContext, result: TemporalDiffResult): Map<string, string | undefined> {
   const previousColors = new Map<string, string | undefined>();
   const paint = (nodeId: string, color: string) => {
+    // Capture from the store graph — this is the authoritative source for the node's
+    // original baseColor, since aggregateDisplayGraph copies from there.
     if (graph.hasNode(nodeId)) {
       previousColors.set(nodeId, graph.getNodeAttribute(nodeId, "baseColor"));
-      graph.setNodeAttribute(nodeId, "baseColor", color);
+      writeBaseColor(context, nodeId, color);
     }
   };
   result.added_nodes.forEach((nodeId) => paint(nodeId, DIFF_ADDED_COLOR));

--- a/explorer/src/workspaces/GraphWorkspace/plugins/temporalOverlayPlugin.tsx
+++ b/explorer/src/workspaces/GraphWorkspace/plugins/temporalOverlayPlugin.tsx
@@ -1,6 +1,10 @@
-import type { CSSProperties } from "react";
+import { useEffect, useRef, useState, type CSSProperties } from "react";
+import { Loader2 } from "lucide-react";
 
-import type { GraphPlugin } from "./types";
+import { graph } from "../../../store/graphStore";
+import { GRAPH_THEME } from "../graphTheme";
+import { fetchTemporalDiff, type TemporalDiffResult } from "./temporalDiffState";
+import type { GraphPlugin, GraphPluginContext } from "./types";
 
 const TEMPORAL_PANEL_ID = "temporal-panel";
 
@@ -9,6 +13,182 @@ function formatTemporalLabel(value: Date | null) {
     return "No time selected";
   }
   return `${value.getFullYear()}/${String(value.getMonth() + 1).padStart(2, "0")}`;
+}
+
+function isValidDateInput(value: string): boolean {
+  return value.trim().length > 0 && !Number.isNaN(new Date(value).getTime());
+}
+
+type DiffRequestState =
+  | { status: "idle" }
+  | { status: "loading" }
+  | { status: "error"; message: string }
+  | { status: "empty"; result: TemporalDiffResult }
+  | { status: "success"; result: TemporalDiffResult };
+
+// Diff highlight colors reuse existing theme tokens rather than introducing new
+// hex values: semantic[2] is the codebase's green, dangerText is the one named
+// danger/red token already used elsewhere in this workspace (GraphWorkspace.tsx).
+const DIFF_ADDED_COLOR = GRAPH_THEME.palette.semantic[2];
+const DIFF_REMOVED_COLOR = GRAPH_THEME.ui.control.dangerText;
+
+// Highlighting uses baseColor (the node's fill color), not ringColor/haloColor: those two
+// are only read by resolveNodeElementStyle/GraphCanvas's decoration pass for nodes in
+// hovered/selected/path visual state (see resolveNodeRingSize, showHalo in graphSceneState.ts
+// and the nodesToDecorate set in GraphCanvas.tsx) and are silently discarded by the sigma
+// nodeReducer for a node sitting in its default (untouched) state — which is exactly the
+// state every diffed node is in here. baseColor is read unconditionally by resolveNodeColor's
+// default branch regardless of interaction state or zoom tier, so it is the one attribute
+// confirmed to actually render the diff highlight.
+function clearDiffHighlight(context: GraphPluginContext, previousColors: Map<string, string | undefined>) {
+  previousColors.forEach((color, nodeId) => {
+    if (graph.hasNode(nodeId)) {
+      graph.setNodeAttribute(nodeId, "baseColor", color);
+    }
+  });
+  context.scene?.requestRender();
+}
+
+function applyDiffHighlight(context: GraphPluginContext, result: TemporalDiffResult): Map<string, string | undefined> {
+  const previousColors = new Map<string, string | undefined>();
+  const paint = (nodeId: string, color: string) => {
+    if (graph.hasNode(nodeId)) {
+      previousColors.set(nodeId, graph.getNodeAttribute(nodeId, "baseColor"));
+      graph.setNodeAttribute(nodeId, "baseColor", color);
+    }
+  };
+  result.added_nodes.forEach((nodeId) => paint(nodeId, DIFF_ADDED_COLOR));
+  result.removed_nodes.forEach((nodeId) => paint(nodeId, DIFF_REMOVED_COLOR));
+  context.scene?.requestRender();
+  return previousColors;
+}
+
+function DiffSection({ context }: { context: GraphPluginContext }) {
+  const [fromTime, setFromTime] = useState("");
+  const [toTime, setToTime] = useState("");
+  const [validationMessage, setValidationMessage] = useState<string | null>(null);
+  const [requestState, setRequestState] = useState<DiffRequestState>({ status: "idle" });
+  const abortRef = useRef<AbortController | null>(null);
+  // Maps currently-highlighted node ID -> its baseColor before highlighting, so clearing
+  // restores the exact prior value instead of an approximation.
+  const previousColorsRef = useRef<Map<string, string | undefined>>(new Map());
+
+  // Cancel any in-flight request and clear stale highlights when the panel unmounts
+  // (panel closed) — matches the cancellation pattern used by the snapshot fetch in
+  // GraphRuntimeStage.tsx (cancel-on-cleanup) plus AbortController per DecisionWorkspace.tsx.
+  useEffect(() => {
+    return () => {
+      abortRef.current?.abort();
+      clearDiffHighlight(context, previousColorsRef.current);
+      previousColorsRef.current = new Map();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const handleCompare = () => {
+    if (!fromTime.trim() || !toTime.trim()) {
+      setValidationMessage("Both a from and to time are required.");
+      return;
+    }
+    if (!isValidDateInput(fromTime) || !isValidDateInput(toTime)) {
+      setValidationMessage("Enter valid ISO datetimes, e.g. 2024-01-01T00:00:00.");
+      return;
+    }
+    if (new Date(fromTime).getTime() >= new Date(toTime).getTime()) {
+      setValidationMessage("From time must be before to time.");
+      return;
+    }
+    setValidationMessage(null);
+
+    // Cancel any request already in flight before starting a new one.
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+
+    clearDiffHighlight(context, previousColorsRef.current);
+    previousColorsRef.current = new Map();
+    setRequestState({ status: "loading" });
+
+    fetchTemporalDiff(fromTime, toTime, controller.signal)
+      .then((result) => {
+        if (controller.signal.aborted) {
+          return;
+        }
+        if (!result.added_nodes.length && !result.removed_nodes.length) {
+          setRequestState({ status: "empty", result });
+          return;
+        }
+        previousColorsRef.current = applyDiffHighlight(context, result);
+        setRequestState({ status: "success", result });
+      })
+      .catch((error: unknown) => {
+        if (error instanceof Error && error.name === "AbortError") {
+          return;
+        }
+        setRequestState({
+          status: "error",
+          message: error instanceof Error ? error.message : "Temporal diff request failed.",
+        });
+      });
+  };
+
+  const isLoading = requestState.status === "loading";
+
+  return (
+    <div style={diffSectionStyle}>
+      <div style={panelEyebrowStyle}>Compare two points in time</div>
+      <div style={diffInputRowStyle}>
+        <input
+          value={fromTime}
+          onChange={(event) => setFromTime(event.target.value)}
+          placeholder="From, e.g. 2024-01-01T00:00:00"
+          style={diffInputStyle}
+        />
+        <input
+          value={toTime}
+          onChange={(event) => setToTime(event.target.value)}
+          placeholder="To, e.g. 2025-06-15T00:00:00"
+          style={diffInputStyle}
+        />
+      </div>
+      <button
+        type="button"
+        onClick={handleCompare}
+        disabled={isLoading}
+        style={{ ...diffActionButtonStyle, opacity: isLoading ? 0.7 : 1 }}
+      >
+        {isLoading ? <Loader2 size={13} className="animate-spin" style={{ marginRight: 6 }} /> : null}
+        {isLoading ? "Comparing…" : "Compare"}
+      </button>
+
+      {validationMessage ? <div style={diffValidationStyle}>{validationMessage}</div> : null}
+
+      {requestState.status === "error" ? (
+        <div style={diffErrorStyle}>{requestState.message}</div>
+      ) : null}
+
+      {requestState.status === "empty" ? (
+        <div style={emptyTextStyle}>No changes between these two points.</div>
+      ) : null}
+
+      {requestState.status === "success" ? (
+        <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+          <div style={detailRowStyle}>
+            <span style={detailLabelStyle}>Added</span>
+            <span style={{ ...detailValueStyle, color: DIFF_ADDED_COLOR }}>
+              {requestState.result.added_nodes.length.toLocaleString()}
+            </span>
+          </div>
+          <div style={detailRowStyle}>
+            <span style={detailLabelStyle}>Removed</span>
+            <span style={{ ...detailValueStyle, color: DIFF_REMOVED_COLOR }}>
+              {requestState.result.removed_nodes.length.toLocaleString()}
+            </span>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
 }
 
 export const temporalOverlayPlugin: GraphPlugin = {
@@ -80,7 +260,7 @@ export const temporalOverlayPlugin: GraphPlugin = {
       order: 30,
       defaultOpen: false,
       preferredWidth: 320,
-      preferredHeight: 220,
+      preferredHeight: 380,
       content: (
         <div style={panelBodyStyle}>
           <div style={panelEyebrowStyle}>Current scrubber state</div>
@@ -100,6 +280,7 @@ export const temporalOverlayPlugin: GraphPlugin = {
               {typeof temporal?.activeNodeCount === "number" ? temporal.activeNodeCount.toLocaleString() : "All"}
             </span>
           </div>
+          <DiffSection context={context} />
         </div>
       ),
     };
@@ -139,4 +320,63 @@ const detailValueStyle: CSSProperties = {
   color: "#f3f7fd",
   fontSize: 12,
   fontWeight: 600,
+};
+
+const diffSectionStyle: CSSProperties = {
+  display: "flex",
+  flexDirection: "column",
+  gap: 8,
+  marginTop: 4,
+  paddingTop: 10,
+  borderTop: "1px solid rgba(255,255,255,0.06)",
+};
+
+const diffInputRowStyle: CSSProperties = {
+  display: "flex",
+  gap: 8,
+};
+
+const diffInputStyle: CSSProperties = {
+  flex: 1,
+  minWidth: 0,
+  background: "rgba(5, 7, 10, 0.52)",
+  border: "1px solid rgba(211, 205, 190, 0.13)",
+  color: "#f3f7fd",
+  borderRadius: 12,
+  padding: "9px 11px",
+  fontSize: 12,
+  boxShadow: "inset 0 1px 0 rgba(255,255,255,0.035)",
+};
+
+const diffActionButtonStyle: CSSProperties = {
+  background: GRAPH_THEME.ui.control.primaryBg,
+  color: GRAPH_THEME.ui.control.primaryText,
+  border: `1px solid ${GRAPH_THEME.ui.control.primaryBorder}`,
+  borderRadius: 12,
+  padding: "9px 12px",
+  cursor: "pointer",
+  fontWeight: 700,
+  fontSize: 12,
+  display: "inline-flex",
+  alignItems: "center",
+  justifyContent: "center",
+  boxShadow: "inset 0 1px 0 rgba(255,255,255,0.07), 0 10px 24px rgba(0,0,0,0.18)",
+};
+
+const diffValidationStyle: CSSProperties = {
+  color: GRAPH_THEME.ui.control.dangerText,
+  fontSize: 12,
+  lineHeight: 1.5,
+};
+
+const diffErrorStyle: CSSProperties = {
+  color: GRAPH_THEME.ui.control.dangerText,
+  fontSize: 12,
+  lineHeight: 1.5,
+};
+
+const emptyTextStyle: CSSProperties = {
+  color: "#8ea4be",
+  fontSize: 12,
+  lineHeight: 1.5,
 };


### PR DESCRIPTION
## Summary

Closes #793. Adds a UI for the existing `GET /api/temporal/diff` backend route, which previously had zero consumers in the Explorer frontend (confirmed via a full grep of `explorer/src/` — no references to `/api/temporal/diff` existed anywhere before this change).

Users can now pick two timestamps in the existing "Temporal Context" panel and see which nodes were added/removed between those two points, highlighted directly on the graph.

## What changed

* **`temporalDiffState.ts`** (new): a small typed fetch wrapper, `fetchTemporalDiff(fromTime, toTime, signal)`, matching the route's `{ from_time, to_time, added_nodes, removed_nodes }` response shape.
* **`temporalOverlayPlugin.tsx`** (extended): the existing "Temporal Context" panel gains a "Compare two points in time" section — two text inputs, a Compare button, and result states.

No changes to `GraphWorkspace.tsx` or `GraphRuntimeStage.tsx`. This follows the plugin-panel pattern already established by `neighborhoodPanelPlugin.tsx` / `explorationEffectsPluginPhaseC.tsx` — no new panel-registration mechanism was introduced.

## Design decisions (and why)

* **Rendering mechanism — `baseColor`, not `ringColor`/`haloColor`.** I initially implemented highlighting via `ringColor`/`haloColor` (the attributes that look most purpose-built for this). Tracing the actual sigma `nodeReducer` in `GraphCanvas.tsx` and `resolveNodeElementStyle` in `graphSceneState.ts` showed those two attributes are only respected for nodes in `hovered`/`selected`/`path` visual state — for a node in its default (untouched) state, the reducer silently discards them and falls back to `borderColor`/nothing. Confirmed via direct execution of the real, shipped modules against a running instance of the app (bypassing a separate, pre-existing panel bug — see below) that `ringColor` produces no visible change, while `baseColor` does, through the exact same resolver the production reducer calls.
* **Highlight restore uses captured original values, not a fallback clear.** Each highlighted node's prior `baseColor` is captured in a `Map` before being overwritten, and restored from that map — not reset to `undefined` — since `undefined` falls through to a semantic-default color rather than the node's actual original color. Verified live: an `undefined`-clear would have produced a different, wrong color; the actual implementation restores the exact original.
* **Cancellation.** Uses `AbortController`, matching the pattern already used in `DecisionWorkspace.tsx`/`App.tsx`. A new comparison aborts any request still in flight *before* issuing the new one, and the in-flight request is also aborted on unmount. Both call sites verified by direct trace.
* **Visual style.** No new button/input/spinner/error patterns — reused `GraphInspectorPanel.tsx`'s exact `actionButtonStyle`/`inputStyle` shapes and its `<Loader2 className="animate-spin">` loading indicator (same directory, same theme tokens). Colors use existing theme tokens (`GRAPH_THEME.palette.semantic[2]` for "added", `ui.control.dangerText` for "removed") rather than new hardcoded hex values. No emojis.
* **States.** Idle / loading / validation-error / request-error / empty ("no changes between these two points" — a valid result, not an error) / success, each with its own distinct rendering.

## Testing performed

* `npx tsc --noEmit` — clean, zero errors.
* `npx eslint` on both changed files — one pre-existing-pattern finding (`react-refresh/only-export-components`), identical to the accepted structure already present in `explorationEffectsPluginPhaseC.tsx` (a local component defined alongside a plugin-object export). Not a regression introduced by this change.
* Started the real FastAPI explorer backend and the Vite dev server against a small sample graph with temporally-bounded nodes; confirmed `GET /api/temporal/diff` returns the correct `added_nodes`/`removed_nodes` through the Vite proxy exactly as the UI calls it.
* Verified the apply and restore highlighting logic by executing the real, shipped `graphSceneState.ts`/`graphTheme.ts` resolvers directly against the live running app (via in-page dynamic `import()`), since manual click-through of the Temporal panel is currently blocked by a pre-existing, unrelated bug (see below). Confirmed:

  * the diff color is actually applied through the production color resolver,
  * clearing the highlight restores the exact original resolved color (not an approximation), tested with a node whose original color does not coincidentally match either diff color,
  * the old `ringColor`/`haloColor` approach would have rendered nothing for a default-state node.

## Known limitation — pre-existing bug blocks manual click-through

The Temporal panel currently fails to open at all in this codebase: clicking the "Temporal" toolbar toggle triggers a React "Maximum update depth exceeded" error and the panel is permanently stuck on "Loading temporal…". This is confirmed pre-existing and unrelated to this change — `git stash`-ing this diff and reproducing against the unmodified base branch shows the identical error. Because of this, this feature could not be manually clicked through in a browser end-to-end; it was verified via direct module execution against the live app instead (see Testing above). I'll file a separate issue for the panel bug after this merges — it should be fixed independently since it blocks the Temporal panel for all consumers, not just this feature.

## Files changed

* `explorer/src/workspaces/GraphWorkspace/plugins/temporalDiffState.ts` (new)
* `explorer/src/workspaces/GraphWorkspace/plugins/temporalOverlayPlugin.tsx` (extended)
