### PR TITLE
fix(export): reject non-mapping input to the YAML exporters

### DIFF
--- a/semantica/export/methods.py
+++ b/semantica/export/methods.py
@@ -494,7 +494,7 @@ def export_graph(
 
 
 def export_yaml(
-    data: Union[Dict[str, Any], List[Dict[str, Any]]],
+    data: Dict[str, Any],
     file_path: Union[str, Path],
     method: str = "semantic_network",
     **kwargs,
@@ -504,13 +504,26 @@ def export_yaml(
 
     This is a user-friendly wrapper that exports data to YAML format.
 
+    Unlike :func:`export_json` and :func:`export_csv`, which treat a list as
+    opaque records, both YAML methods are keyed formats: they distinguish
+    entities from relationships from triplets (and classes from properties
+    for ``method="schema"``). A bare list is therefore rejected rather than
+    guessed at, since inferring which collection it represents would silently
+    mislabel the records.
+
     Args:
-        data: Data to export (semantic network, entities, relationships)
+        data: Data to export, as a mapping. For ``method="semantic_network"``,
+            keyed by 'entities'/'relationships'/'triplets'; for
+            ``method="schema"``, by 'classes'/'properties'.
         file_path: Output YAML file path
         method: Export method (default: "semantic_network")
             - "semantic_network": Semantic network YAML export
             - "schema": Schema YAML export
         **kwargs: Additional options passed to YAML exporters
+
+    Raises:
+        ProcessingError: if ``data`` is not a mapping, or if ``method`` is not
+            a known YAML export method.
 
     Examples:
         >>> from semantica.export.methods import export_yaml

--- a/semantica/export/yaml_exporter.py
+++ b/semantica/export/yaml_exporter.py
@@ -21,6 +21,7 @@ Author: Semantica Contributors
 License: MIT
 """
 
+from collections.abc import Mapping, Sequence
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
@@ -29,6 +30,34 @@ from ..utils.exceptions import ProcessingError, ValidationError
 from ..utils.helpers import ensure_directory
 from ..utils.logging import get_logger
 from ..utils.progress_tracker import get_progress_tracker
+
+
+def _require_mapping(data: Any, expected_keys: Sequence[str]) -> None:
+    """Reject non-mapping export input with an actionable error.
+
+    Both YAML exporters read their payload by key. Handed a sequence (or any
+    other non-mapping), every lookup would fail with a bare
+    ``AttributeError: 'list' object has no attribute 'get'`` from deep inside
+    the exporter, which tells the caller nothing about the shape expected.
+
+    A list is rejected rather than wrapped: these formats distinguish
+    entities from relationships from triplets, so inferring which one a bare
+    list represents would silently mislabel the records.
+
+    Args:
+        data: Candidate export payload.
+        expected_keys: Key names this exporter reads, named in the error so
+            the caller learns the expected shape.
+
+    Raises:
+        ProcessingError: if ``data`` is not a mapping.
+    """
+    if not isinstance(data, Mapping):
+        keys = "/".join(f"'{key}'" for key in expected_keys)
+        raise ProcessingError(
+            f"Cannot export object of type '{type(data).__name__}': "
+            f"expected a dict with {keys}."
+        )
 
 
 class SemanticNetworkYAMLExporter:
@@ -96,6 +125,13 @@ class SemanticNetworkYAMLExporter:
                 - metadata: Metadata dictionary (optional)
             **options: Additional export options (unused)
 
+        Raises:
+            ProcessingError: if ``semantic_network`` is not a mapping. A bare
+                list of records cannot be exported here because this format
+                distinguishes entities, relationships, and triplets, and
+                guessing which one a list represents would silently mislabel
+                it.
+
         Returns:
             String containing YAML representation of semantic network
 
@@ -107,6 +143,8 @@ class SemanticNetworkYAMLExporter:
             ... }
             >>> yaml_str = exporter.export_semantic_network(network)
         """
+        _require_mapping(semantic_network, ("entities", "relationships", "triplets"))
+
         # Track YAML export
         tracking_id = self.progress_tracker.start_tracking(
             file=None,
@@ -308,7 +346,12 @@ class YAMLSchemaExporter:
         • Include hierarchies and constraints
         • Structure for easy editing
         • Return YAML schema
+
+        Raises:
+            ProcessingError: if ``ontology`` is not a mapping.
         """
+        _require_mapping(ontology, ("classes", "properties"))
+
         yaml_data = {
             "ontology": {
                 "uri": ontology.get("uri", ""),

--- a/semantica/export/yaml_exporter.py
+++ b/semantica/export/yaml_exporter.py
@@ -21,10 +21,10 @@ Author: Semantica Contributors
 License: MIT
 """
 
-from collections.abc import Mapping, Sequence
+from collections.abc import Mapping
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Sequence, Union
 
 from ..utils.exceptions import ProcessingError, ValidationError
 from ..utils.helpers import ensure_directory

--- a/tests/export/test_yaml_exporter_input_validation.py
+++ b/tests/export/test_yaml_exporter_input_validation.py
@@ -1,0 +1,174 @@
+"""Regression tests for YAML export input validation (issue #952).
+
+``export_yaml`` declared ``Union[Dict[str, Any], List[Dict[str, Any]]]`` but
+both YAML exporters read their payload by key, so a list reached
+``semantic_network.get(...)`` and surfaced as a bare
+``AttributeError: 'list' object has no attribute 'get'`` from inside the
+exporter — an error that names neither the offending argument nor the shape
+expected.
+
+A list is rejected rather than wrapped. These formats distinguish entities
+from relationships from triplets, so inferring which collection a bare list
+represents would silently mislabel the records; and wrapping it under an
+unrecognised key would write a structurally valid file with every collection
+empty, trading a loud failure for silent data loss.
+
+Both directions are pinned: non-mappings raise ``ProcessingError`` with an
+actionable message, and every mapping that worked before still exports.
+"""
+
+import os
+import tempfile
+import unittest
+from collections import OrderedDict, defaultdict
+
+import yaml
+
+from semantica.export.methods import export_yaml
+from semantica.export.yaml_exporter import (
+    SemanticNetworkYAMLExporter,
+    YAMLSchemaExporter,
+)
+from semantica.utils.exceptions import ProcessingError
+
+# Non-mapping payloads that must be rejected. A list of dicts is the shape
+# from #952; the rest guard the same path against other sequence/scalar types.
+NON_MAPPINGS = {
+    "list_of_dicts": [{"id": "1", "name": "Acme"}],
+    "empty_list": [],
+    "tuple_of_dicts": ({"id": "1"},),
+    "list_of_scalars": ["a", "b"],
+    "string": "entities",
+    "bytes": b"entities",
+    "int": 42,
+    "none": None,
+    "set": {"a"},
+}
+
+# Both YAML methods, with a minimal valid payload and the key names the
+# corresponding error message must mention.
+METHODS = {
+    "semantic_network": {
+        "valid": {
+            "entities": [{"id": "1", "name": "Acme"}],
+            "relationships": [],
+            "triplets": [],
+        },
+        "expected_key": "entities",
+        "top_level_key": "entities",
+    },
+    "schema": {
+        "valid": {"classes": [{"name": "Thing"}], "properties": []},
+        "expected_key": "classes",
+        "top_level_key": "classes",
+    },
+}
+
+
+class TestExportYamlRejectsNonMappings(unittest.TestCase):
+    """Non-mapping input fails loudly, through the public wrapper."""
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+
+    def _path(self, name="out.yaml"):
+        return os.path.join(self.tmpdir, name)
+
+    def test_fixture_tables_are_populated(self):
+        """Guard against a vacuous suite.
+
+        Every test below iterates a table; emptying or renaming one would let
+        those loops pass without asserting anything.
+        """
+        self.assertGreaterEqual(len(NON_MAPPINGS), 9)
+        self.assertEqual(set(METHODS), {"semantic_network", "schema"})
+
+    def test_non_mapping_raises_processing_error(self):
+        for method in METHODS:
+            for label, payload in NON_MAPPINGS.items():
+                with self.subTest(method=method, case=label):
+                    with self.assertRaises(ProcessingError):
+                        export_yaml(payload, self._path(), method=method)
+
+    def test_error_names_the_offending_type_and_expected_keys(self):
+        """The message must be actionable, not just the right exception type."""
+        for method, spec in METHODS.items():
+            with self.subTest(method=method):
+                with self.assertRaises(ProcessingError) as ctx:
+                    export_yaml([{"id": "1"}], self._path(), method=method)
+                message = str(ctx.exception)
+                self.assertIn("list", message)
+                self.assertIn(spec["expected_key"], message)
+
+    def test_no_file_is_written_when_input_is_rejected(self):
+        """A rejected export must not leave a partial or empty artefact."""
+        for method in METHODS:
+            with self.subTest(method=method):
+                path = self._path(f"{method}_rejected.yaml")
+                with self.assertRaises(ProcessingError):
+                    export_yaml([{"id": "1"}], path, method=method)
+                self.assertFalse(os.path.exists(path))
+
+    def test_exporter_classes_reject_non_mappings_directly(self):
+        """Validation lives in the exporters, not only the convenience wrapper.
+
+        Callers using the classes directly get the same contract.
+        """
+        for label, payload in NON_MAPPINGS.items():
+            with self.subTest(exporter="SemanticNetworkYAMLExporter", case=label):
+                with self.assertRaises(ProcessingError):
+                    SemanticNetworkYAMLExporter().export_semantic_network(payload)
+            with self.subTest(exporter="YAMLSchemaExporter", case=label):
+                with self.assertRaises(ProcessingError):
+                    YAMLSchemaExporter().export_ontology_schema(payload)
+
+
+class TestExportYamlStillAcceptsMappings(unittest.TestCase):
+    """Everything that exported before must still export."""
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+
+    def _path(self, name="out.yaml"):
+        return os.path.join(self.tmpdir, name)
+
+    def test_valid_mapping_exports_for_each_method(self):
+        for method, spec in METHODS.items():
+            with self.subTest(method=method):
+                path = self._path(f"{method}.yaml")
+                export_yaml(spec["valid"], path, method=method)
+                self.assertTrue(os.path.exists(path))
+                loaded = yaml.safe_load(open(path, encoding="utf-8"))
+                self.assertIn(spec["top_level_key"], loaded)
+
+    def test_semantic_network_records_survive_the_round_trip(self):
+        path = self._path("network.yaml")
+        export_yaml(METHODS["semantic_network"]["valid"], path)
+        loaded = yaml.safe_load(open(path, encoding="utf-8"))
+        self.assertEqual(loaded["entities"], [{"id": "1", "name": "Acme"}])
+
+    def test_empty_mapping_is_still_accepted(self):
+        """An empty dict is a mapping; rejecting it would be a behaviour change."""
+        for method in METHODS:
+            with self.subTest(method=method):
+                path = self._path(f"{method}_empty.yaml")
+                export_yaml({}, path, method=method)
+                self.assertTrue(os.path.exists(path))
+
+    def test_mapping_subclasses_are_accepted(self):
+        """Validation is by Mapping, not dict, so these must keep working."""
+        valid = METHODS["semantic_network"]["valid"]
+        subclasses = {
+            "OrderedDict": OrderedDict(valid),
+            "defaultdict": defaultdict(list, valid),
+        }
+        for label, payload in subclasses.items():
+            with self.subTest(case=label):
+                path = self._path(f"{label}.yaml")
+                export_yaml(payload, path)
+                loaded = yaml.safe_load(open(path, encoding="utf-8"))
+                self.assertEqual(loaded["entities"], valid["entities"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/export/test_yaml_exporter_input_validation.py
+++ b/tests/export/test_yaml_exporter_input_validation.py
@@ -18,6 +18,7 @@ actionable message, and every mapping that worked before still exports.
 """
 
 import os
+import shutil
 import tempfile
 import unittest
 from collections import OrderedDict, defaultdict
@@ -70,6 +71,7 @@ class TestExportYamlRejectsNonMappings(unittest.TestCase):
 
     def setUp(self):
         self.tmpdir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.tmpdir, ignore_errors=True)
 
     def _path(self, name="out.yaml"):
         return os.path.join(self.tmpdir, name)
@@ -128,9 +130,14 @@ class TestExportYamlStillAcceptsMappings(unittest.TestCase):
 
     def setUp(self):
         self.tmpdir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.tmpdir, ignore_errors=True)
 
     def _path(self, name="out.yaml"):
         return os.path.join(self.tmpdir, name)
+
+    def _load(self, path):
+        with open(path, encoding="utf-8") as handle:
+            return yaml.safe_load(handle)
 
     def test_valid_mapping_exports_for_each_method(self):
         for method, spec in METHODS.items():
@@ -138,13 +145,13 @@ class TestExportYamlStillAcceptsMappings(unittest.TestCase):
                 path = self._path(f"{method}.yaml")
                 export_yaml(spec["valid"], path, method=method)
                 self.assertTrue(os.path.exists(path))
-                loaded = yaml.safe_load(open(path, encoding="utf-8"))
+                loaded = self._load(path)
                 self.assertIn(spec["top_level_key"], loaded)
 
     def test_semantic_network_records_survive_the_round_trip(self):
         path = self._path("network.yaml")
         export_yaml(METHODS["semantic_network"]["valid"], path)
-        loaded = yaml.safe_load(open(path, encoding="utf-8"))
+        loaded = self._load(path)
         self.assertEqual(loaded["entities"], [{"id": "1", "name": "Acme"}])
 
     def test_empty_mapping_is_still_accepted(self):
@@ -166,7 +173,7 @@ class TestExportYamlStillAcceptsMappings(unittest.TestCase):
             with self.subTest(case=label):
                 path = self._path(f"{label}.yaml")
                 export_yaml(payload, path)
-                loaded = yaml.safe_load(open(path, encoding="utf-8"))
+                loaded = self._load(path)
                 self.assertEqual(loaded["entities"], valid["entities"])
 
 


### PR DESCRIPTION
## Description

`export_yaml` declared `Union[Dict[str, Any], List[Dict[str, Any]]]`, but both YAML exporters read their payload by key. A list reached `semantic_network.get(...)` and surfaced as a bare `AttributeError: 'list' object has no attribute 'get'` from inside the exporter — an error naming neither the offending argument nor the shape expected.

Reject rather than wrap. These formats distinguish entities from relationships from triplets, so inferring which collection a bare list represents would silently mislabel the records. Wrapping it under an unrecognised key is worse: the exporter reads only `entities`/`relationships`/`triplets`, so any other key writes a structurally valid file with every collection empty, trading a loud failure for silent data loss.

Validation lives in the exporters rather than the convenience wrapper, matching the existing precedent in `Neo4jCSVExporter._normalize_graph`, so direct users of the classes get the same contract as callers of `export_yaml`.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Related Issues

Closes #952

## Changes Made

- `semantica/export/yaml_exporter.py` — added `_require_mapping(data, expected_keys)`, called from both entry points (`export_semantic_network` and `export_ontology_schema`), each naming its own key set. Raises `ProcessingError` with the same message shape as the existing `Neo4jCSVExporter` check.
- `semantica/export/methods.py` — narrowed `export_yaml`'s `data` hint to `Dict[str, Any]`, documented why a list is rejected rather than guessed at, and added a `Raises:` section.
- `tests/export/test_yaml_exporter_input_validation.py` — 9 tests / 46 subtests covering both directions.

Membership is tested with `isinstance(data, Mapping)` rather than `dict`, so `OrderedDict`, `defaultdict` and other mappings that worked before keep working.

Resulting messages:

```
Cannot export object of type 'list': expected a dict with 'entities'/'relationships'/'triplets'.
Cannot export object of type 'list': expected a dict with 'classes'/'properties'.
```

## Testing

- [x] Tested locally
- [x] Added tests for new functionality
- [x] Package builds successfully (`python -m build`)

Both YAML methods and both exporter classes are covered, directly and through the wrapper. Rejection cases span list-of-dicts (the shape from #952), empty list, tuple, list of scalars, `str`, `bytes`, `int`, `None` and `set`. Acceptance cases pin that valid mappings still export, records survive the round trip, `{}` is still accepted, and mapping subclasses still work.

Verified the guard actually fails: removing both `_require_mapping` calls produces **40 failures**; restoring them gives 9 passed / 46 subtests.

Verified nothing else broke by diffing the full-suite failure *set* against `main` rather than comparing counts — identical, 200 either way, with no failure introduced. (Raw counts are unreliable on this suite; repeat baseline runs gave 240 and 200, which is the order-dependent flakiness tracked in #859.)

Also checked the two non-test callers of the changed API: `examples/capability_gap_context_graphs_example.py` passes `context_graph.to_dict()` (a dict), and `tests/test_notebooks_simulation.py` exercises the YAML export path and passes.

### Test Commands

```bash
pytest tests/export/test_yaml_exporter_input_validation.py -q
```

```bash
pytest tests/export/ tests/test_export_module.py tests/test_export_methods_wrapper.py -q
```

```bash
python -m build
```

Results: `9 passed, 46 subtests`, `93 passed, 46 subtests`, and a clean `semantica-0.6.5` sdist + wheel.

## Documentation

- [ ] Updated relevant documentation
- [x] Added code examples if applicable
- [ ] Updated API reference if adding new APIs
- [ ] Updated cookbook if adding new examples
- [x] No documentation changes needed

The behaviour is documented in the affected docstrings — `export_yaml` now states the expected mapping shape and why a list is rejected, and both exporter methods carry a `Raises:` section. No prose docs referenced the list form.

## Breaking Changes

**Breaking Changes**: No

No working call changes behaviour: passing a list never succeeded, it raised `AttributeError`. The exception type for that input changes from `AttributeError` to `ProcessingError`, so the only code affected is anything catching `AttributeError` specifically to detect this case — which would have been catching an unintended leak from the exporter internals.

The type hint narrows from `Union[Dict[str, Any], List[Dict[str, Any]]]` to `Dict[str, Any]`, which makes the annotation describe what the function actually accepted all along.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Package builds successfully

`yaml_exporter.py` is black- and isort-clean, matching its state on `main`. `methods.py` was already black-unclean on `main` (at `export_neo4j_csv`, ~line 744); my hunk is conformant and I left the pre-existing formatting alone rather than widening the diff. flake8 on the two changed source files went from 4 findings to 3; the remainder are pre-existing `F401`/`E501`.

## Additional Notes

**Deliberately scoped to `export_yaml`.** Six other exporters raise the identical bare `AttributeError` on a list — `export_rdf`, `export_graph`, `export_lpg`, `export_owl`, `export_arango`, and `generate_report`. I kept this PR to the function named in #952 rather than widening it, but the same `_require_mapping` treatment applies to each and I'm happy to open a follow-up issue or extend this PR, whichever you prefer.

**Related.** #953 covers the neighbouring failure mode this fix deliberately avoids: a *mapping* whose keys aren't recognised currently exports an empty file with no warning. That is why a list is rejected here rather than normalised into a wrapper — normalising would route it straight into that silent path.
