### PR TITLE
perf(semantic_extract): cache spaCy models instead of calling spacy.load() on every extraction (132 ms → 2.1 ms)

### DIFF
--- a/semantica/semantic_extract/methods.py
+++ b/semantica/semantic_extract/methods.py
@@ -108,6 +108,7 @@ License: MIT
 
 import re
 import difflib
+import threading
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Any, Dict, List, Optional, Tuple, Union
 
@@ -152,6 +153,39 @@ spacy, SPACY_AVAILABLE = safe_import("spacy")
 # Global cache for spacy model and text embedder to avoid reloading
 _nlp_cache = None
 _embedder_cache = None
+
+# Cache for models loaded by name, so extraction functions do not pay
+# spacy.load() on every call. Entries record the spacy module they were loaded
+# from: tests patch `methods.spacy` with a mock, and an entry produced by a
+# different module object must not be handed back to a later caller.
+_spacy_model_cache: Dict[str, Tuple[Any, Any]] = {}
+_spacy_model_cache_lock = threading.Lock()
+
+
+def load_spacy_model(name: str):
+    """Load a spaCy model once per process, keyed by model name.
+
+    Raises whatever ``spacy.load`` raises (``OSError`` for a missing model), so
+    callers keep their existing fallback behavior.
+    """
+    cached = _spacy_model_cache.get(name)
+    if cached is not None and cached[0] is spacy:
+        return cached[1]
+
+    with _spacy_model_cache_lock:
+        cached = _spacy_model_cache.get(name)
+        if cached is not None and cached[0] is spacy:
+            return cached[1]
+        nlp = spacy.load(name)
+        _spacy_model_cache[name] = (spacy, nlp)
+        return nlp
+
+
+def clear_spacy_model_cache() -> None:
+    """Drop every cached spaCy model. Intended for tests."""
+    with _spacy_model_cache_lock:
+        _spacy_model_cache.clear()
+
 
 def get_text_embedder():
     """
@@ -676,11 +710,11 @@ def extract_entities_ml(
         return extract_entities_pattern(text, **kwargs)
 
     try:
-        nlp = spacy.load(model)
+        nlp = load_spacy_model(model)
     except OSError:
         logger.warning(f"spaCy model {model} not found, using en_core_web_sm")
         try:
-            nlp = spacy.load("en_core_web_sm")
+            nlp = load_spacy_model("en_core_web_sm")
         except OSError:
             logger.warning(
                 "spaCy model not available, falling back to pattern extraction"
@@ -1400,12 +1434,12 @@ def extract_relations_similarity(
             # Prefer larger models for vectors
             for model_name in ["en_core_web_lg", "en_core_web_md", "en_core_web_sm"]:
                 if spacy.util.is_package(model_name):
-                    nlp = spacy.load(model_name)
+                    nlp = load_spacy_model(model_name)
                     break
             if not nlp:
                  # Try loading what we have
                  try:
-                     nlp = spacy.load("en_core_web_sm") 
+                     nlp = load_spacy_model("en_core_web_sm") 
                  except:
                      pass
         except Exception:
@@ -1505,7 +1539,7 @@ def extract_relations_dependency(
         return extract_relations_pattern(text, entities, **kwargs)
 
     try:
-        nlp = spacy.load(model)
+        nlp = load_spacy_model(model)
     except OSError:
         logger.warning(f"spaCy model {model} not found")
         return extract_relations_pattern(text, entities, **kwargs)

--- a/tests/semantic_extract/test_spacy_model_cache.py
+++ b/tests/semantic_extract/test_spacy_model_cache.py
@@ -1,0 +1,114 @@
+"""Tests for the process-level spaCy model cache in semantic_extract.methods.
+
+Before this cache existed, extract_entities_ml(), extract_relations_similarity()
+and extract_relations_dependency() called spacy.load() on every invocation, so a
+short sentence cost ~120 ms of model loading on top of ~2 ms of actual work.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from semantica.semantic_extract import methods
+
+
+@pytest.fixture(autouse=True)
+def clear_cache():
+    methods.clear_spacy_model_cache()
+    yield
+    methods.clear_spacy_model_cache()
+
+
+def _fake_spacy(load):
+    return SimpleNamespace(load=load, util=SimpleNamespace(is_package=lambda name: True))
+
+
+def test_model_loaded_once_across_calls(monkeypatch):
+    calls = []
+
+    def fake_load(name, **kwargs):
+        calls.append(name)
+        return MagicMock()
+
+    monkeypatch.setattr(methods, "spacy", _fake_spacy(fake_load))
+
+    methods.load_spacy_model("en_core_web_sm")
+    methods.load_spacy_model("en_core_web_sm")
+    methods.load_spacy_model("en_core_web_sm")
+
+    assert calls == ["en_core_web_sm"], "spacy.load should run once per model name"
+
+
+def test_same_object_returned(monkeypatch):
+    sentinel = MagicMock()
+    monkeypatch.setattr(methods, "spacy", _fake_spacy(lambda name, **kw: sentinel))
+
+    assert methods.load_spacy_model("en_core_web_sm") is sentinel
+    assert methods.load_spacy_model("en_core_web_sm") is sentinel
+
+
+def test_distinct_models_cached_separately(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        methods,
+        "spacy",
+        _fake_spacy(lambda name, **kw: (calls.append(name), MagicMock())[1]),
+    )
+
+    methods.load_spacy_model("en_core_web_sm")
+    methods.load_spacy_model("en_core_web_lg")
+    methods.load_spacy_model("en_core_web_sm")
+
+    assert calls == ["en_core_web_sm", "en_core_web_lg"]
+
+
+def test_load_errors_propagate_and_are_not_cached(monkeypatch):
+    """Callers rely on OSError to trigger their fallback path."""
+    attempts = []
+
+    def failing_load(name, **kwargs):
+        attempts.append(name)
+        raise OSError(f"Can't find model '{name}'")
+
+    monkeypatch.setattr(methods, "spacy", _fake_spacy(failing_load))
+
+    with pytest.raises(OSError):
+        methods.load_spacy_model("en_core_web_missing")
+    with pytest.raises(OSError):
+        methods.load_spacy_model("en_core_web_missing")
+
+    assert len(attempts) == 2, "a failed load must not populate the cache"
+
+
+def test_cache_ignores_entries_from_a_replaced_spacy_module(monkeypatch):
+    """Patching methods.spacy must not hand back a model from the old module.
+
+    Existing tests patch this attribute with a mock and assert on load calls, so
+    a cache keyed on model name alone would leak objects across those tests.
+    """
+    first = MagicMock()
+    monkeypatch.setattr(methods, "spacy", _fake_spacy(lambda name, **kw: first))
+    assert methods.load_spacy_model("en_core_web_sm") is first
+
+    second = MagicMock()
+    monkeypatch.setattr(methods, "spacy", _fake_spacy(lambda name, **kw: second))
+    assert methods.load_spacy_model("en_core_web_sm") is second
+
+
+def test_extract_entities_ml_reuses_the_cached_model(monkeypatch):
+    calls = []
+
+    def fake_load(name, **kwargs):
+        calls.append(name)
+        nlp = MagicMock()
+        nlp.return_value = SimpleNamespace(ents=[])
+        return nlp
+
+    monkeypatch.setattr(methods, "spacy", _fake_spacy(fake_load))
+    monkeypatch.setattr(methods, "SPACY_AVAILABLE", True)
+
+    methods.extract_entities_ml("Alice works at Acme Corp.")
+    methods.extract_entities_ml("Bob works at Globex.")
+
+    assert len(calls) == 1, "the model should be loaded once, not once per call"


### PR DESCRIPTION
## Description

`extract_entities_ml()`, `extract_relations_similarity()` and `extract_relations_dependency()` called `spacy.load()` on every invocation. This routes those five call sites through a process-level cache, taking `extract_entities_ml()` on a short sentence from **132 ms to 2.1 ms** with identical output.

The module already had a cached loader for one code path — `get_nlp_model()` and its `_nlp_cache` global at `methods.py:181-204` — the extraction functions simply bypassed it.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Performance improvement
- [ ] Code refactoring

## Related Issues

Closes #889

## Changes Made

**`load_spacy_model(name)`** — a dict keyed by model name, guarded by a lock so concurrent callers do not each start their own load. The five sites (`methods.py` 679/683, 1403/1408, 1508 pre-patch) now call it.

Three details worth reviewing:

- **Errors are not cached and propagate unchanged.** Callers rely on `OSError` to fall back to `en_core_web_sm` and then to pattern extraction; a failed load leaves the cache untouched so that path is unaffected.
- **`get_nlp_model()` keeps its own `_nlp_cache`.** It loads with `disable=["parser", "ner", "lemmatizer"]` for similarity work, so its model is not interchangeable with the NER one. Folding the two would need a key covering the `disable` set — happy to do that here if you would rather have one cache, but it seemed out of scope for a perf fix.
- **Entries record the `spacy` module object they came from.** `tests/test_ner_configurations.py` and others patch `methods.spacy` with a mock and assert on `load` call counts. A cache keyed on name alone would hand one test's mock to the next; the identity check makes a swapped module miss the cache. `clear_spacy_model_cache()` is exported for tests that want to be explicit.

## Testing

- [x] Tested locally
- [x] Added tests for new functionality
- [ ] Package builds successfully (`python -m build`)

New `tests/semantic_extract/test_spacy_model_cache.py` (6 tests) covers: load-once across repeated calls, same object returned, distinct models cached separately, failed loads propagating and staying uncached, a replaced `spacy` module bypassing the cache, and `extract_entities_ml()` loading once across two calls.

### Test Commands

```bash
pytest tests/semantic_extract/test_spacy_model_cache.py -q
# 6 passed

pytest tests/semantic_extract tests/test_ner_configurations.py tests/test_extractors_dispatch.py -q
# 62 failed, 109 passed, 9 skipped
```

That failure count needs context: **the same 62 tests fail on `main` before this change** (62 failed, 103 passed there — the +6 are the new ones). I diffed the two `FAILED` lists; the sets are identical, nothing introduced and nothing fixed. They look like pre-existing gaps around optional providers and assorted `TypeError`/`AssertionError` cases, unrelated to model loading.

`flake8 --max-line-length 120` on the two changed files reports the same 235 findings before and after — none new. I did not run `black` over `methods.py`; it is not currently black-clean and reformatting would bury a 30-line change in a whole-file diff.

### Benchmark

Python 3.12.13, macOS 26.5 (arm64), spacy 3.8.15, `en_core_web_sm` 3.8.0, on `"Apple CEO Tim Cook announced record earnings in Cupertino."`:

| | median | runs (ms) |
| --- | --- | --- |
| `extract_entities_ml()` before | 132 ms | 119, 113, 199, 160, 132 |
| `extract_entities_ml()` after | **2.1 ms** | 2.1, 1.9, 1.9, 2.1, 2.1 |
| `spacy.load()` alone | 120 ms | |

Entities are unchanged: `Apple/ORG`, `Tim Cook/PERSON`, `Cupertino/GPE`.

Trade-off to be aware of: a loaded pipeline now stays resident for the life of the process, which is the point, but it does mean a long-running server holds the model in memory rather than releasing it between requests. `clear_spacy_model_cache()` is there if that ever needs to be managed.

Found while working on #883 — that endpoint returned 503 unconditionally, so this cost was invisible over REST. Filed and fixed separately from #886, which stays scoped to the two correctness bugs.

@KaifAhmad1 for review.
