### PR TITLE
fix(vector-store): reconstruct FAISS vectors

### DIFF
--- a/semantica/vector_store/faiss_store.py
+++ b/semantica/vector_store/faiss_store.py
@@ -91,8 +91,17 @@ class FAISSIndex:
 
         try:
             return np.asarray(reconstruct(idx), dtype=np.float32)
-        except (NotImplementedError, RuntimeError):
+        except NotImplementedError:
             return None
+        except RuntimeError as exc:
+            message = str(exc).casefold()
+            unsupported_errors = (
+                "reconstruct not implemented",
+                "reconstruct_from_offset not implemented",
+            )
+            if any(error in message for error in unsupported_errors):
+                return None
+            raise
 
     def save(self, path: Union[str, Path]):
         """Save index to disk."""

--- a/semantica/vector_store/faiss_store.py
+++ b/semantica/vector_store/faiss_store.py
@@ -85,9 +85,14 @@ class FAISSIndex:
             return None
 
         idx = self.vector_ids.index(vector_id)
-        # Note: FAISS doesn't directly support retrieval by index in all cases
-        # This is a simplified approach
-        return None
+        reconstruct = getattr(self.index, "reconstruct", None)
+        if not callable(reconstruct):
+            return None
+
+        try:
+            return np.asarray(reconstruct(idx), dtype=np.float32)
+        except (NotImplementedError, RuntimeError):
+            return None
 
     def save(self, path: Union[str, Path]):
         """Save index to disk."""

--- a/tests/vector_store/test_faiss_index.py
+++ b/tests/vector_store/test_faiss_index.py
@@ -48,7 +48,14 @@ def test_get_vector_returns_none_when_index_has_no_reconstruct_method():
     assert index.get_vector("vec_known") is None
 
 
-@pytest.mark.parametrize("error", [NotImplementedError(), RuntimeError()])
+@pytest.mark.parametrize(
+    "error",
+    [
+        NotImplementedError(),
+        RuntimeError("reconstruct not implemented for this type of index"),
+        RuntimeError("reconstruct_from_offset not implemented"),
+    ],
+)
 def test_get_vector_returns_none_when_reconstruction_is_unsupported(error):
     backend_index = MagicMock()
     backend_index.reconstruct.side_effect = error
@@ -56,3 +63,16 @@ def test_get_vector_returns_none_when_reconstruction_is_unsupported(error):
     index.vector_ids = ["vec_known"]
 
     assert index.get_vector("vec_known") is None
+
+
+def test_get_vector_propagates_unexpected_runtime_errors():
+    backend_index = MagicMock()
+    runtime_error = RuntimeError("direct map not initialized")
+    backend_index.reconstruct.side_effect = runtime_error
+    index = FAISSIndex(backend_index, dimension=3)
+    index.vector_ids = ["vec_known"]
+
+    with pytest.raises(RuntimeError) as exc_info:
+        index.get_vector("vec_known")
+
+    assert exc_info.value is runtime_error

--- a/tests/vector_store/test_faiss_index.py
+++ b/tests/vector_store/test_faiss_index.py
@@ -1,0 +1,58 @@
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+
+from semantica.vector_store.faiss_store import FAISSIndex
+
+
+def test_get_vector_reconstructs_from_flat_l2_index():
+    faiss = pytest.importorskip("faiss")
+    vectors = np.array(
+        [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]],
+        dtype=np.float32,
+    )
+    index = FAISSIndex(faiss.IndexFlatL2(3), dimension=3)
+    index.add_vectors(vectors, ids=["vec_first", "vec_target"])
+
+    result = index.get_vector("vec_target")
+
+    np.testing.assert_array_equal(result, vectors[1])
+
+
+def test_get_vector_reconstructs_vector_at_matching_id_position():
+    backend_index = MagicMock()
+    backend_index.reconstruct.return_value = [0.25, 0.5, 0.75]
+    index = FAISSIndex(backend_index, dimension=3)
+    index.vector_ids = ["vec_first", "vec_target"]
+
+    result = index.get_vector("vec_target")
+
+    backend_index.reconstruct.assert_called_once_with(1)
+    np.testing.assert_array_equal(result, np.array([0.25, 0.5, 0.75], dtype=np.float32))
+
+
+def test_get_vector_returns_none_for_unknown_id_without_reconstructing():
+    backend_index = MagicMock()
+    index = FAISSIndex(backend_index, dimension=3)
+    index.vector_ids = ["vec_known"]
+
+    assert index.get_vector("vec_missing") is None
+    backend_index.reconstruct.assert_not_called()
+
+
+def test_get_vector_returns_none_when_index_has_no_reconstruct_method():
+    index = FAISSIndex(object(), dimension=3)
+    index.vector_ids = ["vec_known"]
+
+    assert index.get_vector("vec_known") is None
+
+
+@pytest.mark.parametrize("error", [NotImplementedError(), RuntimeError()])
+def test_get_vector_returns_none_when_reconstruction_is_unsupported(error):
+    backend_index = MagicMock()
+    backend_index.reconstruct.side_effect = error
+    index = FAISSIndex(backend_index, dimension=3)
+    index.vector_ids = ["vec_known"]
+
+    assert index.get_vector("vec_known") is None


### PR DESCRIPTION
## Description

Enable `FAISSIndex.get_vector()` to return stored embeddings when the underlying FAISS index supports reconstruction. The method maps the public vector ID to its FAISS position, calls `reconstruct()`, and returns a `float32` NumPy array. Missing IDs and indexes with known unsupported-reconstruction errors return `None`; unexpected FAISS runtime failures remain visible to callers.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Related Issues

Fixes #844

## Changes Made

- Resolve stored vector IDs to their FAISS positional index.
- Reconstruct vectors through the backend when supported.
- Return `None` for missing IDs, `NotImplementedError`, and known FAISS unsupported-reconstruction messages.
- Re-raise unexpected `RuntimeError` failures so broken index state remains diagnosable.
- Add unit coverage plus a real `faiss.IndexFlatL2` reconstruction test.

## Testing

- [x] Tested locally
- [x] Added tests for new functionality
- [x] Package builds successfully (`python -m build`)

### Test Commands

```bash
python -m pytest tests/vector_store/test_faiss_index.py -q
# 8 passed

python -m pytest tests/vector_store -m "not integration" \
  --ignore=tests/vector_store/test_pinecone_store.py -q
# 134 passed, 61 skipped, 11 deselected

python -m black --check semantica/vector_store/faiss_store.py \
  tests/vector_store/test_faiss_index.py
python -m isort --check-only semantica/vector_store/faiss_store.py \
  tests/vector_store/test_faiss_index.py
git diff --check
python -m build
# Successfully built sdist and wheel
```

The complete non-integration vector-store run was also attempted. Six unrelated Pinecone tests require the optional Pinecone client and fail their availability guard when it is absent; all other collected vector-store tests pass.

## Documentation

- [ ] Updated relevant documentation
- [ ] Added code examples if applicable
- [ ] Updated API reference if adding new APIs
- [ ] Updated cookbook if adding new examples
- [x] No documentation changes needed

## Breaking Changes

**Breaking Changes**: No

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where the logic is not self-explanatory
- [x] My changes generate no new warnings
- [x] Package builds successfully

## Additional Notes

Unsupported reconstruction matching is intentionally limited to FAISS messages containing `reconstruct not implemented` or `reconstruct_from_offset not implemented`; other runtime errors are re-raised.