### PR TITLE
fix(mcp): report the package version instead of a stale hardcoded 0.4.0

### DIFF
--- a/semantica/mcp_server/__init__.py
+++ b/semantica/mcp_server/__init__.py
@@ -47,6 +47,8 @@ import os
 import sys
 from typing import Any
 
+from semantica import __version__
+
 # ── logging ────────────────────────────────────────────────────────────────
 _log_level = getattr(logging, os.environ.get("SEMANTICA_LOG_LEVEL", "WARNING").upper(), logging.WARNING)
 logging.basicConfig(stream=sys.stderr, level=_log_level,
@@ -477,7 +479,7 @@ def _read_resource(uri: str) -> dict:
     if uri == "semantica://schema/info":
         return {
             "name": "Semantica",
-            "version": "0.4.0",
+            "version": __version__,
             "tools": [t["name"] for t in TOOLS],
             "resources": [r["uri"] for r in RESOURCES],
         }
@@ -490,7 +492,7 @@ def _read_resource(uri: str) -> dict:
 
 SERVER_INFO = {
     "name": "semantica",
-    "version": "0.4.0",
+    "version": __version__,
 }
 
 CAPABILITIES = {

--- a/tests/mcp/test_mcp_server_version.py
+++ b/tests/mcp/test_mcp_server_version.py
@@ -1,0 +1,18 @@
+"""MCP server must report the package version, not a hardcoded string.
+
+Regression test for #863: SERVER_INFO and the semantica://schema/info
+resource used to hardcode "0.4.0", so MCP clients displayed a stale
+version even when the installed package was newer.
+"""
+
+from semantica import __version__
+from semantica.mcp_server import SERVER_INFO, _read_resource
+
+
+def test_server_info_version_matches_package() -> None:
+    assert SERVER_INFO["version"] == __version__
+
+
+def test_schema_info_version_matches_package() -> None:
+    resource = _read_resource("semantica://schema/info")
+    assert resource["version"] == __version__


### PR DESCRIPTION
Fixes #863

**Problem:** the MCP server hardcoded `"version": "0.4.0"` in `SERVER_INFO` and in the `semantica://schema/info` resource while the package is at `0.6.0` (`pyproject.toml` / `semantica/__init__.py`). Every connecting MCP client displays the stale version in its server info panel.

**Fix:** import `__version__` from the package and use it in both places, so the reported version can never drift from the installed package again.

**Test:** `tests/mcp/test_mcp_server_version.py` asserts both `SERVER_INFO["version"]` and the `semantica://schema/info` resource version equal `semantica.__version__`.

Verified: `pytest tests/mcp/test_mcp_server_version.py` (2 passed).