### PR TITLE
fix(context): preserve Markdown import path errors

### DIFF
--- a/semantica/context/agent_memory.py
+++ b/semantica/context/agent_memory.py
@@ -1867,10 +1867,19 @@ class AgentMemory:
                 try:
                     candidate_exists = candidate.exists()
                 except OSError as exc:
-                    raise OSError(
+                    error_message = (
                         "Failed to inspect possible Markdown import "
-                        f"path: {candidate}"
-                    ) from exc
+                        f"path {candidate}: {exc.strerror or str(exc)}"
+                    )
+                    if exc.errno is None:
+                        error = OSError(error_message)
+                    else:
+                        error = OSError(
+                            exc.errno,
+                            error_message,
+                            exc.filename or str(candidate),
+                        )
+                    raise error from exc
 
                 if candidate_exists:
                     documents = self._read_markdown_path(candidate)

--- a/semantica/context/agent_memory.py
+++ b/semantica/context/agent_memory.py
@@ -1865,10 +1865,15 @@ class AgentMemory:
             if "\n" not in data and "\r" not in data:
                 candidate = Path(data)
                 try:
-                    if candidate.exists():
-                        documents = self._read_markdown_path(candidate)
-                except OSError:
-                    pass
+                    candidate_exists = candidate.exists()
+                except OSError as exc:
+                    raise OSError(
+                        "Failed to inspect possible Markdown import "
+                        f"path: {candidate}"
+                    ) from exc
+
+                if candidate_exists:
+                    documents = self._read_markdown_path(candidate)
 
             if documents is None:
                 documents = [("markdown document", data)]

--- a/tests/context/test_agent_memory_markdown.py
+++ b/tests/context/test_agent_memory_markdown.py
@@ -1,3 +1,4 @@
+import errno
 from copy import deepcopy
 from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, patch
@@ -676,18 +677,25 @@ def test_markdown_string_path_read_errors_are_not_treated_as_content(tmp_path):
 
 def test_markdown_string_path_inspection_errors_are_actionable():
     memory = AgentMemory()
+    original_error = PermissionError(
+        errno.EACCES,
+        "inspection denied",
+        "blocked-memory.md",
+    )
 
     with patch(
         "semantica.context.agent_memory.Path.exists",
-        side_effect=PermissionError("inspection denied"),
+        side_effect=original_error,
     ):
         with pytest.raises(
             OSError, match="Failed to inspect possible Markdown import path"
         ) as exc_info:
             memory.import_data("memory.md", format="markdown")
 
-    assert isinstance(exc_info.value.__cause__, PermissionError)
-    assert "inspection denied" in str(exc_info.value.__cause__)
+    assert exc_info.value.errno == errno.EACCES
+    assert exc_info.value.filename == "blocked-memory.md"
+    assert "inspection denied" in str(exc_info.value)
+    assert exc_info.value.__cause__ is original_error
 
 
 def test_legacy_dict_import_behavior_is_unchanged():

--- a/tests/context/test_agent_memory_markdown.py
+++ b/tests/context/test_agent_memory_markdown.py
@@ -658,6 +658,38 @@ def test_empty_markdown_export_and_import_are_no_ops():
     assert memory.import_data("", format="markdown") == 0
 
 
+def test_markdown_string_path_read_errors_are_not_treated_as_content(tmp_path):
+    source = tmp_path / "memory.md"
+    source.write_text(
+        markdown_document(required_frontmatter(), "Content"), encoding="utf-8"
+    )
+    memory = AgentMemory()
+
+    with patch.object(
+        memory,
+        "_read_markdown_path",
+        side_effect=PermissionError("read denied"),
+    ):
+        with pytest.raises(PermissionError, match="read denied"):
+            memory.import_data(str(source), format="markdown")
+
+
+def test_markdown_string_path_inspection_errors_are_actionable():
+    memory = AgentMemory()
+
+    with patch(
+        "semantica.context.agent_memory.Path.exists",
+        side_effect=PermissionError("inspection denied"),
+    ):
+        with pytest.raises(
+            OSError, match="Failed to inspect possible Markdown import path"
+        ) as exc_info:
+            memory.import_data("memory.md", format="markdown")
+
+    assert isinstance(exc_info.value.__cause__, PermissionError)
+    assert "inspection denied" in str(exc_info.value.__cause__)
+
+
 def test_legacy_dict_import_behavior_is_unchanged():
     memory = AgentMemory()
     data = {


### PR DESCRIPTION
## Description

Preserve filesystem errors when a string passed to `AgentMemory.import_data(..., format="markdown")` resolves to a real path. Previously, `_import_markdown_payload()` caught `OSError` around both path detection and file reading, so errors such as `PermissionError` were swallowed and the path string was parsed as raw Markdown, producing a misleading frontmatter error.

This is the error-masking fast-follow identified during the final review of #786.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Related Issues

Follow-up to #786.

## Changes Made

- Narrow the path-probe exception boundary so read failures propagate normally.
- Raise an actionable error, retaining the original exception as the cause, when path inspection itself fails.
- Add regression tests for path inspection and path read failures.

## Testing

- [x] Tested locally
- [x] Added tests for new functionality
- [x] Package builds successfully (`python -m build`)

### Test Commands

```bash
python -m pytest tests/context/test_agent_memory_markdown.py -q
# 46 passed

python -m pytest tests/context -q
# 480 passed

python -m isort --check-only semantica/context/agent_memory.py tests/context/test_agent_memory_markdown.py
git diff --check
python -m build
# Successfully built sdist and wheel
```

The repository-wide test run was attempted, but collection requires unrelated optional dependencies not installed in the local venv. The complete affected component suite passes.

## Documentation

- [ ] Updated relevant documentation
- [ ] Added code examples if applicable
- [ ] Updated API reference if adding new APIs
- [ ] Updated cookbook if adding new examples
- [x] No documentation changes needed

## Breaking Changes

**Breaking Changes**: No

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where the logic is not self-explanatory
- [x] My changes generate no new warnings
- [x] Package builds successfully

## Additional Notes

This PR intentionally does not change read-side symlink policy; that behavior can be considered independently as suggested in #786.