### PR TITLE
fix(seed): guard SeedDataManager.load_from_api against SSRF

### DIFF
--- a/semantica/seed/seed_manager.py
+++ b/semantica/seed/seed_manager.py
@@ -32,17 +32,59 @@ License: MIT
 """
 
 import csv
+import ipaddress
 import json
+import socket
 from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
+from urllib.parse import urlparse
 
 from ..utils.exceptions import ProcessingError, ValidationError
 from ..utils.helpers import read_json_file, write_json_file
 from ..utils.logging import get_logger
 from ..utils.progress_tracker import get_progress_tracker
 from ..utils.types import EntityDict, RelationshipDict
+
+
+def is_safe_api_url(api_url: str) -> bool:
+    """SSRF guard: reject URLs that resolve to non-public addresses.
+
+    Blocks loopback, private, link-local, and IPv6 loopback ranges (issue #936).
+    Raises no exception — returns False for unsafe or unparseable URLs.
+    """
+    try:
+        parsed = urlparse(api_url)
+        if parsed.scheme not in ("http", "https"):
+            return False
+        hostname = parsed.hostname
+        if not hostname:
+            return False
+        # Resolve hostname (DNS rebinding is outside this check's scope; the
+        # connection itself is not re-validated after resolution).
+        try:
+            infos = socket.getaddrinfo(hostname, None)
+            addresses = {info[4][0] for info in infos}
+        except socket.gaierror:
+            return False
+        for addr in addresses:
+            try:
+                ip = ipaddress.ip_address(str(addr).split("%")[0])
+            except ValueError:
+                continue
+            if (
+                ip.is_loopback
+                or ip.is_private
+                or ip.is_link_local
+                or ip.is_reserved
+                or ip.is_multicast
+                or ip.is_unspecified
+            ):
+                return False
+        return True
+    except (ValueError, OSError):
+        return False
 
 
 @dataclass
@@ -490,6 +532,13 @@ class SeedDataManager:
             request_headers = headers or {}
             if api_key:
                 request_headers["Authorization"] = f"Bearer {api_key}"
+
+            # SSRF guard: reject loopback/private/link-local targets (issue #936)
+            if not is_safe_api_url(full_url):
+                raise ProcessingError(
+                    f"Unsafe API URL rejected: {full_url} "
+                    "(loopback, private, or link-local addresses are not allowed)"
+                )
 
             # Make API request
             response = requests.get(full_url, headers=request_headers, timeout=30)

--- a/tests/seed/test_seed_manager.py
+++ b/tests/seed/test_seed_manager.py
@@ -3,7 +3,7 @@ import unittest
 from pathlib import Path
 from unittest.mock import patch
 
-from semantica.seed.seed_manager import SeedData, SeedDataManager, SeedDataSource
+from semantica.seed.seed_manager import SeedData, SeedDataManager, SeedDataSource, is_safe_api_url
 from semantica.utils.exceptions import ProcessingError
 
 
@@ -82,6 +82,45 @@ class TestSeedDataManager(unittest.TestCase):
         self.assertEqual(len(records), 1)
         self.assertEqual(records[0]["name"], "Alice")
         self.assertEqual(records[0]["entity_type"], "Person")
+
+class TestIsSafeApiUrl(unittest.TestCase):
+    """SSRF guard: URL validation for load_from_api (issue #936)."""
+
+    def test_public_https_url_allowed(self):
+        self.assertTrue(is_safe_api_url("https://8.8.8.8/dns"))
+
+    def test_public_http_url_allowed(self):
+        self.assertTrue(is_safe_api_url("http://8.8.8.8/dns"))
+
+    def test_loopback_ip_blocked(self):
+        self.assertFalse(is_safe_api_url("http://127.0.0.1:8000/secret"))
+
+    def test_loopback_hostname_blocked(self):
+        self.assertFalse(is_safe_api_url("http://localhost:8000/secret"))
+
+    def test_private_ip_blocked(self):
+        self.assertFalse(is_safe_api_url("http://192.168.1.1/admin"))
+
+    def test_link_local_blocked(self):
+        self.assertFalse(is_safe_api_url("http://169.254.169.254/latest/meta-data"))
+
+    def test_private_cidr_blocked(self):
+        self.assertFalse(is_safe_api_url("http://10.0.0.5/internal"))
+
+    def test_ipv6_loopback_blocked(self):
+        self.assertFalse(is_safe_api_url("http://[::1]:8080/secret"))
+
+    def test_invalid_scheme_blocked(self):
+        self.assertFalse(is_safe_api_url("file:///etc/passwd"))
+
+    def test_public_ipv4_allowed(self):
+        self.assertTrue(is_safe_api_url("http://8.8.8.8/dns"))
+
+    def test_load_from_api_rejects_loopback(self):
+        manager = SeedDataManager()
+        with self.assertRaises(ProcessingError):
+            manager.load_from_api("http://127.0.0.1:8000/secret")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_seed_manager.py
+++ b/tests/test_seed_manager.py
@@ -154,7 +154,7 @@ def test_load_from_api(mock_get, seed_manager):
     mock_get.return_value = mock_response
 
     records = seed_manager.load_from_api(
-        api_url="http://api.example.com",
+        api_url="http://8.8.8.8",
         endpoint="users",
         entity_type="User"
     )


### PR DESCRIPTION
Closes #936

## Summary

Guards `SeedDataManager.load_from_api()` against SSRF: callers passing untrusted API URLs could previously trigger outbound requests to loopback or link-local endpoints (e.g. cloud metadata services).

**`is_safe_api_url()`** (new, in `semantica/seed/seed_manager.py`):
- Resolves the hostname via `socket.getaddrinfo` and checks every returned address against `ipaddress` flags: rejects loopback, private, link-local, reserved, multicast, and unspecified (IPv4 and IPv6, including `[::1]`)
- Rejects non-`http(s)` schemes (e.g. `file://`)
- Returns `False` for unresolvable hostnames instead of raising

`load_from_api()` now raises `ProcessingError` with a clear message before any request is made when the target is unsafe.

**Tests** — 11 new cases in `tests/seed/test_seed_manager.py`:
- Blocked: `127.0.0.1`, `localhost`, `192.168.x`, `169.254.169.254` (metadata), `10.x`, `[::1]`, `file://`
- Allowed: public IPs (`8.8.8.8`)
- Integration: `load_from_api("http://127.0.0.1...")` raises `ProcessingError`

Also updated the existing `test_load_from_api` (used the non-resolving `api.example.com`, which the guard now rejects) to a public IP to preserve the test's original intent.

## Note

- Pre-existing failure: `TestSeedDataManager::test_load_from_csv` fails on `main` (0 records parsed from the mocked CSV) — unrelated to this change, observed before this branch.
- DNS rebinding (TOCTOU between validation and connect) is noted as a limitation in the guard's docstring; full mitigation requires connecting through a validating proxy or re-checking the resolved IP at connect time.
