### PR TITLE
build(deps): raise fastapi minimum floor to >=0.109.1 (PYSEC-2024-38)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -230,7 +230,7 @@ dev = [
 
 # Explorer Dashboard
 explorer = [
-  "fastapi>=0.100.0",
+  "fastapi>=0.109.1",
   "uvicorn[standard]>=0.22.0",
   "websockets>=15.0.1",
   "python-multipart>=0.0.6"


### PR DESCRIPTION
## Summary

Fixes #869 — the `[explorer]` extra declares `fastapi>=0.100.0`, which allows resolving the vulnerable 0.109.0. FastAPI 0.109.1 patched PYSEC-2024-38 (HTTP response splitting).

## Change

```diff
 explorer = [
-  "fastapi>=0.100.0",
+  "fastapi>=0.109.1",
   ...
 ]
```

One-line bump to a floor published since early 2024. No functional impact — the 0.109.x API is stable and backward-compatible.

## Verification

- `pip-audit` no longer flags `fastapi` against PYSEC-2024-38 when resolved from the updated floor.
- The explorer test suite passes with fastapi 0.141.x (newest satisfying the floor) — see #892 for the suite's pass/fail baseline in this environment.