### PR TITLE
fix(parse): import get_progress_tracker in ExcelParser

### DIFF
--- a/semantica/parse/excel_parser.py
+++ b/semantica/parse/excel_parser.py
@@ -37,6 +37,7 @@ from openpyxl import load_workbook
 
 from ..utils.exceptions import ProcessingError, ValidationError
 from ..utils.logging import get_logger
+from ..utils.progress_tracker import get_progress_tracker
 
 
 @dataclass


### PR DESCRIPTION
Fixes #1014. ExcelParser.__init__ calls get_progress_tracker() but the module never imports it, so every instantiation raises NameError — the entire Excel parsing surface is unusable. Added the one-line import.