### PR TITLE
docs: link CONTRIBUTING.md issue workflow from PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,5 @@
+> **Before you submit:** make sure you followed the [issue workflow in CONTRIBUTING.md](https://github.com/semantica-agi/semantica/blob/main/CONTRIBUTING.md#-working-on-an-existing-issue) — comment on the issue and wait for assignment before opening a PR, to avoid duplicate work.
+
 ## Description
 
 <!-- Provide a clear description of your changes -->


### PR DESCRIPTION
## Summary
- Adds a short note at the top of the PR template linking to CONTRIBUTING.md's "Working on an Existing Issue" section (added in #895)
- Surfaces the comment-before-you-PR workflow directly on the PR creation page, since not everyone reads CONTRIBUTING.md before opening a PR

## Context
Follow-up to #895 — reduces duplicate PRs against the same issue by making the workflow visible where contributors actually see it.

## Testing
- [x] Doc-only change, previewed rendering locally