### PR TITLE
docs: fix dead allcontributors emoji-key link

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -101,7 +101,7 @@ When using the all-contributors bot, use these codes:
 - `infra` - Infrastructure
 - `maintenance` - Maintenance
 
-See [all-contributors specification](https://allcontributors.org/docs/en/emoji-key) for complete list.
+See [all-contributors specification](https://github.com/all-contributors/all-contributors#emoji-key) for complete list.
 
 ---
 


### PR DESCRIPTION
The allcontributors emoji-key page at https://allcontributors.org/docs/en/emoji-key now returns 404. This PR updates `CONTRIBUTORS.md` to point to the emoji key table in the official all-contributors repository README instead.