### PR TITLE
fix(explorer): serialize decision timestamps as ISO-8601 to fix 500 on /api/decisions*

### DIFF
--- a/semantica/explorer/routes/decisions.py
+++ b/semantica/explorer/routes/decisions.py
@@ -3,6 +3,7 @@ Decision routes using ContextGraph-native fallbacks.
 """
 
 import asyncio
+from datetime import datetime, timezone
 from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query
@@ -14,6 +15,15 @@ from ..session import GraphSession
 router = APIRouter(prefix="/api/decisions", tags=["Decisions"])
 
 
+def _coerce_timestamp(value) -> Optional[str]:
+    """Coerce a stored decision timestamp (float epoch or ISO string) to ISO-8601."""
+    if value is None:
+        return None
+    if isinstance(value, (int, float)):
+        return datetime.fromtimestamp(float(value), tz=timezone.utc).isoformat()
+    return str(value)
+
+
 def _node_to_decision(node: dict) -> DecisionResponse:
     properties = node.get("properties", {})
     return DecisionResponse(
@@ -23,7 +33,7 @@ def _node_to_decision(node: dict) -> DecisionResponse:
         reasoning=properties.get("reasoning", ""),
         outcome=properties.get("outcome", ""),
         confidence=float(properties.get("confidence", 0.0) or 0.0),
-        timestamp=properties.get("timestamp"),
+        timestamp=_coerce_timestamp(properties.get("timestamp")),
         metadata=properties,
     )
 

--- a/semantica/explorer/routes/decisions.py
+++ b/semantica/explorer/routes/decisions.py
@@ -19,8 +19,14 @@ def _coerce_timestamp(value) -> Optional[str]:
     """Coerce a stored decision timestamp (float epoch or ISO string) to ISO-8601."""
     if value is None:
         return None
-    if isinstance(value, (int, float)):
-        return datetime.fromtimestamp(float(value), tz=timezone.utc).isoformat()
+    # bool is a subclass of int — don't interpret True/False as epoch seconds.
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        try:
+            return datetime.fromtimestamp(float(value), tz=timezone.utc).isoformat()
+        except (OverflowError, OSError, ValueError):
+            # Out-of-range/negative epochs and other malformed values must not
+            # 500 the endpoint; fall back to the raw string representation.
+            return str(value)
     return str(value)
 
 

--- a/tests/explorer/test_explorer_api.py
+++ b/tests/explorer/test_explorer_api.py
@@ -444,26 +444,34 @@ class TestDecisions:
         assert violation_response.status_code == 200
         assert violation_response.json()["compliant"] is False
 
-    def test_recorded_decision_timestamp_is_iso(self, client):
+    def test_recorded_decision_timestamp_is_iso(self):
         """Regression for #884: record_decision stores a float epoch timestamp,
         which must be serialized as ISO-8601 instead of failing validation."""
-        graph = client.app.state.session.graph
-        graph.record_decision(
-            category="tech",
-            scenario="Recorded decision regression",
-            reasoning="Regression test for #884",
-            outcome="approved",
-            confidence=0.9,
-            entities=["ml"],
-        )
-        response = client.get("/api/decisions")
-        assert response.status_code == 200
-        recorded = [d for d in response.json() if d["scenario"] == "Recorded decision regression"]
-        assert len(recorded) == 1
-        timestamp = recorded[0]["timestamp"]
-        assert timestamp is not None
-        parsed = datetime.fromisoformat(timestamp)
-        assert parsed.tzinfo is not None
+        # Use a fresh function-scoped graph instead of the module-scoped
+        # `client` fixture, so the recorded decision does not leak into
+        # other tests (order-dependent failures).
+        session = GraphSession(_build_sample_graph())
+        app = create_app(session=session)
+        with TestClient(app) as test_client:
+            graph = test_client.app.state.session.graph
+            graph.record_decision(
+                category="tech",
+                scenario="Recorded decision regression",
+                reasoning="Regression test for #884",
+                outcome="approved",
+                confidence=0.9,
+                entities=["ml"],
+            )
+            response = test_client.get("/api/decisions")
+            assert response.status_code == 200
+            recorded = [
+                d for d in response.json() if d["scenario"] == "Recorded decision regression"
+            ]
+            assert len(recorded) == 1
+            timestamp = recorded[0]["timestamp"]
+            assert timestamp is not None
+            parsed = datetime.fromisoformat(timestamp)
+            assert parsed.tzinfo is not None
 
 
 class TestTemporal:

--- a/tests/explorer/test_explorer_api.py
+++ b/tests/explorer/test_explorer_api.py
@@ -1,5 +1,6 @@
 """Integration tests for the explorer API."""
 
+from datetime import datetime
 import json
 from pathlib import Path
 import uuid
@@ -442,6 +443,27 @@ class TestDecisions:
         violation_response = client.get("/api/decisions/decision_1/compliance")
         assert violation_response.status_code == 200
         assert violation_response.json()["compliant"] is False
+
+    def test_recorded_decision_timestamp_is_iso(self, client):
+        """Regression for #884: record_decision stores a float epoch timestamp,
+        which must be serialized as ISO-8601 instead of failing validation."""
+        graph = client.app.state.session.graph
+        graph.record_decision(
+            category="tech",
+            scenario="Recorded decision regression",
+            reasoning="Regression test for #884",
+            outcome="approved",
+            confidence=0.9,
+            entities=["ml"],
+        )
+        response = client.get("/api/decisions")
+        assert response.status_code == 200
+        recorded = [d for d in response.json() if d["scenario"] == "Recorded decision regression"]
+        assert len(recorded) == 1
+        timestamp = recorded[0]["timestamp"]
+        assert timestamp is not None
+        parsed = datetime.fromisoformat(timestamp)
+        assert parsed.tzinfo is not None
 
 
 class TestTemporal:


### PR DESCRIPTION
## Summary

Fixes #884 — every `/api/decisions*` route returns HTTP 500 as soon as the graph contains a decision recorded via `ContextGraph.record_decision()`.

## Root cause

`record_decision()` stores the decision timestamp as a **float epoch** (`context_graph.py`), while `DecisionResponse.timestamp` is typed `Optional[str]` (`schemas.py:144`). Pydantic rejects the float, so `_node_to_decision` raises during response validation and the route returns 500.

```
pydantic_core._pydantic_core.ValidationError: 1 validation error for DecisionResponse
timestamp
  Input should be a valid string [type=string_type, input_value=1786357493.150935, input_type=float]
```

## Fix

Coerce the stored timestamp to ISO-8601 (UTC) in `_node_to_decision` before constructing the response:

- `float`/`int` (epoch) → ISO-8601 string with UTC offset, matching the `recorded_at` format already produced by `record_decision`
- `str` → passed through
- `None` → stays `None` (schema remains `Optional[str]`)

No behavior change for clients that only read `timestamp` as opaque; the wire format is now consistent with `recorded_at`.

## Tests

- Added `test_recorded_decision_timestamp_is_iso` in `tests/explorer/test_explorer_api.py` — records a real decision via `record_decision()` (which stores a float epoch) and asserts `GET /api/decisions` returns 200 with a parseable, timezone-aware ISO timestamp.
- `tests/explorer/test_explorer_api.py`: **5 passed** (all Decision tests, incl. the new one).

Note: 13 failures in `test_sparql_route.py` / `test_ontology_subissue3.py` are pre-existing on `main` in this environment (verified via `git stash` before/after) and unrelated to this change.

## Checklist

- [x] Fix verified with regression test
- [x] Conventional commit message