### PR TITLE
fix(explorer): normalize decision timestamps to ISO 8601 in /api/decisions routes

### DIFF
--- a/semantica/explorer/routes/decisions.py
+++ b/semantica/explorer/routes/decisions.py
@@ -34,9 +34,21 @@ def _normalize_timestamp(value: Any) -> Optional[str]:
     if value is None or isinstance(value, str):
         return value
     if isinstance(value, datetime):
+        # Normalize to UTC (assume UTC for naive datetimes) so every
+        # response carries a consistent ISO 8601 offset — the helper's
+        # documented contract.
+        if value.tzinfo is None:
+            value = value.replace(tzinfo=timezone.utc)
+        else:
+            value = value.astimezone(timezone.utc)
         return value.isoformat()
     if isinstance(value, (int, float)):
-        return datetime.fromtimestamp(value, tz=timezone.utc).isoformat()
+        # Malformed imported timestamps (NaN/inf/out-of-range) must degrade
+        # to None instead of raising and 500-ing the whole endpoint.
+        try:
+            return datetime.fromtimestamp(value, tz=timezone.utc).isoformat()
+        except (ValueError, OverflowError, OSError):
+            return None
     return None
 
 

--- a/semantica/explorer/routes/decisions.py
+++ b/semantica/explorer/routes/decisions.py
@@ -3,7 +3,8 @@ Decision routes using ContextGraph-native fallbacks.
 """
 
 import asyncio
-from typing import Optional
+from datetime import datetime, timezone
+from typing import Any, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 
@@ -12,6 +13,31 @@ from ..schemas import CausalChainResponse, CausalDistanceReport, ComplianceRespo
 from ..session import GraphSession
 
 router = APIRouter(prefix="/api/decisions", tags=["Decisions"])
+
+
+def _normalize_timestamp(value: Any) -> Optional[str]:
+    """Normalize a decision timestamp to an ISO 8601 string (UTC).
+
+    Decisions recorded via :meth:`ContextGraph.record_decision` store an
+    epoch float (``datetime.now().timestamp()``), while the API contract
+    (``DecisionResponse.timestamp``) requires a string. Imported graphs may
+    contain either form, so numeric epochs are converted here — this is the
+    single funnel for every ``/api/decisions*`` route.
+
+    Args:
+        value: The raw ``timestamp`` property of a decision node.
+
+    Returns:
+        An ISO 8601 string (UTC) for numeric/datetime input, the original
+        string for string input, ``None`` for missing or unrecognized values.
+    """
+    if value is None or isinstance(value, str):
+        return value
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if isinstance(value, (int, float)):
+        return datetime.fromtimestamp(value, tz=timezone.utc).isoformat()
+    return None
 
 
 def _node_to_decision(node: dict) -> DecisionResponse:
@@ -23,7 +49,7 @@ def _node_to_decision(node: dict) -> DecisionResponse:
         reasoning=properties.get("reasoning", ""),
         outcome=properties.get("outcome", ""),
         confidence=float(properties.get("confidence", 0.0) or 0.0),
-        timestamp=properties.get("timestamp"),
+        timestamp=_normalize_timestamp(properties.get("timestamp")),
         metadata=properties,
     )
 

--- a/tests/explorer/test_explorer_api.py
+++ b/tests/explorer/test_explorer_api.py
@@ -413,6 +413,41 @@ class TestSearchAndStats:
 
 
 class TestDecisions:
+    def test_decision_with_float_timestamp_returns_iso_string(self):
+        """record_decision() stores an epoch float timestamp, but
+        DecisionResponse.timestamp is Optional[str] — the API must
+        surface it as an ISO 8601 string instead of returning 500
+        on every /api/decisions* route (issue #884)."""
+        from datetime import datetime
+
+        graph = ContextGraph(advanced_analytics=False)
+        decision_id = graph.record_decision(
+            category="loan_underwriting",
+            scenario="Underwriting review for A-7291",
+            reasoning="DTI within policy; clean credit history",
+            outcome="approved",
+            confidence=0.94,
+            entities=["applicant_A7291"],
+        )
+        session = GraphSession(graph)
+        app = create_app(session=session)
+
+        with TestClient(app) as client:
+            response = client.get("/api/decisions")
+            assert response.status_code == 200
+            payload = response.json()
+            decision = next(item for item in payload if item["decision_id"] == decision_id)
+            assert isinstance(decision["timestamp"], str)
+            # ISO 8601 parseable, UTC (epoch float converted at the API boundary)
+            assert datetime.fromisoformat(decision["timestamp"]).tzinfo is not None
+
+            single = client.get(f"/api/decisions/{decision_id}")
+            assert single.status_code == 200
+            assert isinstance(single.json()["timestamp"], str)
+
+            precedents = client.get(f"/api/decisions/{decision_id}/precedents")
+            assert precedents.status_code == 200
+
     def test_list_decisions(self, client):
         response = client.get("/api/decisions")
         assert response.status_code == 200

--- a/tests/explorer/test_normalize_timestamp.py
+++ b/tests/explorer/test_normalize_timestamp.py
@@ -1,0 +1,80 @@
+"""Unit tests for _normalize_timestamp hardening (PR #887 review findings).
+
+Covers the two Qodo review findings:
+1. Numeric epochs must not raise on malformed input (NaN/inf/out-of-range)
+   — the helper contract says it returns None for unrecognized values.
+2. datetime inputs must be normalized to UTC (ISO 8601 with offset), not
+   returned as-is (which can be naive or non-UTC).
+"""
+import math
+from datetime import datetime, timezone, timedelta
+
+import pytest
+
+from semantica.explorer.routes.decisions import _normalize_timestamp
+
+
+class TestNumericEpochHardening:
+    def test_valid_epoch_converts_to_iso_utc(self):
+        # 2026-08-10T12:00:00Z
+        value = 1786262400.0
+        result = _normalize_timestamp(value)
+        assert result is not None
+        parsed = datetime.fromisoformat(result)
+        assert parsed.tzinfo is not None
+        assert parsed.utcoffset() == timedelta(0)
+
+    def test_nan_returns_none_not_raise(self):
+        assert _normalize_timestamp(float("nan")) is None
+
+    def test_inf_returns_none_not_raise(self):
+        assert _normalize_timestamp(float("inf")) is None
+        assert _normalize_timestamp(float("-inf")) is None
+
+    def test_out_of_range_epoch_returns_none_not_raise(self):
+        # Way beyond datetime.max (year 9999)
+        assert _normalize_timestamp(10**20) is None
+
+    def test_negative_epoch_converts(self):
+        # Negative epochs are valid (pre-1970)
+        result = _normalize_timestamp(-86400.0)
+        assert result is not None
+        parsed = datetime.fromisoformat(result)
+        assert parsed.year < 1970
+
+
+class TestDatetimeUtcNormalization:
+    def test_naive_datetime_assumed_utc(self):
+        value = datetime(2026, 8, 10, 12, 0, 0)  # naive
+        result = _normalize_timestamp(value)
+        assert result is not None
+        parsed = datetime.fromisoformat(result)
+        assert parsed.tzinfo is not None
+        assert parsed.utcoffset() == timedelta(0)
+        assert parsed.hour == 12  # assumed UTC, unchanged wall time
+
+    def test_non_utc_datetime_converted_to_utc(self):
+        value = datetime(2026, 8, 10, 15, 0, 0, tzinfo=timezone(timedelta(hours=3)))
+        result = _normalize_timestamp(value)
+        assert result is not None
+        parsed = datetime.fromisoformat(result)
+        assert parsed.utcoffset() == timedelta(0)
+        assert parsed.hour == 12  # 15:00+03:00 -> 12:00Z
+
+    def test_utc_datetime_unchanged(self):
+        value = datetime(2026, 8, 10, 12, 0, 0, tzinfo=timezone.utc)
+        result = _normalize_timestamp(value)
+        parsed = datetime.fromisoformat(result)
+        assert parsed == value
+
+
+class TestOtherInputs:
+    def test_none_passthrough(self):
+        assert _normalize_timestamp(None) is None
+
+    def test_string_passthrough(self):
+        assert _normalize_timestamp("2026-08-10T12:00:00Z") == "2026-08-10T12:00:00Z"
+
+    def test_unrecognized_type_returns_none(self):
+        assert _normalize_timestamp({"nested": True}) is None
+        assert _normalize_timestamp([]) is None


### PR DESCRIPTION
## Summary

Fixes #884 — every `/api/decisions*` route returned HTTP 500 as soon as the graph contained a decision.

### Root cause

`ContextGraph.record_decision()` stores `timestamp` as an epoch float (`datetime.now().timestamp()`), while `DecisionResponse.timestamp` is typed `Optional[str]`. `_node_to_decision()` passed the raw property through, so pydantic rejected the value the library itself produced. All routes that serialize decisions (list, get, precedents) funnel through `_node_to_decision`, so the entire Decisions workspace of the Knowledge Explorer was unusable.

### Fix

Added a `_normalize_timestamp()` helper at the API boundary (the single funnel for all decision routes):

- **float/int epoch → ISO 8601 UTC string** (`datetime.fromtimestamp(value, tz=timezone.utc).isoformat()`), matching the ISO string convention already used across the explorer API (e.g. `datetime.now(UTC).isoformat()` in ontology/temporal routes, which parse timestamps with `datetime.fromisoformat`)
- **str → passthrough** (imported graphs may already store ISO strings)
- **datetime → `.isoformat()`**
- **None/unknown → None** (never 500 the flagship feature for a malformed value)

The internal storage (`_decisions`, `_temporal_index`) keeps the epoch float — analytics/sorting rely on it — so the conversion happens only where the API contract demands a string.

### Tests

New `TestDecisions::test_decision_with_float_timestamp_returns_iso_string`:
- records a decision via `record_decision()` (the exact producer path from the issue)
- asserts `/api/decisions`, `/api/decisions/{id}` and `/api/decisions/{id}/precedents` return 200
- asserts the timestamp is a parseable ISO 8601 string with UTC tzinfo

Also verified the imported-graph path (node with raw float `timestamp` property) returns 200 with an ISO string.

Full explorer suite: **83 passed** (was 82; +1 new test).
