### PR TITLE
fix(export): log exceptions in DistanceExporter metric helpers instead of silently swallowing

### DIFF
--- a/semantica/export/distance_exporter.py
+++ b/semantica/export/distance_exporter.py
@@ -71,7 +71,8 @@ class DistanceExporter:
         try:
             result = self._centrality.calculate_betweenness_centrality(graph_dict)
             return result.get("betweenness", {}) if isinstance(result, dict) else {}
-        except Exception:
+        except Exception as exc:
+            logger.debug("betweenness_centrality failed: %s", exc)
             return {}
 
     def _hop_distance(self, graph_dict: Dict[str, Any], src: str, tgt: str) -> Optional[int]:
@@ -81,7 +82,12 @@ class DistanceExporter:
             result = self._path_finder.bfs_shortest_path(graph_dict, src, tgt)
             path = result.get("path", []) if isinstance(result, dict) else (result or [])
             return len(path) - 1 if path else None
-        except Exception:
+        except Exception as exc:
+            logger.debug(
+                "hop_distance(%s, %s) failed: %s — returning None "
+                "(caller cannot distinguish this from 'no path exists')",
+                src, tgt, exc,
+            )
             return None
 
     def _weighted_distance(self, graph_dict: Dict[str, Any], src: str, tgt: str) -> Optional[float]:
@@ -92,7 +98,12 @@ class DistanceExporter:
             if isinstance(result, dict):
                 return float(result.get("total_weight", len(result.get("path", [])) - 1))
             return None
-        except Exception:
+        except Exception as exc:
+            logger.debug(
+                "weighted_distance(%s, %s) failed: %s — returning None "
+                "(caller cannot distinguish this from 'no path exists')",
+                src, tgt, exc,
+            )
             return None
 
     def _semantic_similarity(self, graph_dict: Dict[str, Any], src: str, tgt: str) -> Optional[float]:
@@ -101,7 +112,11 @@ class DistanceExporter:
         try:
             sim = self._similarity.cosine_similarity(graph_dict, src, tgt)
             return float(sim) if isinstance(sim, (int, float)) else None
-        except Exception:
+        except Exception as exc:
+            logger.debug(
+                "semantic_similarity(%s, %s) failed: %s — returning None",
+                src, tgt, exc,
+            )
             return None
 
     def compute_pairs(

--- a/tests/export/test_distance_exporter_logging.py
+++ b/tests/export/test_distance_exporter_logging.py
@@ -1,0 +1,128 @@
+"""Tests for DistanceExporter error logging.
+
+Verifies that the four metric helper methods log debug messages (rather
+than silently swallowing exceptions) when the underlying computation
+raises an error.
+"""
+
+import logging
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from semantica.export.distance_exporter import DistanceExporter
+
+
+@pytest.fixture
+def mock_graph():
+    """Minimal graph mock with two nodes."""
+    graph = MagicMock()
+    node_a = MagicMock(node_id="a", node_type="entity", content="A", properties={})
+    node_b = MagicMock(node_id="b", node_type="entity", content="B", properties={})
+    graph.nodes = {"a": node_a, "b": node_b}
+    graph.edges = []
+    return graph
+
+
+@pytest.fixture
+def exporter_with_mocked_kg(mock_graph):
+    """DistanceExporter with mocked KG components (regardless of install)."""
+    exporter = DistanceExporter(mock_graph)
+    # Force KG components to be present (mocked)
+    exporter._path_finder = MagicMock()
+    exporter._similarity = MagicMock()
+    exporter._centrality = MagicMock()
+    return exporter
+
+
+class TestDistanceExporterErrorLogging:
+    """Verify that silent exception swallowing is replaced with debug logging."""
+
+    def test_hop_distance_logs_on_failure(self, exporter_with_mocked_kg, caplog):
+        """_hop_distance should log when bfs_shortest_path raises."""
+        exporter = exporter_with_mocked_kg
+        exporter._path_finder.bfs_shortest_path = MagicMock(
+            side_effect=RuntimeError("graph corrupted")
+        )
+        graph_dict = exporter._build_graph_dict()
+
+        with caplog.at_level(logging.DEBUG):
+            result = exporter._hop_distance(graph_dict, "a", "b")
+
+        assert result is None
+        assert "hop_distance(a, b) failed" in caplog.text
+        assert "graph corrupted" in caplog.text
+
+    def test_weighted_distance_logs_on_failure(self, exporter_with_mocked_kg, caplog):
+        """_weighted_distance should log when dijkstra_shortest_path raises."""
+        exporter = exporter_with_mocked_kg
+        exporter._path_finder.dijkstra_shortest_path = MagicMock(
+            side_effect=ValueError("negative weight")
+        )
+        graph_dict = exporter._build_graph_dict()
+
+        with caplog.at_level(logging.DEBUG):
+            result = exporter._weighted_distance(graph_dict, "a", "b")
+
+        assert result is None
+        assert "weighted_distance(a, b) failed" in caplog.text
+        assert "negative weight" in caplog.text
+
+    def test_semantic_similarity_logs_on_failure(self, exporter_with_mocked_kg, caplog):
+        """_semantic_similarity should log when cosine_similarity raises."""
+        exporter = exporter_with_mocked_kg
+        exporter._similarity.cosine_similarity = MagicMock(
+            side_effect=TypeError("embedding not found")
+        )
+        graph_dict = exporter._build_graph_dict()
+
+        with caplog.at_level(logging.DEBUG):
+            result = exporter._semantic_similarity(graph_dict, "a", "b")
+
+        assert result is None
+        assert "semantic_similarity(a, b) failed" in caplog.text
+        assert "embedding not found" in caplog.text
+
+    def test_betweenness_logs_on_failure(self, exporter_with_mocked_kg, caplog):
+        """_betweenness should log when calculate_betweenness_centrality raises."""
+        exporter = exporter_with_mocked_kg
+        exporter._centrality.calculate_betweenness_centrality = MagicMock(
+            side_effect=RuntimeError("unsupported graph structure")
+        )
+        graph_dict = exporter._build_graph_dict()
+
+        with caplog.at_level(logging.DEBUG):
+            result = exporter._betweenness(graph_dict)
+
+        assert result == {}
+        assert "betweenness_centrality failed" in caplog.text
+        assert "unsupported graph structure" in caplog.text
+
+    def test_compute_pairs_still_produces_rows_on_metric_failure(
+        self, exporter_with_mocked_kg, caplog
+    ):
+        """compute_pairs should still produce rows even when all metrics fail."""
+        exporter = exporter_with_mocked_kg
+        exporter._path_finder.bfs_shortest_path = MagicMock(
+            side_effect=RuntimeError("fail")
+        )
+        exporter._path_finder.dijkstra_shortest_path = MagicMock(
+            side_effect=RuntimeError("fail")
+        )
+        exporter._similarity.cosine_similarity = MagicMock(
+            side_effect=RuntimeError("fail")
+        )
+        exporter._centrality.calculate_betweenness_centrality = MagicMock(
+            side_effect=RuntimeError("fail")
+        )
+
+        with caplog.at_level(logging.DEBUG):
+            rows = exporter.compute_pairs()
+
+        # 2 nodes → 2 directed pairs (a→b and b→a)
+        assert len(rows) == 2
+        assert rows[0]["hop_count"] is None
+        assert rows[0]["weighted_distance"] is None
+        assert rows[0]["semantic_similarity"] is None
+        # Verify errors were logged
+        assert "failed" in caplog.text


### PR DESCRIPTION
## Summary

Fixes #874 — four metric helpers in `DistanceExporter` catch all exceptions with bare `except Exception: return None/{}`, making it impossible to distinguish computation failures from legitimate "no path" results in exported data.

## Changes

Added `logger.debug()` calls to all four helpers (`_betweenness`, `_hop_distance`, `_weighted_distance`, `_semantic_similarity`) that record the node pair and exception message before returning the sentinel value.

This preserves existing behavior (callers still receive `None/{}`) while giving operators visibility into failed computations when debug logging is enabled. The debug level was chosen deliberately — these failures may occur frequently in large graphs with disconnected subgraphs, so `warning` would be too noisy.

## Tests

Added `tests/export/test_distance_exporter_logging.py` — 5 tests verifying:
- Each helper logs on failure (with node IDs and exception message)
- `compute_pairs()` still produces complete rows when all metrics fail

```
============================== 5 passed in 0.78s ===============================
```