### PR TITLE
fix(vector_store): stop dropping metadata for add_vectors-only backends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`VectorStore.store_vectors()` silently dropped metadata for FAISS (and any `add_vectors`-only) backend** (#832, #835) by @KaifAhmad1
+  - `store_vectors()` fell into a branch that called `self._backend_store.add_vectors(vectors, **options)` without `metadata` whenever the backend exposed `add_vectors()` but neither `add()` nor `store_vectors()` — true for `FAISSStore`, the backend most real usage configures for genuine ANN search. Every caller that stores vectors with metadata (e.g. `AgentMemory._store_memory_vector()`, used internally by `AgentContext.store()`) lost that metadata once it reached FAISS, with no error or warning
+  - Downstream, `ContextRetriever._retrieve_from_vector()` recovers a result's text via `metadata.get("content", "")`, which was always `""` for any vector stored this way; `_rank_and_merge()` then embedded that empty string, tripping `TextEmbedder.embed_text()`'s empty-text rejection and masking the real bug as a spurious `TextEmbedder` failure recorded by the progress tracker
+  - `store_vectors()` now forwards `metadata` to `add_vectors()`, but only when the backend's `add_vectors()` signature actually accepts it (checked via `inspect.signature`, accepting either an explicit `metadata` parameter or a `**kwargs` catch-all), so a future/custom backend with a stricter signature raises no `TypeError`
+  - **Follow-up review fix**: the `inspect.signature()` probe is wrapped in `try/except (ValueError, TypeError)`, consistent with the identical pattern already used in `ProvenanceManager.trace_lineage()`, so signature introspection failing on an unusual callable can no longer abort `store_vectors()` before it even attempts to call the backend
+
 - **`AgnoDecisionKit.check_policy` silently treated unevaluable policy rules as compliant** (#778, #822) by @Sameer6305
   - `_eval_rule()` previously `return`ed `True` when a rule referenced a field missing from the decision payload, or when the rule string didn't match the expected `<field> <op> <value>` format — the docstring's claim that exceptions never silently return `compliant=True` didn't cover this, since neither path raised
   - Both cases now raise `ValueError` instead, which routes through `check_policy`'s existing exception handler and records a `warnings` entry (e.g. `"Could not evaluate rule 'minimum_score >= 0.9': rule references undefined field 'minimum_score'"`) instead of disappearing with no signal

--- a/semantica/vector_store/vector_store.py
+++ b/semantica/vector_store/vector_store.py
@@ -67,6 +67,7 @@ License: MIT
 
 from typing import Any, Dict, List, Optional, Tuple, Union
 import concurrent.futures
+import inspect
 
 import numpy as np
 
@@ -113,7 +114,7 @@ class VectorStore:
         self.dimension = self.config.get("dimension", 768)
 
         # Initialize backend-specific store if not using generic in-memory implementation
-        self._backend_store = None
+        self._backend_store: Any = None
         self.embedder = None  # Always initialized; may be overridden in _init_backend_store
         if self.backend != "inmemory":
             self._init_backend_store()
@@ -496,7 +497,11 @@ class VectorStore:
                     # Some stores have store_vectors method
                     return self._backend_store.store_vectors(vectors, metadata=metadata, **options)
                 else:
-                    # Basic add_vectors without metadata
+                    add_vectors_params = inspect.signature(self._backend_store.add_vectors).parameters
+                    if 'metadata' in add_vectors_params or any(
+                        p.kind == inspect.Parameter.VAR_KEYWORD for p in add_vectors_params.values()
+                    ):
+                        return self._backend_store.add_vectors(vectors, metadata=metadata, **options)
                     return self._backend_store.add_vectors(vectors, **options)
             else:
                 raise NotImplementedError(f"Backend store {type(self._backend_store).__name__} does not have add or add_vectors method")

--- a/semantica/vector_store/vector_store.py
+++ b/semantica/vector_store/vector_store.py
@@ -497,10 +497,14 @@ class VectorStore:
                     # Some stores have store_vectors method
                     return self._backend_store.store_vectors(vectors, metadata=metadata, **options)
                 else:
-                    add_vectors_params = inspect.signature(self._backend_store.add_vectors).parameters
-                    if 'metadata' in add_vectors_params or any(
-                        p.kind == inspect.Parameter.VAR_KEYWORD for p in add_vectors_params.values()
-                    ):
+                    try:
+                        add_vectors_params = inspect.signature(self._backend_store.add_vectors).parameters
+                        supports_metadata = 'metadata' in add_vectors_params or any(
+                            p.kind == inspect.Parameter.VAR_KEYWORD for p in add_vectors_params.values()
+                        )
+                    except (ValueError, TypeError):
+                        supports_metadata = True
+                    if supports_metadata:
                         return self._backend_store.add_vectors(vectors, metadata=metadata, **options)
                     return self._backend_store.add_vectors(vectors, **options)
             else:

--- a/tests/vector_store/test_vector_store.py
+++ b/tests/vector_store/test_vector_store.py
@@ -89,5 +89,50 @@ class TestVectorStore(unittest.TestCase):
         self.assertEqual(store.get_metadata("v1"), meta)
         self.assertIsNone(store.get_vector("nonexistent"))
 
+    def test_store_vectors_metadata_forwarding(self):
+        """Test that metadata is correctly forwarded to backends that support it."""
+        store = VectorStore(backend="inmemory")
+        
+        class MockBackendWithMetadata:
+            def __init__(self):
+                self.received_metadata = None
+                
+            def add_vectors(self, vectors, ids=None, metadata=None, **options):
+                self.received_metadata = metadata
+                return ["vec1"]
+                
+        mock_backend = MockBackendWithMetadata()
+        store._backend_store = mock_backend
+        
+        vectors = [np.array([0.1, 0.2])]
+        metadata = [{"id": "1"}]
+        
+        store.store_vectors(vectors, metadata=metadata)
+        
+        self.assertEqual(mock_backend.received_metadata, metadata)
+
+    def test_store_vectors_strict_backend(self):
+        """Test that metadata is dropped for strict backends without TypeError."""
+        store = VectorStore(backend="inmemory")
+        
+        class MockBackendStrict:
+            def __init__(self):
+                self.called = False
+                
+            def add_vectors(self, vectors):
+                self.called = True
+                return ["vec1"]
+                
+        mock_backend = MockBackendStrict()
+        store._backend_store = mock_backend
+        
+        vectors = [np.array([0.1, 0.2])]
+        metadata = [{"id": "1"}]
+        
+        # This should not raise TypeError since metadata is dropped
+        store.store_vectors(vectors, metadata=metadata)
+        
+        self.assertTrue(mock_backend.called)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- `VectorStore.store_vectors()` was silently dropping the `metadata` argument for any backend that only exposes `add_vectors()` (notably `FAISSStore`), even though `FAISSStore.add_vectors()` fully supports it. This caused `AgentContext`/`AgentMemory` retrieval to always return empty `content`/`metadata` for FAISS-backed stores, and triggered spurious `TextEmbedder` empty-text warnings downstream.
- Metadata is now forwarded to `add_vectors()`, and is only passed when the backend's `add_vectors()` signature actually supports it (checked via `inspect.signature`, accepting either an explicit `metadata` parameter or a `**kwargs` catch-all) — this avoids a `TypeError` for any backend with a stricter signature that doesn't accept `metadata`.

Fixes #832

## Test plan
- [x] Reproduced the exact scenario from #832 (`AgentContext` + FAISS-backed `VectorStore`) — `sources[0].content`/`.metadata` are now populated instead of `''`/`{}`.
- [x] Added ad-hoc checks against synthetic backends (metadata-kwarg, `**kwargs`-only, strict-no-metadata `add_vectors`) confirming correct routing with no crash in any case.
- [x] `pytest tests/vector_store tests/context` — 641 passed, 36 skipped, same 7 pre-existing/unrelated failures (Pinecone client mocks, a Windows symlink test) that fail identically on `main` without this change.