### PR TITLE
fix(normalize): validate symbol currencies

### DIFF
--- a/semantica/normalize/number_normalizer.py
+++ b/semantica/normalize/number_normalizer.py
@@ -611,13 +611,15 @@ class CurrencyNormalizer:
         # Check for currency code
         if not currency_code:
             for code in self.currency_codes:
-                if code in currency_input.upper():
+                match = re.search(
+                    rf"(?<![A-Z]){re.escape(code)}(?![A-Z])",
+                    currency_input.upper(),
+                )
+                if match:
                     currency_code = code
                     amount_str = (
-                        currency_input.replace(code, "")
-                        .replace(code.lower(), "")
-                        .strip()
-                    )
+                        currency_input[: match.start()] + currency_input[match.end() :]
+                    ).strip()
                     amount_str = amount_str.replace(",", "").replace(" ", "")
                     try:
                         amount = float(amount_str)

--- a/semantica/normalize/number_normalizer.py
+++ b/semantica/normalize/number_normalizer.py
@@ -562,6 +562,11 @@ class CurrencyNormalizer:
             "SEK",
             "NOK",
             "DKK",
+            "RUB",
+            "KRW",
+            "ILS",
+            "NGN",
+            "PKR",
         ]
 
         self.logger.debug("Currency normalizer initialized")

--- a/tests/normalize/test_number_normalizer.py
+++ b/tests/normalize/test_number_normalizer.py
@@ -55,6 +55,18 @@ class TestCurrencyNormalizer(unittest.TestCase):
             self.assertEqual(result["currency"], expected_code)
             self.assertTrue(self.normalizer.validate_currency_code(result["currency"]))
 
+    def test_currency_codes_match_boundaries_without_matching_words(self):
+        for value in ("RUB100", "100 RUB", "rub 100"):
+            result = self.normalizer.normalize_currency(value)
+            self.assertEqual(result["amount"], 100.0)
+            self.assertEqual(result["currency"], "RUB")
+
+        for value in ("ruby 100", "wilson 100"):
+            result = self.normalizer.normalize_currency(value)
+            self.assertEqual(result["amount"], 100.0)
+            self.assertEqual(result["currency"], "USD")
+
+
 class TestScientificNotationHandler(unittest.TestCase):
     def setUp(self):
         self.handler = ScientificNotationHandler()

--- a/tests/normalize/test_number_normalizer.py
+++ b/tests/normalize/test_number_normalizer.py
@@ -49,6 +49,12 @@ class TestCurrencyNormalizer(unittest.TestCase):
         self.assertEqual(result["amount"], 100.0)
         self.assertEqual(result["currency"], "EUR")
 
+    def test_symbol_currencies_are_validated_as_supported_codes(self):
+        for symbol, expected_code in self.normalizer.currency_symbols.items():
+            result = self.normalizer.normalize_currency(f"{symbol}100")
+            self.assertEqual(result["currency"], expected_code)
+            self.assertTrue(self.normalizer.validate_currency_code(result["currency"]))
+
 class TestScientificNotationHandler(unittest.TestCase):
     def setUp(self):
         self.handler = ScientificNotationHandler()


### PR DESCRIPTION
### Summary
- include every currency code exposed by the symbol parser in the supported-code list
- keep symbol parsing and `validate_currency_code()` consistent
- add a round-trip regression test for all configured currency symbols

### Verification
- `uv run --no-project --with pytest --with chardet --with loguru --with tqdm --with numpy --with pandas pytest tests/normalize/test_number_normalizer.py -q`
- 7 passed

This keeps parsed RUB, KRW, ILS, NGN, and PKR values from being rejected by the same normalizer API that produced them.