### PR TITLE
fix(explorer): align dev esbuild target

### DIFF
--- a/explorer/vite.config.ts
+++ b/explorer/vite.config.ts
@@ -57,6 +57,13 @@ export default defineConfig({
       },
     },
   },
+  optimizeDeps: {
+    // Keep dependency pre-bundling aligned with the production build target.
+    // esbuild >=0.28 no longer lowers destructuring for Vite's default target.
+    esbuildOptions: {
+      target: 'esnext',
+    },
+  },
   server: {
     proxy: {
       '/api': {


### PR DESCRIPTION
## Summary

- align Vite dependency pre-bundling with the existing `esnext` production target
- prevent esbuild 0.28 from attempting unsupported destructuring transforms during `npm run dev`

## Reproduction

Before this change, starting the Explorer dev server failed while pre-bundling dependencies with hundreds of `Transforming destructuring ... is not supported yet` errors.

## Verification

- `npm run dev -- --host 127.0.0.1`
- fetched `/` and `/src/main.tsx` successfully
- `npm run build`